### PR TITLE
feat(backend): unified extension abstraction (step 1 of RFC #594)

### DIFF
--- a/crates/node/src/backend/ext.rs
+++ b/crates/node/src/backend/ext.rs
@@ -1,0 +1,137 @@
+#![warn(missing_docs)]
+//! Unified extension/protocol abstraction shared by `native` and `browser`.
+//!
+//! This is the seam that replaces the closed `BackendMessage` enum and the two
+//! divergent dispatch paradigms. A protocol is an [`Extension`]; the node routes
+//! inbound [`Envelope`]s to extensions by `namespace`; an extension talks back to the
+//! node only through the [`Ctx`] capability handle.
+//!
+//! The abstraction, structure and constraints are identical on both targets; the only
+//! divergence is the `Send` / `?Send` bound on async trait methods (browser futures
+//! are not `Send`), expressed with the same `cfg_attr` pair used throughout the crate.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use rings_core::dht::Did;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::error::Error;
+use crate::error::Result;
+use crate::processor::Processor;
+
+/// Namespaced message envelope carried over the P2P transport (bincode), in place of
+/// the old closed `BackendMessage` enum.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Envelope {
+    /// Protocol namespace this payload belongs to.
+    pub namespace: String,
+    /// Opaque protocol payload; the inner codec is the extension's own business.
+    pub payload: Bytes,
+}
+
+impl Envelope {
+    /// Build an envelope from a namespace and payload.
+    pub fn new(namespace: impl Into<String>, payload: Bytes) -> Self {
+        Self {
+            namespace: namespace.into(),
+            payload,
+        }
+    }
+
+    /// Encode the envelope for the P2P transport.
+    pub fn encode(&self) -> Result<Vec<u8>> {
+        bincode::serialize(self).map_err(|_| Error::EncodeError)
+    }
+
+    /// Decode an envelope received from the P2P transport.
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        bincode::deserialize(bytes).map_err(|_| Error::DecodeError)
+    }
+}
+
+/// Capability handle handed to an extension: the bounded set of node operations an
+/// extension may perform. Extensions never see `Provider`/`Processor` directly.
+#[derive(Clone)]
+pub struct Ctx {
+    processor: Arc<Processor>,
+}
+
+impl Ctx {
+    /// Build a ctx over a processor.
+    pub fn new(processor: Arc<Processor>) -> Self {
+        Self { processor }
+    }
+
+    /// This node's DID.
+    pub fn did(&self) -> Did {
+        self.processor.did()
+    }
+
+    /// Send a namespaced payload to a peer.
+    pub async fn send(&self, to: Did, namespace: &str, payload: Bytes) -> Result<()> {
+        let bytes = Envelope::new(namespace, payload).encode()?;
+        self.processor.send_message(to, &bytes).await?;
+        Ok(())
+    }
+}
+
+/// `Arc<dyn Extension>` with the target-appropriate auto-trait bounds.
+#[cfg(not(feature = "browser"))]
+pub type DynExtension = dyn Extension + Send + Sync;
+/// `Arc<dyn Extension>` with the target-appropriate auto-trait bounds.
+#[cfg(feature = "browser")]
+pub type DynExtension = dyn Extension;
+
+/// A protocol extension. Same trait and bounds on both targets.
+#[cfg_attr(feature = "browser", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "browser"), async_trait::async_trait)]
+pub trait Extension {
+    /// The protocol namespace this extension handles.
+    fn namespace(&self) -> &str;
+
+    /// Handle an inbound payload addressed to this extension's namespace.
+    async fn on_message(&self, ctx: &Ctx, from: Did, payload: Bytes) -> Result<()>;
+}
+
+/// Registry that routes inbound envelopes to extensions by namespace.
+#[derive(Default, Clone)]
+pub struct Extensions {
+    handlers: HashMap<String, Arc<DynExtension>>,
+}
+
+impl Extensions {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register an extension under its declared namespace.
+    pub fn register(&mut self, ext: Arc<DynExtension>) {
+        self.handlers.insert(ext.namespace().to_string(), ext);
+    }
+
+    /// Whether a namespace has a registered extension.
+    pub fn contains(&self, namespace: &str) -> bool {
+        self.handlers.contains_key(namespace)
+    }
+
+    /// Route a decoded envelope to its namespace's extension.
+    ///
+    /// Unknown namespaces are logged and dropped (non-fatal): a peer speaking a
+    /// protocol this node does not have is expected.
+    pub async fn dispatch(&self, ctx: &Ctx, from: Did, envelope: Envelope) -> Result<()> {
+        match self.handlers.get(&envelope.namespace) {
+            Some(ext) => ext.on_message(ctx, from, envelope.payload).await,
+            None => {
+                tracing::debug!(
+                    "no extension registered for namespace {:?}, dropping",
+                    envelope.namespace
+                );
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/node/src/backend/mod.rs
+++ b/crates/node/src/backend/mod.rs
@@ -1,6 +1,7 @@
 #![warn(missing_docs)]
 //! This module provide basic mechanism.
 
+pub mod ext;
 #[cfg(feature = "snark")]
 pub mod snark;
 pub mod types;

--- a/crates/node/src/provider/mod.rs
+++ b/crates/node/src/provider/mod.rs
@@ -66,6 +66,12 @@ impl Provider {
             handler: InternalRpcHandler,
         }
     }
+
+    /// Build an extension capability [`Ctx`](crate::backend::ext::Ctx) over this
+    /// provider's processor.
+    pub fn ctx(&self) -> crate::backend::ext::Ctx {
+        crate::backend::ext::Ctx::new(self.processor.clone())
+    }
     /// Create a provider instance with storage name
     pub(crate) async fn new_provider_with_storage_internal(
         config: ProcessorConfig,


### PR DESCRIPTION
First step of the extension-layer unification described in #594.

## What

Adds a single, **target-identical** extension abstraction in `crates/node/src/backend/ext.rs`:

- **`Envelope { namespace, payload }`** — namespaced message envelope (bincode on the P2P transport) that will replace the closed `BackendMessage` enum. Inner `payload` codec is the extension's own business.
- **`Ctx`** — capability handle over `Processor` (`did()`, `send()`); extensions never see `Provider`/`Processor` directly.
- **`Extension` trait** + **`Extensions`** namespace router; unknown namespaces are logged at `debug` and dropped (non-fatal).
- **`Provider::ctx()`** to build a `Ctx`.

## Scope

**Additive only.** `BackendMessage` and the existing native/browser dispatch are untouched — nothing is wired to the new types yet. This lands the shared seam so subsequent PRs can port built-ins and remove the enum (RFC rollout steps 3–5).

The only target divergence is the `Send`/`?Send` bound on async trait methods, handled with the crate's usual `cfg_attr` pair.

## Verification

- `cargo check -p rings-node` (native)
- `cargo check -p rings-node --no-default-features --features browser_default --target wasm32-unknown-unknown`
- `cargo +nightly fmt --check`

Refs #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)