### PR TITLE
ci: fix protoc setup limitation

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Setup protoc
         uses: arduino/setup-protoc@v2.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup rust toolchain
         run: |
@@ -125,6 +127,8 @@ jobs:
 
       - name: Setup protoc
         uses: arduino/setup-protoc@v2.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup rust toolchain
         run: |
@@ -187,6 +191,8 @@ jobs:
 
       - name: Setup protoc
         uses: arduino/setup-protoc@v2.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup rust toolchain
         run: |

--- a/.github/workflows/qaci.yml
+++ b/.github/workflows/qaci.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Setup protoc
         uses: arduino/setup-protoc@v2.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup rust toolchain
         run: rustup show
@@ -72,6 +74,8 @@ jobs:
 
       - name: Setup protoc
         uses: arduino/setup-protoc@v2.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup rust toolchain
         run: rustup show
@@ -105,6 +109,8 @@ jobs:
 
       - name: Setup protoc
         uses: arduino/setup-protoc@v2.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup rust toolchain
         run: rustup show
@@ -142,6 +148,8 @@ jobs:
 
       - name: Setup protoc
         uses: arduino/setup-protoc@v2.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup rust toolchain
         run: |


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
The CI always failed with log:
```
API rate limit exceeded for [some ip]. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
```

According to https://github.com/arduino/setup-protoc/issues/6 , this PR should fix that.

## :brown_circle: What is the current behavior? (You can also link to an open issue here)

## :green_circle: What is the new behavior (if this is a feature change)?

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

## :information_source: Other information
https://github.com/arduino/setup-protoc/issues/6

Closes #issue
