### PR TITLE
feature: disable multicast dns in native webrtc connection

### DIFF
--- a/crates/node/src/logging.rs
+++ b/crates/node/src/logging.rs
@@ -149,20 +149,11 @@ pub mod node {
         let subscriber = Registry::default();
         let level_filter = filter::LevelFilter::from_level(level.into());
 
-        // Filter floating log of mdns
-        let mdns_log_filter = filter::FilterFn::new(|metadata| {
-            !metadata.target().starts_with("webrtc_mdns::conn")
-                || [276, 322]
-                    .iter()
-                    .all(|&line| !metadata.line().unwrap_or_default() == line)
-        });
-
         // Stderr
         let subscriber = subscriber.with(
             fmt::layer()
                 .with_writer(std::io::stderr)
-                .with_filter(level_filter)
-                .with_filter(mdns_log_filter.clone()),
+                .with_filter(level_filter),
         );
 
         // Jaeger
@@ -178,8 +169,7 @@ pub mod node {
                 subscriber.with(Some(
                     tracing_opentelemetry::layer()
                         .with_tracer(jaeger)
-                        .with_filter(level_filter)
-                        .with_filter(mdns_log_filter),
+                        .with_filter(level_filter),
                 ))
             } else {
                 subscriber.with(None)

--- a/crates/transport/src/connections/native_webrtc/mod.rs
+++ b/crates/transport/src/connections/native_webrtc/mod.rs
@@ -199,10 +199,9 @@ impl TransportInterface for WebrtcTransport {
         if let Some(ref addr) = self.external_address {
             tracing::debug!("setting external ip {:?}", addr);
             setting.set_nat_1to1_ips(vec![addr.to_string()], RTCIceCandidateType::Host);
-            setting.set_ice_multicast_dns_mode(MulticastDnsMode::QueryOnly);
+            setting.set_ice_multicast_dns_mode(MulticastDnsMode::Disabled);
         } else {
-            // mDNS gathering cannot be used with 1:1 NAT IP mapping for host candidate
-            setting.set_ice_multicast_dns_mode(MulticastDnsMode::QueryAndGather);
+            setting.set_ice_multicast_dns_mode(MulticastDnsMode::Disabled);
         }
 
         let webrtc_api = webrtc::api::APIBuilder::new()


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This PR disables mdns query to prevent overload when creating repeated connections in lightweight hardware.

## :brown_circle: What is the current behavior? (You can also link to an open issue here)

## :green_circle: What is the new behavior (if this is a feature change)?

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

## :information_source: Other information

Closes #issue
