### PR TITLE
docs: accurate architecture, examples/extending, ROADMAP, and sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [RingsNetwork]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Rings Network
 [![cargo](https://img.shields.io/crates/v/rings-node.svg)](https://crates.io/crates/rings-node)
 [![docs](https://docs.rs/rings-node/badge.svg)](https://docs.rs/rings-node/latest/rings_node/)
 ![GitHub](https://img.shields.io/github/license/RingsNetwork/rings-node)
+[![Sponsor](https://img.shields.io/badge/Sponsor-RingsNetwork-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/RingsNetwork)
 
 The Rings Network aimed at creating a fully decentralized network. It is built upon technologies such as WebRTC, WASM (WebAssembly), and Chord DHT (Distributed Hash Table), enabling direct connections between browsers.
 
@@ -82,6 +83,40 @@ wasm-pack build --scope ringsnetwork -t web --no-default-features --features bro
 rings help
 ```
 
+## Examples
+
+Runnable examples live in [`examples/`](./examples):
+
+| Example | What it shows |
+|---|---|
+| [`native`](./examples/native) | A minimal native node registering a custom namespaced protocol |
+| [`browser`](./examples/browser) | The same protocol model in the browser (WASM) — same Rust code, no JS handler |
+| [`relay`](./examples/relay) | TCP & UDP tunnels to a peer's service over the overlay (`tcp.rs` / `udp.rs`) |
+| [`snark`](./examples/snark) | Fold-scheme zkSNARK proving / verification |
+| [`proof-demo`](./examples/proof-demo) | A browser zk-proof app (Yew / Trunk) |
+| [`dweb`](./examples/dweb) | A decentralized-web app (Yew / Trunk) |
+| [`ffi`](./examples/ffi) | Driving a node over the C FFI |
+
+## Extending Rings
+
+A protocol is a **pure** state machine; all IO lives in its interpreter shell, which can only
+act within its own namespace. Inbound overlay messages are routed to a protocol by namespace.
+
+```rust
+// Register a pure Protocol + its Interpret shell, then route inbound envelopes to it.
+provider.register_protocol(Echo, EchoShell)?;
+provider.set_backend()?;
+
+// Built-in relay: tunnel a local socket to a peer's service over the overlay — no server.
+let relay = RelayHandle::install(&provider.extensions())?;
+relay.register_tcp_service("web".into(), "example.com:80".parse()?).await?; // server side
+relay.open_tcp_tunnel(local_addr, peer_did, "web".into()).await?;          // client side
+```
+
+In the browser a protocol can be a JS handler instead: `provider.on(namespace, initialState,
+handler)`. See [`examples/relay`](./examples/relay) and
+[`crates/node/src/extension`](./crates/node/src/extension).
+
 ## Resource
 
 | Resource                         | Link                                                                       | Status                                                                                                                                                                                    |
@@ -99,7 +134,7 @@ rings help
 
 * node: The implementation of Rings native, Rings browser, and Rings FFI provider.
 
-* rpc: The definition of Rings RPC protocol is here.
+* rpc: Rings RPC shared types and the JSON-RPC client/handlers (over HTTP).
 
 * derive: Rings macros, including `wasm_export` macro.
 
@@ -109,35 +144,44 @@ rings help
 
 ## Architecture
 
-The Rings Network architecture is streamlined into five distinct layers.
+Rings is layered so that **every layer is decentralized — there is no server in the data
+path**. Each layer maps directly to a crate/module:
 
 ```text
-+-----------------------------------------------------------------------------------------+
-|                                         RINGS                                           |
-+-----------------------------------------------------------------------------------------+
-|   Encrypted IM / Secret Sharing Storage / Distributed Content / Secret Data Exchange    |
-+-----------------------------------------------------------------------------------------+
-|                  SSSS                  |  Perdson Commitment/zkPod/ Secret Sharing      |
-+-----------------------------------------------------------------------------------------+
-|                     |       dDNS       |                 Sigma Protocol                 |
-+      K-V Storage    +------------------+------------------------------------------------+
-|                     |  Peer LOOKUP     |          MSRP        |  End-to-End Encryption  |
-+----------------------------------------+------------------------------------------------+
-|            Peer-to-Peer Network        |                                                |
-|----------------------------------------+               DID / Resource ID                |
-|                 Chord DHT              |                                                |
-+----------------------------------------+------------------------------------------------+
-|                Trickle SDP             |        ElGamal        | Persistence Storage    |
-+----------------------------------------+-----------------------+------------------------+
-|            STUN  | SDP  | ICE          |  Crosschain Binding   | Smart Contract Binding |
-+----------------------------------------+------------------------------------------------+
-|             SCTP | UDP | TCP           |             Finate Pubkey Group                |
-+----------------------------------------+------------------------------------------------+
-|   WASM Runtime    |                    |                                                |
-+-------------------|  Operation System  |                   ECDSA                        |
-|     Browser       |                    |                                                |
-+-----------------------------------------------------------------------------------------+
+┌──────────────────────────────────────────────────────────────────────┐
+│  Applications   dWeb · zk-proof demo · relay/tunnel · your own app     │
+├──────────────────────────────────────────────────────────────────────┤
+│  Protocols      built-ins: relay (tcp/udp tunnels), SNARK, echo —      │  node::extension::protocols
+│  (namespaced)   plus any user Protocol, addressed by namespace         │  crates/snark
+├──────────────────────────────────────────────────────────────────────┤
+│  Extension      pure `Protocol::step` → `Effect` → `Interpret` shell   │  node::extension::ext
+│  runtime        over a namespace-scoped `Scope` (send / self-inject)   │
+├──────────────────────────────────────────────────────────────────────┤
+│  Overlay        Chord DHT: successor / finger tables, stabilization,   │  crates/core
+│  (routing)      DID addressing, message relay, network_id isolation    │
+├──────────────────────────────────────────────────────────────────────┤
+│  Transport      direct WebRTC datachannels (native + browser/web_sys), │  crates/transport
+│                 STUN / ICE / SDP NAT traversal                         │
+├──────────────────────────────────────────────────────────────────────┤
+│  Identity       DID + secp256k1 / secp256r1 / ed25519 / BLS / bip137   │  crates/core::ecc
+└──────────────────────────────────────────────────────────────────────┘
 ```
+
+- **Transport** establishes direct, peer-to-peer WebRTC datachannels — browser-to-browser
+  included — using STUN/ICE/SDP for NAT traversal, so traffic never transits a central server.
+- **Overlay** organizes peers into a Chord DHT and routes messages by DID; distinct overlays are
+  isolated by `network_id`.
+- **Extension runtime** is a *functional core / imperative shell*: a protocol's state transition
+  is pure (`step`), and all IO happens in its `Interpret` shell, which only ever receives a
+  **namespace-scoped capability** (`Scope`). The core owns no global effect/command bus — adding
+  a protocol never touches it, and a protocol cannot reach another namespace.
+- **Protocols** are addressed by namespace. Built-ins include a **relay** that tunnels local
+  TCP/UDP sockets to a peer's service across the overlay (server-less tunneling / peer exit), and
+  **SNARK** (fold-scheme zkSNARK) proving/verification. Register your own with
+  `provider.register_protocol(..)` (Rust) or `provider.on(namespace, ..)` (JS).
+
+Where this is heading — a fully server-less, sovereign **network layer** and **privacy layer** —
+is described in [ROADMAP.md](./ROADMAP.md).
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,79 @@
+# Rings Network — Roadmap
+
+## Vision
+
+A **fully server-less, decentralized sovereign network**: every node — a daemon or a plain
+browser tab — participates directly, and no centralized infrastructure sits in the data path.
+Two tracks carry the work:
+
+- **Network layer** — connectivity, routing and transport with no servers to depend on.
+- **Privacy layer** — confidentiality and verifiable computation by default, not as an add-on.
+
+This document tracks what is shipped versus where each track is heading. Items under
+*In progress* / *Planned* are direction, not commitments, and are refined as RFCs land.
+
+---
+
+## Foundations (shipped)
+
+The substrate both layers build on:
+
+- **Chord DHT** routing — successor/finger tables, stabilization, DID addressing
+  (`crates/core`).
+- **WebRTC transport**, native and browser (`web_sys`), with STUN/ICE/SDP NAT traversal and
+  direct peer-to-peer datachannels (`crates/transport`).
+- **DID identity** with secp256k1 / secp256r1 / ed25519 / BLS / bip137 signatures
+  (`crates/core::ecc`).
+- **`network_id`-isolated overlays**, so independent networks don't intermix.
+- **Extension/protocol model** — pure `Protocol` + namespace-scoped `Interpret` shells, with
+  inbound envelopes routed by namespace (RFC #594; `crates/node/src/extension`).
+- **Control & embedding surfaces** — native daemon + `rings` CLI, JSON-RPC over HTTP, C FFI,
+  and a browser/WASM provider.
+
+---
+
+## Network layer
+
+> Goal: remove every centralized dependency from connectivity — discovery, NAT traversal and
+> routing all run between peers.
+
+**Shipped**
+- Browser ↔ browser direct datachannels (no media/relay server in the path).
+- Overlay message relay (DHT-routed delivery between peers that aren't directly connected).
+- Built-in **relay protocol**: tunnel a local TCP/UDP socket to a peer's service across the
+  overlay — server-less tunneling and peer-exit (`node::extension::protocols::relay`).
+
+**In progress**
+- WebTransport-backed relay in the browser (compile-checked; runtime hardening).
+- Connection resilience / optimistic send on the overlay.
+
+**Planned**
+- Server-less bootstrapping: decentralized peer discovery that reduces reliance on seed nodes
+  and external STUN.
+- Richer routing primitives over the extension layer (pub/sub, service discovery as protocols).
+
+---
+
+## Privacy layer
+
+> Goal: confidentiality and verifiability are defaults of the network, expressed as protocols
+> over the same extension runtime.
+
+**Shipped**
+- **zkSNARK** proving/verification as a protocol — fold-scheme based (`crates/snark`).
+- Signed messaging with selectable signature schemes; plaintext and signed message paths.
+
+**Planned**
+- End-to-end encryption across the messaging layer (sender-to-recipient, not hop-by-hop).
+- Zero-knowledge identity and verifiable off-chain compute built on the SNARK protocol.
+- Secret sharing and private storage primitives.
+- Metadata-resistant routing (reducing what intermediaries can observe).
+
+---
+
+## Contributing to the roadmap
+
+Direction is shaped through RFCs and issues on
+[GitHub](https://github.com/RingsNetwork/rings-node/issues). If you want to help build either
+layer, an extension protocol is the lightest way in — see **Extending Rings** in the
+[README](./README.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,8 +48,7 @@ The substrate both layers build on:
 - Connection resilience / optimistic send on the overlay.
 
 **Planned**
-- Server-less bootstrapping: decentralized peer discovery that reduces reliance on seed nodes
-  and external STUN.
+- Decentralized peer discovery / bootstrapping.
 - Richer routing primitives over the extension layer (pub/sub, service discovery as protocols).
 
 ---


### PR DESCRIPTION
## What

Refresh the docs to match what's actually built and add a roadmap + sponsors.

### Architecture (README)
The old "five layers" ASCII stack listed mostly-unimplemented pieces (SSSS, Pedersen commitments, zkPod, dDNS, Sigma protocol, MSRP, Trickle-SDP, ElGamal…). Replaced with a layered diagram that maps each layer to a real crate/module:

`Identity` → `Transport` (WebRTC, native + browser) → `Overlay` (Chord DHT) → `Extension runtime` (pure `Protocol::step` + scoped `Interpret`/`Scope`) → namespaced `Protocols` (relay, SNARK) → apps. Plus prose explaining each.

### New README sections
- **Examples** — table of the in-repo examples (native, browser, relay, snark, proof-demo, dweb, ffi).
- **Extending Rings** — the protocol model with a real snippet (`register_protocol` / `RelayHandle::install` / `open_tcp_tunnel`; `provider.on(..)` for JS).
- **Sponsors** — GitHub Sponsors badge in the header.
- Fix: the `rpc` component is JSON-RPC over HTTP now (protobuf dropped in #593).

### ROADMAP.md (new)
Vision (a fully server-less, decentralized **sovereign network**) → Foundations (shipped) → two tracks:
- **Network layer** — connectivity/routing with no servers (shipped: browser↔browser, overlay relay, TCP/UDP relay tunnels; planned: server-less bootstrapping/discovery).
- **Privacy layer** — confidentiality + verifiability by default (shipped: zkSNARK protocol; planned: E2E encryption, ZK identity/compute, secret sharing, metadata-resistant routing).

In-progress/Planned items are marked as direction, refined as RFCs land.

### .github/FUNDING.yml
`github: [RingsNetwork]` (enables the repo Sponsor button).

## Notes
Docs-only; no code changes. The ROADMAP **Planned** items are framed from the stated vision — happy to adjust wording/scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)