### PR TITLE
fix: check if destination is already connected when infer the next ho…

### DIFF
--- a/crates/core/src/message/payload.rs
+++ b/crates/core/src/message/payload.rs
@@ -240,6 +240,9 @@ pub trait PayloadSender {
     /// Get access to DHT.
     fn dht(&self) -> Arc<PeerRing>;
 
+    /// Used to check if destination is already connected when `infer_next_hop`
+    fn is_connected(&self, did: Did) -> bool;
+
     /// Send a message payload to a specified DID.
     async fn do_send_payload(&self, did: Did, payload: MessagePayload) -> Result<()>;
 
@@ -247,6 +250,10 @@ pub trait PayloadSender {
     fn infer_next_hop(&self, next_hop: Option<Did>, destination: Did) -> Result<Did> {
         if let Some(next_hop) = next_hop {
             return Ok(next_hop);
+        }
+
+        if self.is_connected(destination) {
+            return Ok(destination);
         }
 
         match self.dht().find_successor(destination)? {

--- a/crates/core/src/swarm/mod.rs
+++ b/crates/core/src/swarm/mod.rs
@@ -18,6 +18,7 @@ use rings_derive::JudgeConnection;
 use rings_transport::core::transport::BoxedTransport;
 use rings_transport::core::transport::ConnectionInterface;
 use rings_transport::core::transport::TransportMessage;
+use rings_transport::core::transport::WebrtcConnectionState;
 use rings_transport::error::Error as TransportError;
 pub use types::MeasureImpl;
 pub use types::WrappedDid;
@@ -320,6 +321,13 @@ impl PayloadSender for Swarm {
 
     fn dht(&self) -> Arc<PeerRing> {
         Swarm::dht(self)
+    }
+
+    fn is_connected(&self, did: Did) -> bool {
+        let Some(conn) = self.get_connection(did) else {
+            return false;
+        };
+        conn.webrtc_connection_state() == WebrtcConnectionState::Connected
     }
 
     async fn do_send_payload(&self, did: Did, payload: MessagePayload) -> Result<()> {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Allow a node send the message directly when the destination is already connected.

## :brown_circle: What is the current behavior? (You can also link to an open issue here)

## :green_circle: What is the new behavior (if this is a feature change)?

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

## :information_source: Other information

Closes #issue
