### PR TITLE
bugfix! fix bip137 sig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "examples/native", "examples/snark"]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 license = "GPL-3.0"
 authors = ["RND <dev@ringsnetwork.io>"]

--- a/crates/core/src/ecc/signers/bip137.rs
+++ b/crates/core/src/ecc/signers/bip137.rs
@@ -26,9 +26,10 @@ pub fn recover(msg: &[u8], sig: impl AsRef<[u8]>) -> Result<PublicKey> {
     let sig = sig.as_mut_slice();
     let sig_byte = array_mut_ref![sig, 0, 65];
     let hash = self::magic_hash(msg);
-    if sig_byte[64] >= 27 && sig_byte[64] <= 31 {
+
+    if sig_byte[64] >= 27 && sig_byte[64] <= 30 {
 	sig_byte[64] -= 27;
-    } else if sig_byte[64] >=32 && sig_byte[64] <= 34 {
+    } else if sig_byte[64] >=31 && sig_byte[64] <= 34 {
 	sig_byte[64] -= 31;
     } else {
 	return Err(Error::InvalidRecoverId(sig_byte[64]))

--- a/crates/core/src/ecc/signers/bip137.rs
+++ b/crates/core/src/ecc/signers/bip137.rs
@@ -7,15 +7,32 @@ use sha2::Sha256;
 use crate::ecc::PublicKey;
 use crate::ecc::PublicKeyAddress;
 use crate::error::Result;
+use crate::error::Error;
 
 /// recover pubkey according to signature.
+/// | y-parity | x-order       | compression | recovery id | v  |
+/// |----------|---------------|-------------|-------------|----|
+/// | even     | less than n   | false       | 0           | 27 |
+/// | odd      | less than n   | false       | 1           | 28 |
+/// | even     | more than n   | false       | 2           | 29 |
+/// | odd      | more than n   | false       | 3           | 30 |
+/// | even     | less than n   | true        | 0           | 31 |
+/// | odd      | less than n   | true        | 1           | 32 |
+/// | even     | more than n   | true        | 2           | 33 |
+/// | odd      | more than n   | true        | 3           | 34 |
 pub fn recover(msg: &[u8], sig: impl AsRef<[u8]>) -> Result<PublicKey> {
     let mut sig = sig.as_ref().to_vec();
     sig.rotate_left(1);
     let sig = sig.as_mut_slice();
     let sig_byte = array_mut_ref![sig, 0, 65];
     let hash = self::magic_hash(msg);
-    sig_byte[64] -= 27;
+    if sig_byte[64] >= 27 && sig_byte[64] <= 31 {
+	sig_byte[64] -= 27;
+    } else if sig_byte[64] >=32 && sig_byte[64] <= 34 {
+	sig_byte[64] -= 31;
+    } else {
+	return Err(Error::InvalidRecoverId(sig_byte[64]))
+    }
     crate::ecc::recover_hash(&hash, sig_byte)
 }
 

--- a/crates/core/src/ecc/signers/bip137.rs
+++ b/crates/core/src/ecc/signers/bip137.rs
@@ -6,8 +6,8 @@ use sha2::Sha256;
 
 use crate::ecc::PublicKey;
 use crate::ecc::PublicKeyAddress;
-use crate::error::Result;
 use crate::error::Error;
+use crate::error::Result;
 
 /// recover pubkey according to signature.
 /// | y-parity | x-order       | compression | recovery id | v  |
@@ -28,11 +28,11 @@ pub fn recover(msg: &[u8], sig: impl AsRef<[u8]>) -> Result<PublicKey> {
     let hash = self::magic_hash(msg);
 
     if sig_byte[64] >= 27 && sig_byte[64] <= 30 {
-	sig_byte[64] -= 27;
-    } else if sig_byte[64] >=31 && sig_byte[64] <= 34 {
-	sig_byte[64] -= 31;
+        sig_byte[64] -= 27;
+    } else if sig_byte[64] >= 31 && sig_byte[64] <= 34 {
+        sig_byte[64] -= 31;
     } else {
-	return Err(Error::InvalidRecoverId(sig_byte[64]))
+        return Err(Error::InvalidRecoverId(sig_byte[64]));
     }
     crate::ecc::recover_hash(&hash, sig_byte)
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -88,6 +88,9 @@ pub enum Error {
     #[error("Failed on verify message signature")]
     VerifySignatureFailed,
 
+    #[error("ECDSA Invalid recover Id {0}")]
+    InvalidRecoverId(u8),
+
     #[error("Gzip encode error.")]
     GzipEncode,
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "RND <dev@ringsnetwork.io>"
   ],
   "description": "Rings is a structured peer-to-peer network implementation using WebRTC, Chord algorithm, and full WebAssembly (WASM) support.\n",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "GPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixed: recovery ID of compressed bitcoin signature is not covered in our implementation.

Protocol Details:

| y-parity | x-order       | compression | recovery id | v  |
 |----------|---------------|-------------|-------------|----|
| even     | less than n   | false       | 0           | 27 |
| odd      | less than n   | false       | 1           | 28 |
| even     | more than n   | false       | 2           | 29 |
| odd      | more than n   | false       | 3           | 30 |
| even     | less than n   | true        | 0           | 31 |
| odd      | less than n   | true        | 1           | 32 |
| even     | more than n   | true        | 2           | 33 |
| odd      | more than n   | true        | 3           | 34 |
