### PR TITLE
feat: support BLS (Boneh-Lynn-Shacham) signature

### DIFF
--- a/.github/workflows/qaci.yml
+++ b/.github/workflows/qaci.yml
@@ -64,7 +64,7 @@ jobs:
 
   build:
     name: Build and test
-    timeout-minutes: 25
+    timeout-minutes: 30
     strategy:
       matrix:
         os: ["ubuntu-latest"]

--- a/.github/workflows/qaci.yml
+++ b/.github/workflows/qaci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run core browser tests
         uses: coactions/setup-xvfb@v1
         with:
-          run: cargo test -p rings-core --target=wasm32-unknown-unknown --features wasm --no-default-features
+          run: cargo test -p rings-core --release --target=wasm32-unknown-unknown --features wasm --no-default-features
           working-directory: ./
 
       - name: Run node browser tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "bls-signatures"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc7fce0356b52c2483bb6188cc8bdc11add526bce75d1a44e5e5d889a6ab008"
+dependencies = [
+ "bls12_381",
+ "blst",
+ "blstrs",
+ "ff",
+ "group",
+ "hkdf 0.11.0",
+ "pairing",
+ "rand_core 0.6.4",
+ "rayon",
+ "sha2 0.9.9",
+ "subtle",
+ "thiserror",
+]
+
+[[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
+dependencies = [
+ "digest 0.9.0",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "blst"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1162,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
+dependencies = [
+ "generic-array 0.14.7",
+ "subtle",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,7 +1405,7 @@ checksum = "53f43496fc04523aa716c5dd76133cb6d7c81eb213375684d06a8b1683f8bc1e"
 dependencies = [
  "aes-gcm",
  "getrandom 0.2.12",
- "hkdf",
+ "hkdf 0.12.4",
  "libsecp256k1",
  "once_cell",
  "parking_lot 0.12.1",
@@ -1412,7 +1456,7 @@ dependencies = [
  "ff",
  "generic-array 0.14.7",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -2004,6 +2048,16 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
+dependencies = [
+ "digest 0.9.0",
+ "hmac 0.11.0",
+]
+
+[[package]]
+name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
@@ -2017,7 +2071,17 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac 0.11.0",
  "digest 0.9.0",
 ]
 
@@ -3775,7 +3839,7 @@ dependencies = [
 
 [[package]]
 name = "rings-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "arrayref",
  "async-lock",
@@ -3785,6 +3849,8 @@ dependencies = [
  "base58",
  "base58-monero",
  "bincode",
+ "bls-signatures",
+ "bls12_381",
  "bytes",
  "chrono",
  "dashmap",
@@ -3838,7 +3904,7 @@ dependencies = [
 
 [[package]]
 name = "rings-derive"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3848,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "rings-native-example"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "rings-core",
@@ -3860,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "rings-node"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -3920,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "rings-rpc"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3940,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "rings-snark"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "bellman_ce",
  "bellpepper-core",
@@ -3969,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "rings-snark-example"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "rings-core",
@@ -3981,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "rings-transport"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5716,7 +5782,7 @@ dependencies = [
  "cbc",
  "ccm",
  "der-parser",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "log",
  "p256",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,40 +707,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bls-signatures"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc7fce0356b52c2483bb6188cc8bdc11add526bce75d1a44e5e5d889a6ab008"
-dependencies = [
- "bls12_381",
- "blst",
- "blstrs",
- "ff",
- "group",
- "hkdf 0.11.0",
- "pairing",
- "rand_core 0.6.4",
- "rayon",
- "sha2 0.9.9",
- "subtle",
- "thiserror",
-]
-
-[[package]]
-name = "bls12_381"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
-dependencies = [
- "digest 0.9.0",
- "ff",
- "group",
- "pairing",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "blst"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,16 +1258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
-dependencies = [
- "generic-array 0.14.7",
- "subtle",
-]
-
-[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,7 +1491,7 @@ checksum = "53f43496fc04523aa716c5dd76133cb6d7c81eb213375684d06a8b1683f8bc1e"
 dependencies = [
  "aes-gcm",
  "getrandom 0.2.12",
- "hkdf 0.12.4",
+ "hkdf",
  "libsecp256k1",
  "once_cell",
  "parking_lot 0.12.1",
@@ -1586,7 +1542,7 @@ dependencies = [
  "ff",
  "generic-array 0.14.7",
  "group",
- "hkdf 0.12.4",
+ "hkdf",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -2187,16 +2143,6 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
-dependencies = [
- "digest 0.9.0",
- "hmac 0.11.0",
-]
-
-[[package]]
-name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
@@ -2210,17 +2156,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac 0.11.0",
+ "crypto-mac",
  "digest 0.9.0",
 ]
 
@@ -3993,8 +3929,6 @@ dependencies = [
  "base58",
  "base58-monero",
  "bincode",
- "bls-signatures",
- "bls12_381",
  "bytes",
  "chrono",
  "dashmap",
@@ -5926,7 +5860,7 @@ dependencies = [
  "cbc",
  "ccm",
  "der-parser",
- "hkdf 0.12.4",
+ "hkdf",
  "hmac 0.12.1",
  "log",
  "p256",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if 1.0.0",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +169,124 @@ name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint 0.4.4",
+ "num-traits",
+ "paste",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint 0.4.4",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest 0.10.7",
+ "num-bigint 0.4.4",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "arrayref"
@@ -1983,7 +2113,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.7",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.11",
 ]
 
 [[package]]
@@ -3841,6 +3980,11 @@ dependencies = [
 name = "rings-core"
 version = "0.7.0"
 dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "arrayref",
  "async-lock",
  "async-recursion",
@@ -6221,6 +6365,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2960,9 +2960,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -42,6 +42,11 @@ browser_chrome_test = ["wasm"]
 
 [dependencies]
 # global
+ark-bls12-381 = "0.4.0"
+ark-ec = "0.4.2"
+ark-ff = "0.4.2"
+ark-serialize = "0.4.2"
+ark-std = "0.4.0"
 arrayref = "0.3.6"
 async-lock = "2.5.0"
 async-recursion = "1.0.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -55,8 +55,6 @@ async-trait = { workspace = true }
 base58 = "0.2.0"
 base58-monero = { version = "0.3", default-features = false, features = ["check"] }
 bincode = "1.3.3"
-bls-signatures = { version = "0.15.0", features = ["blst-portable"] }
-bls12_381 = "0.8.0"
 bytes = { version = "1.2.1", features = ["serde"] }
 chrono = { version = "0.4.19", features = ["wasmbind"] }
 dashmap = "5"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -50,6 +50,8 @@ async-trait = { workspace = true }
 base58 = "0.2.0"
 base58-monero = { version = "0.3", default-features = false, features = ["check"] }
 bincode = "1.3.3"
+bls-signatures = { version = "0.15.0", features = ["blst-portable"] }
+bls12_381 = "0.8.0"
 bytes = { version = "1.2.1", features = ["serde"] }
 chrono = { version = "0.4.19", features = ["wasmbind"] }
 dashmap = "5"

--- a/crates/core/src/ecc/elgamal.rs
+++ b/crates/core/src/ecc/elgamal.rs
@@ -156,8 +156,8 @@ pub fn decrypt(m: &[(CurveEle, CurveEle)], k: SecretKey) -> Result<String> {
     affine_to_str(
         m.iter()
             .map(|(c1, c2)| {
-                let c1: Affine = (*c1).try_into().expect("bad curve point");
-                let c2: Affine = (*c2).try_into().expect("bad curve point");
+                let c1: Affine = c1.clone().try_into().expect("bad curve point");
+                let c2: Affine = c2.clone().try_into().expect("bad curve point");
                 let mut t = Jacobian::default();
                 cxt.ecmult_const(&mut t, &c1, &sar);
                 let a_t = Affine::from_gej(&t).neg();

--- a/crates/core/src/ecc/elgamal.rs
+++ b/crates/core/src/ecc/elgamal.rs
@@ -117,7 +117,7 @@ pub fn affine_to_str(a: &[Affine]) -> Result<String> {
     field_to_str(a.iter().map(|x| x.x).collect::<Vec<Field>>().as_slice())
 }
 
-pub fn encrypt(s: &str, k: PublicKey) -> Result<Vec<(CurveEle, CurveEle)>> {
+pub fn encrypt(s: &str, k: PublicKey<33>) -> Result<Vec<(CurveEle<33>, CurveEle<33>)>> {
     let random_sar: Scalar = SecretKey::random().into();
     let mut h: Affine = k.try_into()?;
     h.y.normalize();
@@ -143,21 +143,21 @@ pub fn encrypt(s: &str, k: PublicKey) -> Result<Vec<(CurveEle, CurveEle)>> {
             (a_c1, a_c2)
         })
         .collect();
-    let mut ret: Vec<(CurveEle, CurveEle)> = vec![];
+    let mut ret: Vec<(CurveEle<33>, CurveEle<33>)> = vec![];
     for (c1, c2) in affines {
         ret.push((c1.try_into()?, c2.try_into()?))
     }
     Ok(ret)
 }
 
-pub fn decrypt(m: &[(CurveEle, CurveEle)], k: SecretKey) -> Result<String> {
+pub fn decrypt(m: &[(CurveEle<33>, CurveEle<33>)], k: SecretKey) -> Result<String> {
     let sar: Scalar = k.into();
     let cxt = ECMultContext::new_boxed();
     affine_to_str(
         m.iter()
             .map(|(c1, c2)| {
-                let c1: Affine = c1.clone().try_into().expect("bad curve point");
-                let c2: Affine = c2.clone().try_into().expect("bad curve point");
+                let c1: Affine = (*c1).try_into().expect("bad curve point");
+                let c2: Affine = (*c2).try_into().expect("bad curve point");
                 let mut t = Jacobian::default();
                 cxt.ecmult_const(&mut t, &c1, &sar);
                 let a_t = Affine::from_gej(&t).neg();

--- a/crates/core/src/ecc/mod.rs
+++ b/crates/core/src/ecc/mod.rs
@@ -154,7 +154,7 @@ impl From<ed25519_dalek::PublicKey> for PublicKey {
         s.reverse();
         s.push(0);
         s.reverse();
-        Self(s.as_slice().try_into().unwrap())
+        Self(s.as_slice().into())
     }
 }
 

--- a/crates/core/src/ecc/mod.rs
+++ b/crates/core/src/ecc/mod.rs
@@ -83,7 +83,10 @@ impl From<SecretKey> for libsecp256k1::SecretKey {
 impl TryFrom<PublicKey> for libsecp256k1::PublicKey {
     type Error = Error;
     fn try_from(key: PublicKey) -> Result<Self> {
-	let data: [u8; 33] = key.0.try_into().map_err(|_| Error::ECDSAPublicKeyBadFormat)?;
+        let data: [u8; 33] = key
+            .0
+            .try_into()
+            .map_err(|_| Error::ECDSAPublicKeyBadFormat)?;
         Self::parse_compressed(&data).map_err(|_| Error::ECDSAPublicKeyBadFormat)
     }
 }

--- a/crates/core/src/ecc/mod.rs
+++ b/crates/core/src/ecc/mod.rs
@@ -33,7 +33,7 @@ pub use types::PublicKey;
 /// length r: 32, length s: 32, length v(recovery_id): 1
 pub type SigBytes = [u8; 65];
 /// Alias PublicKey.
-pub type CurveEle = PublicKey;
+pub type CurveEle<const SIZE: usize> = PublicKey<SIZE>;
 /// PublicKeyAddress is H160.
 pub type PublicKeyAddress = H160;
 
@@ -80,26 +80,23 @@ impl From<SecretKey> for libsecp256k1::SecretKey {
     }
 }
 
-impl TryFrom<PublicKey> for libsecp256k1::PublicKey {
+impl TryFrom<PublicKey<33>> for libsecp256k1::PublicKey {
     type Error = Error;
-    fn try_from(key: PublicKey) -> Result<Self> {
-        let data: [u8; 33] = key
-            .0
-            .try_into()
-            .map_err(|_| Error::ECDSAPublicKeyBadFormat)?;
+    fn try_from(key: PublicKey<33>) -> Result<Self> {
+        let data: [u8; 33] = key.0;
         Self::parse_compressed(&data).map_err(|_| Error::ECDSAPublicKeyBadFormat)
     }
 }
 
-impl TryFrom<PublicKey> for ed25519_dalek::PublicKey {
+impl TryFrom<PublicKey<33>> for ed25519_dalek::PublicKey {
     type Error = Error;
-    fn try_from(key: PublicKey) -> Result<Self> {
+    fn try_from(key: PublicKey<33>) -> Result<Self> {
         // pubkey[0] == 0
         Self::from_bytes(&key.0[1..]).map_err(|_| Error::EdDSAPublicKeyBadFormat)
     }
 }
 
-impl AffineCoordinates for PublicKey {
+impl AffineCoordinates for PublicKey<33> {
     type FieldRepr = GenericArray<u8, U32>;
 
     fn x(&self) -> Self::FieldRepr {
@@ -116,7 +113,7 @@ impl AffineCoordinates for PublicKey {
     }
 }
 
-impl PublicKey {
+impl PublicKey<33> {
     /// Map a PublicKey into secp256r1 affine point,
     /// This function is an constant-time cryptographic implementations
     pub fn ct_into_secp256r1_affine(self) -> CtOption<primeorder::AffinePoint<NistP256>> {
@@ -145,7 +142,7 @@ impl From<SecretKey> for FieldBytes<NistP256> {
     }
 }
 
-impl From<ed25519_dalek::PublicKey> for PublicKey {
+impl From<ed25519_dalek::PublicKey> for PublicKey<33> {
     fn from(key: ed25519_dalek::PublicKey) -> Self {
         // [u8;32] here
         // ref: https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.PublicKey.html
@@ -154,18 +151,18 @@ impl From<ed25519_dalek::PublicKey> for PublicKey {
         s.reverse();
         s.push(0);
         s.reverse();
-        Self(s.as_slice().into())
+        Self(s.as_slice().try_into().unwrap())
     }
 }
 
-impl TryFrom<PublicKey> for libsecp256k1::curve::Affine {
+impl TryFrom<PublicKey<33>> for libsecp256k1::curve::Affine {
     type Error = Error;
-    fn try_from(key: PublicKey) -> Result<Self> {
+    fn try_from(key: PublicKey<33>) -> Result<Self> {
         Ok(TryInto::<libsecp256k1::PublicKey>::try_into(key)?.into())
     }
 }
 
-impl TryFrom<libsecp256k1::curve::Affine> for PublicKey {
+impl TryFrom<libsecp256k1::curve::Affine> for PublicKey<33> {
     type Error = Error;
     fn try_from(a: libsecp256k1::curve::Affine) -> Result<Self> {
         let pubkey: libsecp256k1::PublicKey = a.try_into().map_err(|_| Error::InvalidPublicKey)?;
@@ -185,13 +182,13 @@ impl From<libsecp256k1::SecretKey> for SecretKey {
     }
 }
 
-impl From<libsecp256k1::PublicKey> for PublicKey {
+impl From<libsecp256k1::PublicKey> for PublicKey<33> {
     fn from(key: libsecp256k1::PublicKey) -> Self {
-        Self(key.serialize_compressed().to_vec())
+        Self(key.serialize_compressed())
     }
 }
 
-impl From<SecretKey> for PublicKey {
+impl From<SecretKey> for PublicKey<33> {
     fn from(secret_key: SecretKey) -> Self {
         libsecp256k1::PublicKey::from_secret_key(&secret_key.0).into()
     }
@@ -264,8 +261,8 @@ impl Serialize for SecretKey {
     }
 }
 
-fn public_key_address(pubkey: &PublicKey) -> PublicKeyAddress {
-    let hash = match TryInto::<libsecp256k1::PublicKey>::try_into(pubkey.clone()) {
+fn public_key_address(pubkey: &PublicKey<33>) -> PublicKeyAddress {
+    let hash = match TryInto::<libsecp256k1::PublicKey>::try_into(*pubkey) {
         // if pubkey is ecdsa key
         Ok(pk) => {
             let data = pk.serialize();
@@ -312,7 +309,7 @@ impl SecretKey {
         sig_bytes
     }
 
-    pub fn pubkey(&self) -> PublicKey {
+    pub fn pubkey(&self) -> PublicKey<33> {
         libsecp256k1::PublicKey::from_secret_key(&(*self).into()).into()
     }
 
@@ -321,14 +318,14 @@ impl SecretKey {
     }
 }
 
-impl PublicKey {
+impl PublicKey<33> {
     pub fn address(&self) -> PublicKeyAddress {
         public_key_address(self)
     }
 }
 
 /// Recover PublicKey from RawMessage using signature.
-pub fn recover<S>(message: &[u8], signature: S) -> Result<PublicKey>
+pub fn recover<S>(message: &[u8], signature: S) -> Result<PublicKey<33>>
 where S: AsRef<[u8]> {
     let sig_bytes: SigBytes = signature.as_ref().try_into()?;
     let message_hash: [u8; 32] = keccak256(message);
@@ -336,7 +333,7 @@ where S: AsRef<[u8]> {
 }
 
 /// Recover PublicKey from HashMessage using signature.
-pub fn recover_hash(message_hash: &[u8; 32], sig: &[u8; 65]) -> Result<PublicKey> {
+pub fn recover_hash(message_hash: &[u8; 32], sig: &[u8; 65]) -> Result<PublicKey<33>> {
     let r_s_signature: [u8; 64] = sig[..64].try_into()?;
     let recovery_id: u8 = sig[64];
     Ok(libsecp256k1::recover(

--- a/crates/core/src/ecc/signers/bip137.rs
+++ b/crates/core/src/ecc/signers/bip137.rs
@@ -20,7 +20,7 @@ use crate::error::Result;
 /// | odd      | less than n   | true        | 1           | 32 |
 /// | even     | more than n   | true        | 2           | 33 |
 /// | odd      | more than n   | true        | 3           | 34 |
-pub fn recover(msg: &[u8], sig: impl AsRef<[u8]>) -> Result<PublicKey> {
+pub fn recover(msg: &[u8], sig: impl AsRef<[u8]>) -> Result<PublicKey<33>> {
     let mut sig = sig.as_ref().to_vec();
     sig.rotate_left(1);
     let sig = sig.as_mut_slice();

--- a/crates/core/src/ecc/signers/bls.rs
+++ b/crates/core/src/ecc/signers/bls.rs
@@ -2,15 +2,17 @@
 //! based on [bls_signatures](https://docs.rs/bls-signatures/latest/bls_signatures/)
 //! This module implement transform of [libsecp256k1::Secretkey] and [bls_signature::PrivateKey]
 
-use bls12_381::Scalar;
-use bls_signatures  as bls;
-use libsecp256k1;
-use bls12_381::G1Affine;
 use crate::ecc::PublicKey;
 use crate::ecc::SecretKey;
 use crate::error::Error;
 use crate::error::Result;
+use bls12_381::G1Affine;
 use bls12_381::G1Projective;
+use bls12_381::G2Affine;
+use bls12_381::G2Projective;
+use bls12_381::Scalar;
+use bls_signatures as bls;
+use libsecp256k1;
 
 impl TryInto<SecretKey> for bls::PrivateKey {
     type Error = Error;
@@ -34,25 +36,38 @@ impl TryInto<bls::PrivateKey> for SecretKey {
     }
 }
 
-
 impl TryInto<PublicKey> for bls::PublicKey {
     type Error = Error;
     fn try_into(self) -> Result<PublicKey> {
-	let data: [u8; 48] = self.as_affine().to_compressed();
-	Ok(PublicKey(data.to_vec()))
+        let data: [u8; 48] = self.as_affine().to_compressed();
+        Ok(PublicKey(data.to_vec()))
     }
 }
-
 
 impl TryInto<bls::PublicKey> for PublicKey {
     type Error = Error;
     fn try_into(self) -> Result<bls::PublicKey> {
-	let data: [u8; 48] = self.0.try_into().map_err(|_| Error::PublicKeyBadFormat)?;
-	let affine: Option<G1Affine> = G1Affine::from_compressed(&data).into();
-	if let Some(af) = affine {
-	    Ok(bls::PublicKey::from(G1Projective::from(af)))
-	} else {
-	    Err(Error::PublicKeyBadFormat)
-	}
+        let data: [u8; 48] = self.0.try_into().map_err(|_| Error::PublicKeyBadFormat)?;
+        let affine: Option<G1Affine> = G1Affine::from_compressed(&data).into();
+        if let Some(af) = affine {
+            Ok(bls::PublicKey::from(G1Projective::from(af)))
+        } else {
+            Err(Error::PublicKeyBadFormat)
+        }
+    }
+}
+
+/// Sign message with bls privatekey
+/// reimplemented via https://docs.rs/bls-signatures/latest/src/bls_signatures/key.rs.html#103
+/// signature = hash_into_g2(message) * sk
+pub fn sign(sec: SecretKey, hash: &[u8; 96]) -> Result<[u8; 96]> {
+    let sk: bls::PrivateKey = sec.try_into()?;
+    let affine: Option<G2Affine> = G2Affine::from_compressed(hash).into();
+    if let Some(af) = affine {
+        let mut proj: G2Projective = af.into();
+        proj *= Into::<Scalar>::into(sk);
+        Ok(G2Affine::from(proj).to_compressed())
+    } else {
+        Err(Error::PublicKeyBadFormat)
     }
 }

--- a/crates/core/src/ecc/signers/bls.rs
+++ b/crates/core/src/ecc/signers/bls.rs
@@ -120,7 +120,6 @@ pub fn hash_to_curve(msg: &[u8]) -> Result<[u8; 96]> {
 }
 
 /// Sign message with bls privatekey
-/// reimplemented via https://docs.rs/bls-signatures/latest/src/bls_signatures/key.rs.html#103
 /// signature = hash_into_g2(message) * sk
 pub fn sign(sk: SecretKey, hashed_msg: &[u8; 96]) -> Result<Signature> {
     let sk: Fr = sk.try_into()?;

--- a/crates/core/src/ecc/signers/bls.rs
+++ b/crates/core/src/ecc/signers/bls.rs
@@ -37,11 +37,10 @@ impl TryInto<bls::PrivateKey> for SecretKey {
     }
 }
 
-impl TryInto<PublicKey> for bls::PublicKey {
-    type Error = Error;
-    fn try_into(self) -> Result<PublicKey> {
+impl Into<PublicKey> for bls::PublicKey {
+    fn into(self) -> PublicKey {
         let data: [u8; 48] = self.as_affine().to_compressed();
-        Ok(PublicKey(data.to_vec()))
+        PublicKey(data.to_vec())
     }
 }
 
@@ -58,6 +57,11 @@ impl TryInto<bls::PublicKey> for PublicKey {
     }
 }
 
+pub fn hash(msg: &[u8]) -> [u8; 96] {
+    let hash: G2Affine = bls::hash(msg).into();
+    hash.to_compressed()
+}
+
 /// Sign message with bls privatekey
 /// reimplemented via https://docs.rs/bls-signatures/latest/src/bls_signatures/key.rs.html#103
 /// signature = hash_into_g2(message) * sk
@@ -70,5 +74,82 @@ pub fn sign(sec: SecretKey, hash: &[u8; 96]) -> Result<[u8; 96]> {
         Ok(G2Affine::from(proj).to_compressed())
     } else {
         Err(Error::PublicKeyBadFormat)
+    }
+}
+
+/// Sign message with bls privatekey and message
+pub fn sign_raw(sec: SecretKey, msg: &[u8]) -> Result<[u8; 96]> {
+    let sk: bls::PrivateKey = sec.try_into()?;
+    let sig = sk.sign(hash(msg));
+    Ok(G2Affine::from(sig).to_compressed())
+}
+
+/// Verify message
+pub fn verify(hashes: &[[u8; 96]], sig: &[u8; 96], public_keys: &[PublicKey]) -> Result<bool> {
+    let sig_affine: Option<G2Affine> = G2Affine::from_compressed(sig).into();
+    if let Some(affine) = sig_affine {
+        let signature = bls::Signature::from(affine);
+        let hash: Option<Vec<G2Projective>> = hashes
+            .iter()
+            .map(|h| Into::<Option<G2Affine>>::into(G2Affine::from_compressed(h)))
+            .map(|a| a.map(|b| b.into()))
+            .collect::<Option<Vec<G2Projective>>>();
+        let pk: Result<Vec<bls::PublicKey>> =
+            public_keys.iter().map(|pk| pk.clone().try_into()).collect();
+        if let (Some(h), Ok(p)) = (hash, pk) {
+            Ok(bls::verify(&signature, &h, &p))
+        } else {
+            Err(Error::BlsAffineDecodeFailed)
+        }
+    } else {
+        Err(Error::PublicKeyBadFormat)
+    }
+}
+
+/// Verify message
+pub fn verify_msg(msgs: &[&[u8]], sig: &[u8; 96], public_keys: &[PublicKey]) -> Result<bool> {
+    let sig_affine: Option<G2Affine> = G2Affine::from_compressed(sig).into();
+    if let Some(affine) = sig_affine {
+        let signature = bls::Signature::from(affine);
+        let pk: Result<Vec<bls::PublicKey>> =
+            public_keys.iter().map(|pk| pk.clone().try_into()).collect();
+        if let Ok(p) = pk {
+            Ok(bls::verify_messages(&signature, &msgs, &p))
+        } else {
+            Err(Error::BlsAffineDecodeFailed)
+        }
+    } else {
+        Err(Error::PublicKeyBadFormat)
+    }
+}
+
+/// Cast bls publickey from bls secretkey
+pub fn to_bls_pk(sk: SecretKey) -> Result<PublicKey> {
+    let seckey: bls::PrivateKey = sk.try_into()?;
+    let pk = seckey.public_key();
+    Ok(pk.into())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ecc::SecretKey;
+
+    #[test]
+    fn test_sign_and_verify() {
+        let key =
+            SecretKey::try_from("65860affb4b570dba06db294aa7c676f68e04a5bf2721243ad3cbc05a79c68c0")
+                .unwrap();
+        let msg = "hello";
+        let sig = sign_raw(key, msg.as_bytes()).unwrap();
+        let pk = to_bls_pk(key).unwrap();
+        let hash = hash(msg.as_bytes());
+        assert!(verify_msg(
+            vec![msg.as_bytes()].as_slice(),
+            &sig,
+            vec![pk.clone()].as_slice()
+        )
+        .unwrap());
+        assert!(verify(vec![hash].as_slice(), &sig, vec![pk].as_slice()).unwrap());
     }
 }

--- a/crates/core/src/ecc/signers/bls.rs
+++ b/crates/core/src/ecc/signers/bls.rs
@@ -5,9 +5,12 @@
 use bls12_381::Scalar;
 use bls_signatures  as bls;
 use libsecp256k1;
+use bls12_381::G1Affine;
+use crate::ecc::PublicKey;
 use crate::ecc::SecretKey;
 use crate::error::Error;
 use crate::error::Result;
+use bls12_381::G1Projective;
 
 impl TryInto<SecretKey> for bls::PrivateKey {
     type Error = Error;
@@ -28,5 +31,28 @@ impl TryInto<bls::PrivateKey> for SecretKey {
         } else {
             Err(Error::PrivateKeyBadFormat)
         }
+    }
+}
+
+
+impl TryInto<PublicKey> for bls::PublicKey {
+    type Error = Error;
+    fn try_into(self) -> Result<PublicKey> {
+	let data: [u8; 48] = self.as_affine().to_compressed();
+	Ok(PublicKey(data.to_vec()))
+    }
+}
+
+
+impl TryInto<bls::PublicKey> for PublicKey {
+    type Error = Error;
+    fn try_into(self) -> Result<bls::PublicKey> {
+	let data: [u8; 48] = self.0.try_into().map_err(|_| Error::PublicKeyBadFormat)?;
+	let affine: Option<G1Affine> = G1Affine::from_compressed(&data).into();
+	if let Some(af) = affine {
+	    Ok(bls::PublicKey::from(G1Projective::from(af)))
+	} else {
+	    Err(Error::PublicKeyBadFormat)
+	}
     }
 }

--- a/crates/core/src/ecc/signers/bls.rs
+++ b/crates/core/src/ecc/signers/bls.rs
@@ -6,12 +6,20 @@
 //! It integrates the use of random number generation for key creation and provides conversions
 //! between different key types.
 
-use bls12_381::G1Affine;
-use bls12_381::G1Projective;
-use bls12_381::G2Affine;
-use bls12_381::G2Projective;
-use bls12_381::Scalar;
-use bls_signatures as bls;
+use ark_bls12_381::fr::Fr;
+use ark_bls12_381::g2::Config as G2Config;
+use ark_bls12_381::Bls12_381;
+use ark_bls12_381::G1Projective;
+use ark_bls12_381::G2Projective;
+use ark_ec::hashing::curve_maps::wb::WBMap;
+use ark_ec::hashing::map_to_curve_hasher::MapToCurveBasedHasher;
+use ark_ec::hashing::HashToCurve;
+use ark_ec::pairing::Pairing;
+use ark_ec::Group;
+use ark_ff::fields::field_hashers::DefaultFieldHasher;
+use ark_serialize::CanonicalDeserialize;
+use ark_serialize::CanonicalSerialize;
+use ark_std::UniformRand;
 use libsecp256k1;
 use rand::SeedableRng;
 use rand_hc::Hc128Rng;
@@ -25,129 +33,132 @@ use crate::error::Result;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Signature(pub [u8; 96]);
 
-impl From<bls::Signature> for Signature {
-    fn from(s: bls::Signature) -> Self {
-        Self(G2Affine::from(s).to_compressed())
-    }
-}
-
-impl TryInto<bls::Signature> for Signature {
-    type Error = Error;
-    fn try_into(self) -> Result<bls::Signature> {
-        let affine: Option<G2Affine> = G2Affine::from_compressed(&self.0).into();
-        if let Some(af) = affine {
-            Ok(bls::Signature::from(af))
-        } else {
-            Err(Error::BlsAffineDecodeFailed)
-        }
-    }
-}
-
-/// Generates a random BLS private key.
+/// this function is used to generate a random secret key
 pub fn random_sk() -> Result<SecretKey> {
     let mut rng = Hc128Rng::from_entropy();
-    bls::PrivateKey::generate(&mut rng).try_into()
+    Fr::rand(&mut rng).try_into()
 }
 
-impl TryInto<SecretKey> for bls::PrivateKey {
+fn from_compressed<T: CanonicalDeserialize, const S: usize>(a: &[u8; S]) -> Result<T> {
+    T::deserialize_compressed(&a[..]).map_err(|_| Error::EccDeserializeFailed)
+}
+
+fn to_compressed<T: CanonicalSerialize, const S: usize>(s: &T) -> Result<[u8; S]> {
+    let mut data: Vec<u8> = vec![];
+    s.serialize_compressed(&mut data)
+        .map_err(|_| Error::EccSerializeFailed)?;
+    assert_eq!(s.compressed_size(), S);
+    assert_eq!(data.len(), S);
+    let ret: [u8; S] = data.try_into().map_err(|_| Error::EccSerializeFailed)?;
+    Ok(ret)
+}
+
+impl TryFrom<SecretKey> for Fr {
     type Error = Error;
-    fn try_into(self) -> Result<SecretKey> {
-        let data: [u8; 32] = Into::<Scalar>::into(self).to_bytes();
+    fn try_from(sk: SecretKey) -> Result<Fr> {
+        let data: [u8; 32] = sk.0.serialize();
+        let ret: Fr = from_compressed(&data)?;
+        Ok(ret)
+    }
+}
+
+impl TryFrom<Fr> for SecretKey {
+    type Error = Error;
+    fn try_from(sk: Fr) -> Result<SecretKey> {
+        let data: [u8; 32] = to_compressed(&sk)?;
         let sk = libsecp256k1::SecretKey::parse(&data)?;
         Ok(SecretKey(sk))
     }
 }
 
-impl TryInto<bls::PrivateKey> for SecretKey {
+impl TryFrom<Signature> for G2Projective {
     type Error = Error;
-    fn try_into(self) -> Result<bls::PrivateKey> {
-        let sk = self.0.serialize();
-        let scalar: Option<Scalar> = Scalar::from_bytes(&sk).into();
-        if let Some(key) = scalar {
-            Ok(bls::PrivateKey::from(key))
-        } else {
-            Err(Error::PrivateKeyBadFormat)
-        }
+    fn try_from(s: Signature) -> Result<Self> {
+        from_compressed(&s.0)
     }
 }
 
-impl From<bls::PublicKey> for PublicKey {
-    fn from(val: bls::PublicKey) -> Self {
-        let data: [u8; 48] = val.as_affine().to_compressed();
-        PublicKey(data.to_vec())
-    }
-}
-
-impl TryInto<bls::PublicKey> for PublicKey {
+impl TryFrom<G2Projective> for Signature {
     type Error = Error;
-    fn try_into(self) -> Result<bls::PublicKey> {
-        let data: [u8; 48] = self.0.try_into().map_err(|_| Error::PublicKeyBadFormat)?;
-        let affine: Option<G1Affine> = G1Affine::from_compressed(&data).into();
-        if let Some(af) = affine {
-            Ok(bls::PublicKey::from(G1Projective::from(af)))
-        } else {
-            Err(Error::PublicKeyBadFormat)
-        }
+    fn try_from(s: G2Projective) -> Result<Self> {
+        Ok(Signature(to_compressed(&s)?))
     }
 }
 
-/// Hashes a message to a 96-byte array using BLS hashing.
-pub fn hash(msg: &[u8]) -> [u8; 96] {
-    let hash: G2Affine = bls::hash(msg).into();
-    hash.to_compressed()
+impl TryFrom<G1Projective> for PublicKey {
+    type Error = Error;
+    fn try_from(p: G1Projective) -> Result<Self> {
+        Ok(PublicKey(to_compressed::<G1Projective, 48>(&p)?.to_vec()))
+    }
+}
+
+impl TryFrom<PublicKey> for G1Projective {
+    type Error = Error;
+    fn try_from(pk: PublicKey) -> Result<Self> {
+        let data: [u8; 48] = pk.0.try_into().map_err(|_| Error::PublicKeyBadFormat)?;
+        let ret: Self = from_compressed(&data)?;
+        Ok(ret)
+    }
+}
+
+/// Hashes a message to a 96-byte array using BLS
+// https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve/
+/// TODO:
+/// https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-12#appendix-K.1
+/// Xmd is not implemented here
+pub fn hash_to_curve(msg: &[u8]) -> Result<[u8; 96]> {
+    // let swu_map: WBMap<G1Config> = WBMap::new().unwrap();
+    let hasher = MapToCurveBasedHasher::<
+        G2Projective,
+        DefaultFieldHasher<sha2::Sha256, 128>,
+        WBMap<G2Config>,
+    >::new(&[])
+    .map_err(|_| Error::CurveHasherInitFailed)?;
+    let hashed = hasher.hash(&msg).map_err(|_| Error::CurveHasherFailed)?;
+    let ret: [u8; 96] = to_compressed(&hashed)?;
+    Ok(ret)
 }
 
 /// Sign message with bls privatekey
 /// reimplemented via https://docs.rs/bls-signatures/latest/src/bls_signatures/key.rs.html#103
 /// signature = hash_into_g2(message) * sk
-pub fn sign(sec: SecretKey, hash: &[u8; 96]) -> Result<Signature> {
-    let sk: bls::PrivateKey = sec.try_into()?;
-    let affine: Option<G2Affine> = G2Affine::from_compressed(hash).into();
-    if let Some(af) = affine {
-        let mut proj: G2Projective = af.into();
-        proj *= Into::<Scalar>::into(sk);
-        Ok(Signature(G2Affine::from(proj).to_compressed()))
+pub fn sign(sk: SecretKey, hashed_msg: &[u8; 96]) -> Result<Signature> {
+    let sk: Fr = sk.try_into()?;
+    let msg: G2Projective = from_compressed(&hashed_msg).unwrap();
+    Ok(Signature(to_compressed(&(msg * sk))?))
+}
+
+/// Verifies that the signature is the actual aggregated signature of hashes - pubkeys. Calculated by
+/// e(g1, signature) == \prod_{i = 0}^n e(pk_i, hash_i).
+pub fn verify(hashes: &[[u8; 96]], sig: &Signature, pks: &[PublicKey]) -> Result<bool> {
+    let sig: G2Projective = sig.clone().try_into()?;
+    let g1 = G1Projective::generator();
+    let e1 = Bls12_381::pairing(&g1, &sig);
+
+    let hashes: Vec<G2Projective> = hashes
+        .iter()
+        .map(|h| from_compressed(h))
+        .collect::<Result<Vec<G2Projective>>>()?;
+
+    let pks: Vec<G1Projective> = pks
+        .iter()
+        .map(|pk| pk.clone().try_into())
+        .collect::<Result<Vec<G1Projective>>>()?;
+
+    let mm_out = Bls12_381::multi_miller_loop(pks, hashes);
+    if let Some(e2) = Bls12_381::final_exponentiation(mm_out) {
+        Ok(e1 == e2)
     } else {
-        Err(Error::PublicKeyBadFormat)
+        Ok(false)
     }
 }
 
-/// Signs a message with a BLS private key by first hashing the message.
-pub fn sign_raw(sec: SecretKey, msg: &[u8]) -> Result<Signature> {
-    sign(sec, &hash(msg))
-}
-
-/// Verifies a BLS signature against a set of hashes and public keys.
-pub fn verify(hashes: &[[u8; 96]], sig: &Signature, public_keys: &[PublicKey]) -> Result<bool> {
-    let sig: bls::Signature = sig.clone().try_into()?;
-    let hash: Vec<G2Projective> = hashes
-        .iter()
-        .map(|h| Into::<Option<G2Affine>>::into(G2Affine::from_compressed(h)))
-        .map(|a| a.map(|b| b.into()))
-        .collect::<Option<Vec<G2Projective>>>()
-        .ok_or(Error::BlsAffineDecodeFailed)?;
-    let pk: Vec<bls::PublicKey> = public_keys
-        .iter()
-        .map(|pk| pk.clone().try_into())
-        .collect::<Result<Vec<bls::PublicKey>>>()?;
-    Ok(bls::verify(&sig, &hash, &pk))
-}
-
-/// Verifies a BLS signature against a set of messages and public keys.
-pub fn verify_msg(msgs: &[&[u8]], sig: &Signature, public_keys: &[PublicKey]) -> Result<bool> {
-    let sig: bls::Signature = sig.clone().try_into()?;
-    let pk: Vec<bls::PublicKey> = public_keys
-        .iter()
-        .map(|pk| pk.clone().try_into())
-        .collect::<Result<Vec<bls::PublicKey>>>()?;
-    Ok(bls::verify_messages(&sig, msgs, &pk))
-}
-
 /// Converts a BLS private key to a BLS public key.
-pub fn to_bls_pk(sk: &SecretKey) -> Result<PublicKey> {
-    let seckey: bls::PrivateKey = sk.clone().try_into()?;
-    let pk = seckey.public_key();
-    Ok(pk.into())
+/// Get the public key for this private key. Calculated by pk = g1 * sk.
+pub fn public_key(key: &SecretKey) -> Result<PublicKey> {
+    let sk: Fr = key.clone().try_into()?;
+    let g1 = G1Projective::generator();
+    (g1 * sk).try_into()
 }
 
 #[cfg(test)]
@@ -155,43 +166,12 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_types() {
-        let key1: SecretKey = random_sk().unwrap();
-        let bls_key: bls::PrivateKey = key1.try_into().unwrap();
-        let key2: SecretKey = bls_key.try_into().unwrap();
-        assert_eq!(key1, key2);
-
-        let pk1: PublicKey = to_bls_pk(&key1).unwrap();
-        let bls_pk: bls::PublicKey = bls_key.public_key();
-        let pk2: PublicKey = bls_pk.try_into().unwrap();
-        assert_eq!(pk1, pk2);
-    }
-
-    #[test]
     fn test_sign_and_verify() {
         let key = random_sk().unwrap();
-        let msg = "hello";
-        let pk = to_bls_pk(&key).unwrap();
-        let sig = sign_raw(key, msg.as_bytes()).unwrap();
-        let hash = hash(msg.as_bytes());
-
-        // test sign with bls
-        let bls_sk: bls::PrivateKey = key.try_into().unwrap();
-        let bls_pk: bls::PublicKey = bls_sk.public_key();
-        let bls_sig = bls_sk.sign(msg.as_bytes());
-        assert!(bls::verify_messages(
-            &bls_sig,
-            vec![msg.as_bytes()].as_slice(),
-            vec![bls_pk].as_slice()
-        ));
-        assert_eq!(Signature::from(bls_sig), sig);
-
-        assert!(verify_msg(
-            vec![msg.as_bytes()].as_slice(),
-            &sig,
-            vec![pk.clone()].as_slice()
-        )
-        .expect("panic on verify msg"));
-        assert!(verify(vec![hash].as_slice(), &sig, vec![pk].as_slice()).unwrap());
+        let msg = "hello world";
+        let pk = public_key(&key).unwrap();
+        let h = hash_to_curve(msg.as_bytes()).unwrap();
+        let sig = sign(key, &h).unwrap();
+        assert!(super::verify(vec![h].as_slice(), &sig, vec![pk].as_slice()).unwrap());
     }
 }

--- a/crates/core/src/ecc/signers/bls.rs
+++ b/crates/core/src/ecc/signers/bls.rs
@@ -240,11 +240,9 @@ mod test {
 
         let sig_agg = aggregate(&[sig1, sig2]).unwrap();
 
-        assert!(super::verify_hash(
-            vec![h1, h2].as_slice(),
-            &sig_agg,
-            vec![pk1, pk2].as_slice()
-        )
-        .unwrap());
+        assert!(
+            super::verify_hash(vec![h1, h2].as_slice(), &sig_agg, vec![pk1, pk2].as_slice())
+                .unwrap()
+        );
     }
 }

--- a/crates/core/src/ecc/signers/bls.rs
+++ b/crates/core/src/ecc/signers/bls.rs
@@ -114,7 +114,7 @@ pub fn hash_to_curve(msg: &[u8]) -> Result<[u8; 96]> {
         WBMap<G2Config>,
     >::new(&[])
     .map_err(|_| Error::CurveHasherInitFailed)?;
-    let hashed = hasher.hash(&msg).map_err(|_| Error::CurveHasherFailed)?;
+    let hashed = hasher.hash(msg).map_err(|_| Error::CurveHasherFailed)?;
     let ret: [u8; 96] = to_compressed(&hashed)?;
     Ok(ret)
 }
@@ -124,7 +124,7 @@ pub fn hash_to_curve(msg: &[u8]) -> Result<[u8; 96]> {
 /// signature = hash_into_g2(message) * sk
 pub fn sign(sk: SecretKey, hashed_msg: &[u8; 96]) -> Result<Signature> {
     let sk: Fr = sk.try_into()?;
-    let msg: G2Projective = from_compressed(&hashed_msg).unwrap();
+    let msg: G2Projective = from_compressed(hashed_msg).unwrap();
     Ok(Signature(to_compressed(&(msg * sk))?))
 }
 
@@ -133,11 +133,11 @@ pub fn sign(sk: SecretKey, hashed_msg: &[u8; 96]) -> Result<Signature> {
 pub fn verify(hashes: &[[u8; 96]], sig: &Signature, pks: &[PublicKey]) -> Result<bool> {
     let sig: G2Projective = sig.clone().try_into()?;
     let g1 = G1Projective::generator();
-    let e1 = Bls12_381::pairing(&g1, &sig);
+    let e1 = Bls12_381::pairing(g1, sig);
 
     let hashes: Vec<G2Projective> = hashes
         .iter()
-        .map(|h| from_compressed(h))
+        .map(from_compressed)
         .collect::<Result<Vec<G2Projective>>>()?;
 
     let pks: Vec<G1Projective> = pks
@@ -156,7 +156,7 @@ pub fn verify(hashes: &[[u8; 96]], sig: &Signature, pks: &[PublicKey]) -> Result
 /// Converts a BLS private key to a BLS public key.
 /// Get the public key for this private key. Calculated by pk = g1 * sk.
 pub fn public_key(key: &SecretKey) -> Result<PublicKey> {
-    let sk: Fr = key.clone().try_into()?;
+    let sk: Fr = (*key).try_into()?;
     let g1 = G1Projective::generator();
     (g1 * sk).try_into()
 }

--- a/crates/core/src/ecc/signers/bls.rs
+++ b/crates/core/src/ecc/signers/bls.rs
@@ -1,0 +1,32 @@
+//! signer of bls
+//! based on [bls_signatures](https://docs.rs/bls-signatures/latest/bls_signatures/)
+//! This module implement transform of [libsecp256k1::Secretkey] and [bls_signature::PrivateKey]
+
+use bls12_381::Scalar;
+use bls_signatures  as bls;
+use libsecp256k1;
+use crate::ecc::SecretKey;
+use crate::error::Error;
+use crate::error::Result;
+
+impl TryInto<SecretKey> for bls::PrivateKey {
+    type Error = Error;
+    fn try_into(self) -> Result<SecretKey> {
+        let data: [u8; 32] = Into::<Scalar>::into(self).to_bytes();
+        let sk = libsecp256k1::SecretKey::parse(&data)?;
+        Ok(SecretKey(sk))
+    }
+}
+
+impl TryInto<bls::PrivateKey> for SecretKey {
+    type Error = Error;
+    fn try_into(self) -> Result<bls::PrivateKey> {
+        let sk = self.0.serialize();
+        let scalar: Option<Scalar> = Scalar::from_bytes(&sk).into();
+        if let Some(key) = scalar {
+            Ok(bls::PrivateKey::from(key))
+        } else {
+            Err(Error::PrivateKeyBadFormat)
+        }
+    }
+}

--- a/crates/core/src/ecc/signers/bls.rs
+++ b/crates/core/src/ecc/signers/bls.rs
@@ -37,9 +37,9 @@ impl TryInto<bls::PrivateKey> for SecretKey {
     }
 }
 
-impl Into<PublicKey> for bls::PublicKey {
-    fn into(self) -> PublicKey {
-        let data: [u8; 48] = self.as_affine().to_compressed();
+impl From<bls::PublicKey> for PublicKey {
+    fn from(val: bls::PublicKey) -> Self {
+        let data: [u8; 48] = val.as_affine().to_compressed();
         PublicKey(data.to_vec())
     }
 }
@@ -114,7 +114,7 @@ pub fn verify_msg(msgs: &[&[u8]], sig: &[u8; 96], public_keys: &[PublicKey]) -> 
         let pk: Result<Vec<bls::PublicKey>> =
             public_keys.iter().map(|pk| pk.clone().try_into()).collect();
         if let Ok(p) = pk {
-            Ok(bls::verify_messages(&signature, &msgs, &p))
+            Ok(bls::verify_messages(&signature, msgs, &p))
         } else {
             Err(Error::BlsAffineDecodeFailed)
         }

--- a/crates/core/src/ecc/signers/bls.rs
+++ b/crates/core/src/ecc/signers/bls.rs
@@ -2,10 +2,6 @@
 //! based on [bls_signatures](https://docs.rs/bls-signatures/latest/bls_signatures/)
 //! This module implement transform of [libsecp256k1::Secretkey] and [bls_signature::PrivateKey]
 
-use crate::ecc::PublicKey;
-use crate::ecc::SecretKey;
-use crate::error::Error;
-use crate::error::Result;
 use bls12_381::G1Affine;
 use bls12_381::G1Projective;
 use bls12_381::G2Affine;
@@ -13,6 +9,11 @@ use bls12_381::G2Projective;
 use bls12_381::Scalar;
 use bls_signatures as bls;
 use libsecp256k1;
+
+use crate::ecc::PublicKey;
+use crate::ecc::SecretKey;
+use crate::error::Error;
+use crate::error::Result;
 
 impl TryInto<SecretKey> for bls::PrivateKey {
     type Error = Error;

--- a/crates/core/src/ecc/signers/bls.rs
+++ b/crates/core/src/ecc/signers/bls.rs
@@ -102,9 +102,9 @@ impl TryFrom<PublicKey> for G1Projective {
 }
 
 /// Hashes a message to a 96-byte array using BLS
-// https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve/
+/// `<https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve/>`
 /// TODO:
-/// https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-12#appendix-K.1
+/// `<https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-12#appendix-K.1>`
 /// Xmd is not implemented here
 pub fn hash_to_curve(msg: &[u8]) -> Result<[u8; 96]> {
     // let swu_map: WBMap<G1Config> = WBMap::new().unwrap();

--- a/crates/core/src/ecc/signers/ed25519.rs
+++ b/crates/core/src/ecc/signers/ed25519.rs
@@ -9,7 +9,7 @@ pub fn verify(
     msg: &[u8],
     address: &PublicKeyAddress,
     sig: impl AsRef<[u8]>,
-    pubkey: &PublicKey,
+    pubkey: &PublicKey<33>,
 ) -> bool {
     if pubkey.address() != *address {
         return false;
@@ -19,7 +19,7 @@ pub fn verify(
     }
     let sig_data: [u8; 64] = sig.as_ref().try_into().unwrap();
     if let (Ok(p), Ok(s)) = (
-        TryInto::<ed25519_dalek::PublicKey>::try_into(pubkey.clone()),
+        TryInto::<ed25519_dalek::PublicKey>::try_into(*pubkey),
         ed25519_dalek::Signature::from_bytes(&sig_data),
     ) {
         match p.verify(msg, &s) {

--- a/crates/core/src/ecc/signers/ed25519.rs
+++ b/crates/core/src/ecc/signers/ed25519.rs
@@ -9,7 +9,7 @@ pub fn verify(
     msg: &[u8],
     address: &PublicKeyAddress,
     sig: impl AsRef<[u8]>,
-    pubkey: PublicKey,
+    pubkey: &PublicKey,
 ) -> bool {
     if pubkey.address() != *address {
         return false;
@@ -19,7 +19,7 @@ pub fn verify(
     }
     let sig_data: [u8; 64] = sig.as_ref().try_into().unwrap();
     if let (Ok(p), Ok(s)) = (
-        TryInto::<ed25519_dalek::PublicKey>::try_into(pubkey),
+        TryInto::<ed25519_dalek::PublicKey>::try_into(pubkey.clone()),
         ed25519_dalek::Signature::from_bytes(&sig_data),
     ) {
         match p.verify(msg, &s) {
@@ -58,7 +58,7 @@ mod test {
             msg.as_bytes(),
             &signer.address(),
             sig.as_slice(),
-            signer
+            &signer
         ))
     }
 }

--- a/crates/core/src/ecc/signers/eip191.rs
+++ b/crates/core/src/ecc/signers/eip191.rs
@@ -27,7 +27,7 @@ pub fn hash(msg: &[u8]) -> [u8; 32] {
 }
 
 /// recover pubkey according to signature.
-pub fn recover(msg: &[u8], sig: impl AsRef<[u8]>) -> Result<PublicKey> {
+pub fn recover(msg: &[u8], sig: impl AsRef<[u8]>) -> Result<PublicKey<33>> {
     let sig_byte: [u8; 65] = sig.as_ref().try_into()?;
     let hash = hash(msg);
     let mut sig712 = sig_byte;

--- a/crates/core/src/ecc/signers/mod.rs
+++ b/crates/core/src/ecc/signers/mod.rs
@@ -1,4 +1,5 @@
 pub mod bip137;
+pub mod bls;
 pub mod ed25519;
 pub mod eip191;
 pub mod secp256k1;

--- a/crates/core/src/ecc/signers/secp256k1.rs
+++ b/crates/core/src/ecc/signers/secp256k1.rs
@@ -22,7 +22,7 @@ pub fn hash(msg: &[u8]) -> [u8; 32] {
 }
 
 /// recover public key from message and signature.
-pub fn recover(msg: &[u8], sig: impl AsRef<[u8]>) -> Result<PublicKey> {
+pub fn recover(msg: &[u8], sig: impl AsRef<[u8]>) -> Result<PublicKey<33>> {
     let sig_byte: [u8; 65] = sig.as_ref().try_into()?;
     crate::ecc::recover(msg, sig_byte)
 }

--- a/crates/core/src/ecc/signers/secp256r1.rs
+++ b/crates/core/src/ecc/signers/secp256r1.rs
@@ -94,7 +94,7 @@ pub fn verify(
     msg: &[u8],
     address: &PublicKeyAddress,
     sig: impl AsRef<[u8]>,
-    pubkey: &PublicKey,
+    pubkey: &PublicKey<33>,
 ) -> bool {
     if pubkey.address() != *address {
         return false;
@@ -103,7 +103,7 @@ pub fn verify(
         return false;
     }
     let ct_pk: CtOption<Result<ecdsa::VerifyingKey<p256::NistP256>>> =
-        pubkey.clone().ct_try_into_secp256r1_pubkey();
+        (*pubkey).ct_try_into_secp256r1_pubkey();
     let msg_hash = hash(msg);
     if ct_pk.is_some().into() {
         let res: Result<()> = ct_pk.unwrap().and_then(|pk| {
@@ -176,7 +176,7 @@ mod test {
     /// ```
     #[test]
     fn test_secp256r1_sign_and_verify() {
-        let pk: PublicKey = PublicKey::from_hex_string(
+        let pk: PublicKey<33> = PublicKey::<33>::from_hex_string(
 	    "17a6afd392fcbe4ac9270a599a9c5732c4f838ce35ea2234d389d8f0c367f3f5dcab906352e27289002c7f2c96039ddce7c1b5aad8b87ba94984d4c8b4f95702"
 	).unwrap();
         let sk =

--- a/crates/core/src/ecc/signers/secp256r1.rs
+++ b/crates/core/src/ecc/signers/secp256r1.rs
@@ -94,7 +94,7 @@ pub fn verify(
     msg: &[u8],
     address: &PublicKeyAddress,
     sig: impl AsRef<[u8]>,
-    pubkey: PublicKey,
+    pubkey: &PublicKey,
 ) -> bool {
     if pubkey.address() != *address {
         return false;
@@ -103,7 +103,7 @@ pub fn verify(
         return false;
     }
     let ct_pk: CtOption<Result<ecdsa::VerifyingKey<p256::NistP256>>> =
-        pubkey.ct_try_into_secp256r1_pubkey();
+        pubkey.clone().ct_try_into_secp256r1_pubkey();
     let msg_hash = hash(msg);
     if ct_pk.is_some().into() {
         let res: Result<()> = ct_pk.unwrap().and_then(|pk| {
@@ -194,7 +194,7 @@ mod test {
 
         // Check our sign and verify work right
         let our_sig = sign(sk, &hash(msg.as_bytes()));
-        assert!(verify(msg.as_bytes(), &pk.address(), our_sig, pk));
+        assert!(verify(msg.as_bytes(), &pk.address(), our_sig, &pk));
 
         let hash_msg: [u8; 32] =
             hex::decode("5e230abb2ae1cb0717986854d6e16b998da03b827b736c9ac32f6ec9e47e3670")
@@ -204,6 +204,6 @@ mod test {
         let hashed = hash(msg.as_bytes());
         assert_eq!(hashed, hash_msg, "hash ret not equal");
 
-        assert!(verify(msg.as_bytes(), &pk.address(), sig, pk));
+        assert!(verify(msg.as_bytes(), &pk.address(), sig, &pk));
     }
 }

--- a/crates/core/src/ecc/types.rs
+++ b/crates/core/src/ecc/types.rs
@@ -7,12 +7,12 @@ use crate::error::Error;
 use crate::error::Result;
 
 /// PublicKey for ECDSA and EdDSA.
-#[derive(PartialEq, Eq, Debug, Clone)]
-pub struct PublicKey(pub Vec<u8>);
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub struct PublicKey<const SIZE: usize>(pub [u8; SIZE]);
 
-struct PublicKeyVisitor;
+struct PublicKeyVisitor<const SIZE: usize>;
 // /// twist from https://docs.rs/libsecp256k1/latest/src/libsecp256k1/lib.rs.html#335-344
-impl Serialize for PublicKey {
+impl<const SIZE: usize> Serialize for PublicKey<SIZE> {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where S: serde::ser::Serializer {
         serializer.serialize_str(
@@ -21,23 +21,23 @@ impl Serialize for PublicKey {
     }
 }
 
-impl PublicKey {
+impl PublicKey<33> {
     /// trezor style b58
-    pub fn try_from_b58t(value: &str) -> Result<PublicKey> {
+    pub fn try_from_b58t(value: &str) -> Result<PublicKey<33>> {
         let value: Vec<u8> =
             base58::FromBase58::from_base58(value).map_err(|_| Error::PublicKeyBadFormat)?;
         Self::from_u8(value.as_slice())
     }
 
     /// monero and bitcoin style b58
-    pub fn try_from_b58m(value: &str) -> Result<PublicKey> {
+    pub fn try_from_b58m(value: &str) -> Result<PublicKey<33>> {
         let value: &[u8] =
             &base58_monero::decode_check(value).map_err(|_| Error::PublicKeyBadFormat)?;
         Self::from_u8(value)
     }
 
     /// monero style uncheck base56
-    pub fn try_from_b58m_uncheck(value: &str) -> Result<PublicKey> {
+    pub fn try_from_b58m_uncheck(value: &str) -> Result<PublicKey<33>> {
         let value: &[u8] = &base58_monero::decode(value).map_err(|_| Error::PublicKeyBadFormat)?;
         Self::from_u8(value)
     }
@@ -47,7 +47,7 @@ impl PublicKey {
     /// The format is <odd_flat (1 bytes), x_cordinate (32 bytes)>
     /// For 32 bytes case, we mark the odd flas as 00 (unknown)
     /// For 64 bytes case, we compress the public key into compressed public key
-    pub fn from_u8(value: &[u8]) -> Result<PublicKey> {
+    pub fn from_u8(value: &[u8]) -> Result<PublicKey<33>> {
         let mut s = value.to_vec();
         let data: Vec<u8> = match s.len() {
             32 => {
@@ -69,7 +69,8 @@ impl PublicKey {
             }
             _ => Err(Error::PublicKeyBadFormat),
         }?;
-        Ok(PublicKey(data))
+        let pub_data: [u8; 33] = data.as_slice().try_into()?;
+        Ok(PublicKey(pub_data))
     }
 
     /// convert pubkey to base58_string
@@ -78,14 +79,14 @@ impl PublicKey {
     }
 
     /// convert public_key from hex string
-    pub fn from_hex_string(value: &str) -> Result<Self> {
+    pub fn from_hex_string(value: &str) -> Result<PublicKey<33>> {
         let v = hex::decode(value)?;
         Self::from_u8(v.as_slice())
     }
 }
 
-impl<'de> serde::de::Visitor<'de> for PublicKeyVisitor {
-    type Value = PublicKey;
+impl<'de> serde::de::Visitor<'de> for PublicKeyVisitor<33> {
+    type Value = PublicKey<33>;
 
     fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
         formatter.write_str("a bytestring of in length 33")
@@ -96,7 +97,7 @@ impl<'de> serde::de::Visitor<'de> for PublicKeyVisitor {
     }
 }
 
-impl<'de> Deserialize<'de> for PublicKey {
+impl<'de> Deserialize<'de> for PublicKey<33> {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where D: serde::de::Deserializer<'de> {
         deserializer.deserialize_str(PublicKeyVisitor)

--- a/crates/core/src/ecc/types.rs
+++ b/crates/core/src/ecc/types.rs
@@ -7,8 +7,8 @@ use crate::error::Error;
 use crate::error::Result;
 
 /// PublicKey for ECDSA and EdDSA.
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
-pub struct PublicKey(pub [u8; 33]);
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct PublicKey(pub Vec<u8>);
 
 struct PublicKeyVisitor;
 // /// twist from https://docs.rs/libsecp256k1/latest/src/libsecp256k1/lib.rs.html#335-344
@@ -69,8 +69,7 @@ impl PublicKey {
             }
             _ => Err(Error::PublicKeyBadFormat),
         }?;
-        let pub_data: [u8; 33] = data.as_slice().try_into()?;
-        Ok(PublicKey(pub_data))
+        Ok(PublicKey(data))
     }
 
     /// convert pubkey to base58_string

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -7,6 +7,15 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
+    #[error("Serialize affine failed")]
+    EccSerializeFailed,
+    #[error("desrialize affine failed")]
+    EccDeserializeFailed,
+    #[error("Failed to initialize Curve hasher")]
+    CurveHasherInitFailed,
+    #[error("Failed to hash data into cruve")]
+    CurveHasherFailed,
+
     #[error("Ed25519/EdDSA pubkey bad format")]
     EdDSAPublicKeyBadFormat,
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -19,6 +19,9 @@ pub enum Error {
     #[error("ECDSA or EdDSA pubkey bad format")]
     PublicKeyBadFormat,
 
+    #[error("Failed to decode vector to bls affine")]
+    BlsAffineDecodeFailed,
+
     #[error("private bad format")]
     PrivateKeyBadFormat,
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -19,6 +19,9 @@ pub enum Error {
     #[error("ECDSA or EdDSA pubkey bad format")]
     PublicKeyBadFormat,
 
+    #[error("private bad format")]
+    PrivateKeyBadFormat,
+
     #[error("Invalid Transport")]
     InvalidTransport,
 
@@ -109,8 +112,8 @@ pub enum Error {
     #[error("Ice server get url without host")]
     IceServerURLMissHost,
 
-    #[error("SecretKey parse error, {0}")]
-    Libsecp256k1SecretKeyParse(String),
+    #[error("Libsecp256k1 error")]
+    Libsecp256k1Error(#[from] libsecp256k1::Error),
 
     #[error("Signature standard parse failed, {0}")]
     Libsecp256k1SignatureParseStandard(String),

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -290,7 +290,7 @@ impl Session {
             Account::Ed25519(ref pk) => {
                 signers::ed25519::verify(&auth_bytes, &pk.address(), &self.sig, pk)
             }
-	    Account::Secp256r1(ref pk) => {
+            Account::Secp256r1(ref pk) => {
                 signers::secp256r1::verify(&auth_bytes, &pk.address(), &self.sig, pk)
             }
         }) {

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -287,10 +287,10 @@ impl Session {
             }
             Account::EIP191(did) => signers::eip191::verify(&auth_bytes, &did.into(), &self.sig),
             Account::BIP137(did) => signers::bip137::verify(&auth_bytes, &did.into(), &self.sig),
-            Account::Ed25519(pk) => {
+            Account::Ed25519(ref pk) => {
                 signers::ed25519::verify(&auth_bytes, &pk.address(), &self.sig, pk)
             }
-            Account::Secp256r1(pk) => {
+	    Account::Secp256r1(ref pk) => {
                 signers::secp256r1::verify(&auth_bytes, &pk.address(), &self.sig, pk)
             }
         }) {
@@ -316,8 +316,8 @@ impl Session {
             Account::Secp256k1(_) => signers::secp256k1::recover(&auth_bytes, &self.sig),
             Account::BIP137(_) => signers::bip137::recover(&auth_bytes, &self.sig),
             Account::EIP191(_) => signers::eip191::recover(&auth_bytes, &self.sig),
-            Account::Ed25519(pk) => Ok(pk),
-            Account::Secp256r1(pk) => Ok(pk),
+            Account::Ed25519(ref pk) => Ok(pk.clone()),
+            Account::Secp256r1(ref pk) => Ok(pk.clone()),
         }
     }
 
@@ -327,8 +327,8 @@ impl Session {
             Account::Secp256k1(did) => did,
             Account::BIP137(did) => did,
             Account::EIP191(did) => did,
-            Account::Ed25519(pk) => pk.address().into(),
-            Account::Secp256r1(pk) => pk.address().into(),
+            Account::Ed25519(ref pk) => pk.address().into(),
+            Account::Secp256r1(ref pk) => pk.address().into(),
         }
     }
 }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -157,13 +157,13 @@ pub enum Account {
     /// ecdsa
     Secp256k1(Did),
     /// ref: <https://eips.ethereum.org/EIPS/eip-191>
-    Secp256r1(PublicKey),
+    Secp256r1(PublicKey<33>),
     /// ref: <https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API>
     EIP191(Did),
     /// bitcoin bip137 ref: <https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki>
     BIP137(Did),
     /// ed25519
-    Ed25519(PublicKey),
+    Ed25519(PublicKey<33>),
 }
 
 impl TryFrom<(String, String)> for Account {
@@ -310,14 +310,14 @@ impl Session {
     }
 
     /// Get public key from session for encryption.
-    pub fn account_pubkey(&self) -> Result<PublicKey> {
+    pub fn account_pubkey(&self) -> Result<PublicKey<33>> {
         let auth_bytes = self.pack();
         match self.account {
             Account::Secp256k1(_) => signers::secp256k1::recover(&auth_bytes, &self.sig),
             Account::BIP137(_) => signers::bip137::recover(&auth_bytes, &self.sig),
             Account::EIP191(_) => signers::eip191::recover(&auth_bytes, &self.sig),
-            Account::Ed25519(ref pk) => Ok(pk.clone()),
-            Account::Secp256r1(ref pk) => Ok(pk.clone()),
+            Account::Ed25519(ref pk) => Ok(*pk),
+            Account::Secp256r1(ref pk) => Ok(*pk),
         }
     }
 


### PR DESCRIPTION
## Implementation of BLS (Boneh-Lynn-Shacham) signature
* Map privatekey to bls primefield
* Map publickey to projective point of G2
* Implemented sign and verify of bls
* implementation of bls aggregate
* The msg is extending with prefix `"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_` which is as same as filecoin's implementation.

