### PR TITLE
docs(readme): fix repo badges after rename (rings-node → rings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 Rings Network
 ===============
 
-[![rings-node](https://github.com/RingsNetwork/rings-node/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RingsNetwork/rings-node/actions/workflows/auto-release.yml)
+[![rings-node](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml)
 [![cargo](https://img.shields.io/crates/v/rings-node.svg)](https://crates.io/crates/rings-node)
 [![docs](https://docs.rs/rings-node/badge.svg)](https://docs.rs/rings-node/latest/rings_node/)
-![GitHub](https://img.shields.io/github/license/RingsNetwork/rings-node)
+![GitHub](https://img.shields.io/github/license/RingsNetwork/rings)
 [![Sponsor](https://img.shields.io/badge/Sponsor-RingsNetwork-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/RingsNetwork)
 
 The Rings Network aimed at creating a fully decentralized network. It is built upon technologies such as WebRTC, WASM (WebAssembly), and Chord DHT (Distributed Hash Table), enabling direct connections between browsers.


### PR DESCRIPTION
## Why

The repo was renamed `rings-node` → `rings`. The README's **GitHub Actions** and **license** badges still queried the old name (`RingsNetwork/rings-node`), resolving only via GitHub's redirect — which can render (and get cached by GitHub's camo image proxy) as **`invalid`** around a rename. That's why the license badge was showing `invalid`.

## Change

Point the repo-scoped badges at `RingsNetwork/rings`:
- Actions status badge + link
- license badge

The `crates.io` / `docs.rs` badges keep `rings-node` — that's the **crate** name (unchanged), not the repo.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)