### PR TITLE
feat!: differentiate swarms based on network_id

### DIFF
--- a/crates/core/src/message/handlers/connection.rs
+++ b/crates/core/src/message/handlers/connection.rs
@@ -60,6 +60,10 @@ impl HandleMsg<QueryForTopoInfoReport> for MessageHandler {
 #[cfg_attr(not(feature = "wasm"), async_trait)]
 impl HandleMsg<ConnectNodeSend> for MessageHandler {
     async fn handle(&self, ctx: &MessagePayload, msg: &ConnectNodeSend) -> Result<()> {
+        if msg.network_id != self.transport.network_id {
+            return Ok(());
+        }
+
         if self.dht.did != ctx.relay.destination {
             self.transport.forward_payload(ctx, None).await
         } else {

--- a/crates/core/src/message/types.rs
+++ b/crates/core/src/message/types.rs
@@ -24,6 +24,9 @@ pub trait Then {
 pub struct ConnectNodeSend {
     /// sdp offer of webrtc
     pub sdp: String,
+    /// The network_id is used to distinguish different networks.
+    /// Use 1 for main network.
+    pub network_id: u32,
 }
 
 /// MessageType report to origin with own transport_uuid and handshake_info.

--- a/crates/core/src/swarm/builder.rs
+++ b/crates/core/src/swarm/builder.rs
@@ -19,6 +19,7 @@ impl SwarmCallback for DefaultCallback {}
 
 /// Creates a SwarmBuilder to configure a Swarm.
 pub struct SwarmBuilder {
+    network_id: u32,
     ice_servers: String,
     external_address: Option<String>,
     dht_succ_max: u8,
@@ -31,8 +32,14 @@ pub struct SwarmBuilder {
 
 impl SwarmBuilder {
     /// Creates new instance of [SwarmBuilder]
-    pub fn new(ice_servers: &str, dht_storage: VNodeStorage, session_sk: SessionSk) -> Self {
+    pub fn new(
+        network_id: u32,
+        ice_servers: &str,
+        dht_storage: VNodeStorage,
+        session_sk: SessionSk,
+    ) -> Self {
         SwarmBuilder {
+            network_id,
             ice_servers: ice_servers.to_string(),
             external_address: None,
             dht_succ_max: 3,
@@ -91,6 +98,7 @@ impl SwarmBuilder {
         );
 
         let transport = Arc::new(SwarmTransport::new(
+            self.network_id,
             &self.ice_servers,
             self.external_address,
             self.session_sk,

--- a/crates/core/src/swarm/transport.rs
+++ b/crates/core/src/swarm/transport.rs
@@ -39,6 +39,7 @@ use crate::session::SessionSk;
 use crate::swarm::callback::InnerSwarmCallback;
 
 pub struct SwarmTransport {
+    pub(crate) network_id: u32,
     transport: Transport,
     session_sk: SessionSk,
     pub(crate) dht: Arc<PeerRing>,
@@ -54,6 +55,7 @@ pub struct SwarmConnection {
 
 impl SwarmTransport {
     pub fn new(
+        network_id: u32,
         ice_servers: &str,
         external_address: Option<String>,
         session_sk: SessionSk,
@@ -61,6 +63,7 @@ impl SwarmTransport {
         measure: Option<MeasureImpl>,
     ) -> Self {
         Self {
+            network_id,
             transport: Transport::new(ice_servers, external_address),
             session_sk,
             dht,
@@ -184,7 +187,10 @@ impl SwarmTransport {
 
         let offer = conn.webrtc_create_offer().await.map_err(Error::Transport)?;
         let offer_str = serde_json::to_string(&offer).map_err(|_| Error::SerializeToString)?;
-        let offer_msg = ConnectNodeSend { sdp: offer_str };
+        let offer_msg = ConnectNodeSend {
+            sdp: offer_str,
+            network_id: self.network_id,
+        };
 
         Ok(offer_msg)
     }

--- a/crates/core/src/tests/default/mod.rs
+++ b/crates/core/src/tests/default/mod.rs
@@ -93,7 +93,7 @@ pub async fn prepare_node(key: SecretKey) -> Node {
     let storage = Box::new(MemStorage::new());
 
     let session_sk = SessionSk::new_with_seckey(&key).unwrap();
-    let swarm = Arc::new(SwarmBuilder::new(stun, storage, session_sk).build());
+    let swarm = Arc::new(SwarmBuilder::new(0, stun, storage, session_sk).build());
 
     println!("key: {:?}", key.to_string());
     println!("did: {:?}", swarm.did());

--- a/crates/core/src/tests/wasm/mod.rs
+++ b/crates/core/src/tests/wasm/mod.rs
@@ -30,7 +30,7 @@ pub async fn prepare_node(key: SecretKey) -> Arc<Swarm> {
             .unwrap(),
     );
 
-    let swarm = Arc::new(SwarmBuilder::new(stun, storage, session_sk).build());
+    let swarm = Arc::new(SwarmBuilder::new(0, stun, storage, session_sk).build());
 
     println!("key: {:?}", key.to_string());
     println!("did: {:?}", swarm.did());

--- a/crates/node/src/provider/browser/provider.rs
+++ b/crates/node/src/provider/browser/provider.rs
@@ -79,6 +79,7 @@ impl Provider {
     /// Signer should function as same as account_type declared, Eg: eip191 or secp256k1 or ed25519.
     #[wasm_bindgen(constructor)]
     pub fn new_instance(
+        network_id: u32,
         ice_servers: String,
         stabilize_interval: u64,
         account: String,
@@ -123,6 +124,7 @@ impl Provider {
             );
 
             let provider = Provider::new_provider_internal(
+                network_id,
                 ice_servers,
                 stabilize_interval,
                 account,

--- a/crates/node/src/provider/ffi.rs
+++ b/crates/node/src/provider/ffi.rs
@@ -221,6 +221,7 @@ pub extern "C" fn request(
 /// * This function cast CStr into Str
 #[no_mangle]
 pub unsafe extern "C" fn new_provider_with_callback(
+    network_id: u32,
     ice_server: *const c_char,
     stabilize_interval: u64,
     account: *const c_char,
@@ -254,6 +255,7 @@ pub unsafe extern "C" fn new_provider_with_callback(
         let acc_ty: String = c_char_to_string(account_type)?;
 
         executor::block_on(Provider::new_provider_internal(
+            network_id,
             ice,
             stabilize_interval,
             acc,

--- a/crates/node/src/provider/mod.rs
+++ b/crates/node/src/provider/mod.rs
@@ -97,7 +97,9 @@ impl Provider {
     /// please check [rings_core::ecc]
     /// Signer should accept a String and returns bytes.
     /// Signer should function as same as account_type declared, Eg: eip191 or secp256k1 or ed25519.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new_provider_internal(
+        network_id: u32,
         ice_servers: String,
         stabilize_interval: u64,
         account: String,
@@ -114,7 +116,7 @@ impl Provider {
         };
         sk_builder = sk_builder.set_session_sig(sig.to_vec());
         let session_sk = sk_builder.build().map_err(Error::InternalError)?;
-        let config = ProcessorConfig::new(ice_servers, session_sk, stabilize_interval);
+        let config = ProcessorConfig::new(network_id, ice_servers, session_sk, stabilize_interval);
         Self::new_provider_with_storage_internal(config, vnode_storage, measure_storage).await
     }
 

--- a/crates/node/src/tests/native/mod.rs
+++ b/crates/node/src/tests/native/mod.rs
@@ -12,6 +12,7 @@ pub async fn prepare_processor() -> Processor {
     let sm = SessionSk::new_with_seckey(&key).unwrap();
 
     let config = serde_yaml::to_string(&ProcessorConfig::new(
+        0,
         "stun://stun.l.google.com:19302".to_string(),
         sm,
         3,

--- a/crates/node/src/tests/wasm/mod.rs
+++ b/crates/node/src/tests/wasm/mod.rs
@@ -27,6 +27,7 @@ pub async fn prepare_processor() -> Processor {
     let sm = SessionSk::new_with_seckey(&key).unwrap();
 
     let config = serde_yaml::to_string(&ProcessorConfig::new(
+        0,
         "stun://stun.l.google.com:19302".to_string(),
         sm,
         200,

--- a/examples/ffi/rings.h
+++ b/examples/ffi/rings.h
@@ -91,7 +91,8 @@ const char *request(const struct ProviderPtr *provider_ptr, const char *method, 
  *
  * * This function cast CStr into Str
  */
-struct ProviderPtr new_provider_with_callback(const char *ice_server,
+struct ProviderPtr new_provider_with_callback(uint32_t network_id,
+                                              const char *ice_server,
                                               uint64_t stabilize_interval,
                                               const char *account,
                                               const char *account_type,

--- a/examples/ffi/rings.py
+++ b/examples/ffi/rings.py
@@ -58,6 +58,7 @@ def create_provider(acc,
     rings.init_logging(rings.Debug)
     callback = rings.new_ffi_backend_behaviour(on_paintext_message, on_service_message, on_extension_message)
     provider = rings.new_provider_with_callback(
+        0,
         "stun://stun.l.google.com".encode(),
         10,
         acc.address.encode(),

--- a/examples/native/src/main.rs
+++ b/examples/native/src/main.rs
@@ -52,7 +52,9 @@ async fn main() {
     let sk = skb.build().unwrap();
 
     // Build processor
-    let config = ProcessorConfig::new("stun://stun.l.google.com:19302".to_string(), sk, 3);
+    let config = ProcessorConfig::new(0, "stun://stun.l.google.com:19302".to_string(), sk, 3);
+    println!("===> Use network_id: 0");
+
     let storage = Box::new(MemStorage::new());
     let processor = Arc::new(
         ProcessorBuilder::from_config(&config)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This PR introduces a `network_id` field in `ConnectNodeSend` message. It's used to prevent nodes from different networks from connecting to each other.

## :brown_circle: What is the current behavior? (You can also link to an open issue here)

## :green_circle: What is the new behavior (if this is a feature change)?

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
There is a breaking change in config file.
User must specify network_id in config file now.

## :information_source: Other information

Closes #issue
