### PR TITLE
[codex] chore: pin protobufjs-cli for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "protobufjs": "https://github.com/RingsNetwork/protobuf.js#83686a0"
   },
   "devDependencies": {
-    "protobufjs-cli": "^1.1.2",
+    "protobufjs-cli": "1.1.2",
     "typescript": "^4.9.5"
   },
   "files": [


### PR DESCRIPTION
## Summary

Pin `protobufjs-cli` to `1.1.2` in `package.json`.

## Root Cause

The auto release workflow runs a fresh `npm install` for the browser package build. Because `package-lock.json` is ignored and not tracked, CI resolves dependencies directly from `package.json`. The previous `protobufjs-cli` range `^1.1.2` now resolves to `1.3.3`, whose peer dependency requires `protobufjs@^7.6.2`. That conflicts with the project dependency on the RingsNetwork protobuf.js fork, which reports `protobufjs@7.2.6`, causing `npm ERR! ERESOLVE unable to resolve dependency tree`.

## Impact

Fresh release installs now stay on `protobufjs-cli@1.1.2`, whose peer dependency is compatible with the existing protobuf.js fork.

## Validation

- `git diff --check`
- Local dependency metadata check confirmed `protobufjs-cli@1.1.2` peers on `protobufjs@^7.0.0`, compatible with the current fork version `7.2.6`.