### PR TITLE
fix: subtract overflow in measure

### DIFF
--- a/crates/core/src/measure.rs
+++ b/crates/core/src/measure.rs
@@ -48,11 +48,11 @@ pub trait BehaviourJudgement: Measure {
 /// The "goodness" of a node is measured by comparing the connection and disconnection counts against a given threshold.
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
-pub trait ConnectBehaviour<const THRESHOLD: i16>: Measure {
+pub trait ConnectBehaviour<const THRESHOLD: i64>: Measure {
     /// This asynchronous method returns a boolean indicating whether the node identified by `did` has a satisfactory connection behavior.
     async fn good(&self, did: Did) -> bool {
-        let conn = self.get_count(did, MeasureCounter::Connect).await;
-        let disconn = self.get_count(did, MeasureCounter::Disconnected).await;
+        let conn = self.get_count(did, MeasureCounter::Connect).await as i64;
+        let disconn = self.get_count(did, MeasureCounter::Disconnected).await as i64;
         tracing::debug!(
             "[ConnectBehaviour] in Threadhold: {:}, connect: {:}, disconn: {:}, delta: {:}",
             THRESHOLD,
@@ -60,7 +60,7 @@ pub trait ConnectBehaviour<const THRESHOLD: i16>: Measure {
             disconn,
             conn - disconn
         );
-        ((conn - disconn) as i16) < THRESHOLD
+        (conn - disconn) < THRESHOLD
     }
 }
 
@@ -69,11 +69,11 @@ pub trait ConnectBehaviour<const THRESHOLD: i16>: Measure {
 /// The "goodness" of a node is measured by comparing the sent and failed-to-send counts against a given threshold.
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
-pub trait MessageSendBehaviour<const THRESHOLD: i16>: Measure {
+pub trait MessageSendBehaviour<const THRESHOLD: i64>: Measure {
     /// This asynchronous method returns a boolean indicating whether the node identified by `did` has a satisfactory message sending behavior.
     async fn good(&self, did: Did) -> bool {
         let failed = self.get_count(did, MeasureCounter::FailedToSend).await;
-        (failed as i16) < THRESHOLD
+        (failed as i64) < THRESHOLD
     }
 }
 
@@ -82,10 +82,10 @@ pub trait MessageSendBehaviour<const THRESHOLD: i16>: Measure {
 /// The "goodness" of a node is measured by comparing the received and failed-to-receive counts against a given threshold.
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
-pub trait MessageRecvBehaviour<const THRESHOLD: i16>: Measure {
+pub trait MessageRecvBehaviour<const THRESHOLD: i64>: Measure {
     /// This asynchronous method returns a boolean indicating whether the node identified by `did` has a satisfactory message receiving behavior.
     async fn good(&self, did: Did) -> bool {
         let failed = self.get_count(did, MeasureCounter::FailedToReceive).await;
-        (failed as i16) < THRESHOLD
+        (failed as i64) < THRESHOLD
     }
 }

--- a/crates/core/src/swarm/impls.rs
+++ b/crates/core/src/swarm/impls.rs
@@ -401,6 +401,7 @@ impl ConnectionManager for Swarm {
 impl Judegement for Swarm {
     /// Record a succeeded connected
     async fn record_connect(&self, did: Did) {
+        tracing::info!("Record connect {:?}", &did);
         if let Some(measure) = &self.measure {
             tracing::info!("[Judgement] Record connect");
             measure.incr(did, MeasureCounter::Connect).await;
@@ -409,6 +410,7 @@ impl Judegement for Swarm {
 
     /// Record a disconnected
     async fn record_disconnected(&self, did: Did) {
+        tracing::info!("Record disconnected {:?}", &did);
         if let Some(measure) = &self.measure {
             tracing::info!("[Judgement] Record disconnected");
             measure.incr(did, MeasureCounter::Disconnected).await;

--- a/crates/derive/src/derives.rs
+++ b/crates/derive/src/derives.rs
@@ -4,13 +4,13 @@ pub fn impl_measure_behaviour_traits(ast: &syn::DeriveInput) -> proc_macro2::Tok
     let impl_token = quote! {
     #[cfg_attr(feature = "node", async_trait)]
     #[cfg_attr(feature = "browser", async_trait(?Send))]
-    impl<const T: i16> MessageSendBehaviour<T> for #name {}
+    impl<const T: i64> MessageSendBehaviour<T> for #name {}
     #[cfg_attr(feature = "node", async_trait)]
     #[cfg_attr(feature = "browser", async_trait(?Send))]
-    impl<const T: i16> MessageRecvBehaviour<T> for #name {}
+    impl<const T: i64> MessageRecvBehaviour<T> for #name {}
     #[cfg_attr(feature = "node", async_trait)]
     #[cfg_attr(feature = "browser", async_trait(?Send))]
-    impl<const T: i16> ConnectBehaviour<T> for #name {}
+    impl<const T: i64> ConnectBehaviour<T> for #name {}
     };
 
     #[cfg(not(feature = "core_crate"))]

--- a/crates/node/src/consts.rs
+++ b/crates/node/src/consts.rs
@@ -4,10 +4,10 @@ pub const BACKEND_MTU: usize = TRANSPORT_MAX_SIZE - TRANSPORT_MTU;
 /// Redundant setting of vnode data storage
 pub const DATA_REDUNDANT: u16 = 6;
 /// Connect Behaviour
-pub const CONNECT_FAILED_LIMIT: i16 = 3;
+pub const CONNECT_FAILED_LIMIT: i64 = 3;
 /// Message Send Behaviour
-pub const MSG_SEND_FAILED_LIMIT: i16 = 10;
+pub const MSG_SEND_FAILED_LIMIT: i64 = 10;
 /// Message Received Behaviour
-pub const MSG_RECV_FAILED_LIMIT: i16 = 10;
+pub const MSG_RECV_FAILED_LIMIT: i64 = 10;
 /// Timeout for proxied TCP connections
 pub const TCP_SERVER_TIMEOUT: u64 = 30;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
The method `good` of `ConnectBehaviour` trait raise `attempt to subtract with overflow` panic when `conn < disconn` somehow.

## :brown_circle: What is the current behavior? (You can also link to an open issue here)

## :green_circle: What is the new behavior (if this is a feature change)?

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

## :information_source: Other information

Closes #issue
