### PR TITLE
Default correct chord and bump 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "rings-browser-example"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bytes",
  "js-sys",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "rings-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "rings-derive"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4346,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "rings-native-example"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "rings-node"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -4421,7 +4421,7 @@ dependencies = [
 
 [[package]]
 name = "rings-relay-example"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "rings-core",
  "rings-node",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "rings-rpc"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "rings-snark"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bellpepper-core",
  "byteorder",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "rings-snark-example"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "rings-core",
@@ -4488,7 +4488,7 @@ dependencies = [
 
 [[package]]
 name = "rings-transport"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "examples/browser", "examples/native", "examples/relay", "examples/snark"]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "GPL-3.0"
 authors = ["RND <dev@ringsnetwork.io>"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,9 +11,8 @@ authors.workspace = true
 repository.workspace = true
 
 [features]
-# Feature "experimental" is used to mark an implementation as experimental, which means that:
-# It may not have been thoroughly tested.
-# The corresponding API may be deprecated or adjusted in the future.
+# Deprecated compatibility alias. The formerly experimental correct-chord path
+# now runs by default.
 experimental = ["std"]
 default = ["std"]
 redundant = ["default"]

--- a/crates/core/src/dht/chord.rs
+++ b/crates/core/src/dht/chord.rs
@@ -95,7 +95,10 @@ pub enum RemoteAction {
     FindVNode(Did),
     /// Need `did_a` to find VirtualNode for operating.
     FindVNodeForOperate(VNodeOperation),
-    /// Let `did_a` [notify](Chord::notify) `did_b`.
+    /// Send a predecessor notification to `did_a`.
+    ///
+    /// `did_a` is the remote recipient from [`PeerRingAction::RemoteAction`].
+    /// This field is the predecessor DID announced in `NotifyPredecessorSend`.
     Notify(Did),
     /// Let `did_a` sync data with it's successor.
     SyncVNodeWithSuccessor(Vec<VirtualNode>),
@@ -203,6 +206,9 @@ impl PeerRing {
     }
 
     /// Same as new with config, but with a given storage and finger table size.
+    ///
+    /// `Did` is 160-bit. Sizes above [`DEFAULT_FINGER_TABLE_SIZE`] are clamped
+    /// by [`FingerTable::new`]; zero is allowed to disable finger maintenance.
     pub fn new_with_storage_and_finger_table_size(
         did: Did,
         succ_max: u8,
@@ -616,7 +622,12 @@ impl CorrectChord<PeerRingAction> for PeerRing {
     }
 
     /// Stabilize Operation:
-    /// Perform stabilization for the successor list.
+    ///
+    /// Mirrors the TLA+-style `CorrectStabilize` operator in
+    /// `tests/default/dht_convergence.rs`.
+    /// The old head is captured before updating successors for the improved-successor
+    /// query check; the remote successor list contributes `but_last`; and notify
+    /// is emitted for the post-update head when that head is not self.
     fn stabilize(&self, info: TopoInfo) -> Result<PeerRingAction> {
         let mut ret = vec![];
         let successors = self.successors();

--- a/crates/core/src/dht/chord.rs
+++ b/crates/core/src/dht/chord.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use super::did::BiasId;
+use super::finger::DEFAULT_FINGER_TABLE_SIZE;
 use super::successor::SuccessorSeq;
 use super::types::Chord;
 use super::types::ChordStorage;
@@ -193,11 +194,25 @@ impl From<Vec<PeerRingAction>> for PeerRingAction {
 impl PeerRing {
     /// Same as new with config, but with a given storage.
     pub fn new_with_storage(did: Did, succ_max: u8, storage: VNodeStorage) -> Self {
+        Self::new_with_storage_and_finger_table_size(
+            did,
+            succ_max,
+            storage,
+            DEFAULT_FINGER_TABLE_SIZE,
+        )
+    }
+
+    /// Same as new with config, but with a given storage and finger table size.
+    pub fn new_with_storage_and_finger_table_size(
+        did: Did,
+        succ_max: u8,
+        storage: VNodeStorage,
+        finger_table_size: usize,
+    ) -> Self {
         Self {
             successor_seq: SuccessorSeq::new(did, succ_max),
             predecessor: Arc::new(Mutex::new(None)),
-            // for Eth address, it's 160
-            finger: Arc::new(Mutex::new(FingerTable::new(did, 160))),
+            finger: Arc::new(Mutex::new(FingerTable::new(did, finger_table_size))),
             storage,
             cache: Box::new(MemStorage::new()),
             did,
@@ -339,10 +354,17 @@ impl Chord<PeerRingAction> for PeerRing {
     /// According to the paper, this method should be called periodically.
     /// According to the paper, only one finger should be fixed at a time.
     fn fix_fingers(&self) -> Result<PeerRingAction> {
-        let mut fix_finger_index = self.lock_finger()?.fix_finger_index;
+        let (mut fix_finger_index, finger_table_size) = {
+            let finger = self.lock_finger()?;
+            (finger.fix_finger_index, finger.slot_count())
+        };
+
+        if finger_table_size == 0 {
+            return Ok(PeerRingAction::None);
+        }
 
         // Only one finger should be fixed at a time.
-        fix_finger_index = (fix_finger_index + 1) % 160;
+        fix_finger_index = (fix_finger_index + 1) % finger_table_size;
 
         // Get finger did.
         let finger_did = Did::from(BigUint::from(2u16).pow(fix_finger_index as u32));

--- a/crates/core/src/dht/chord.rs
+++ b/crates/core/src/dht/chord.rs
@@ -598,25 +598,33 @@ impl CorrectChord<PeerRingAction> for PeerRing {
     fn stabilize(&self, info: TopoInfo) -> Result<PeerRingAction> {
         let mut ret = vec![];
         let successors = self.successors();
+        let old_head = if successors.is_empty()? {
+            None
+        } else {
+            Some(successors.min()?)
+        };
         let succ_len = info.successors.len();
-        let but_last = &info.successors[..succ_len - 1].to_vec();
+        let but_last = &info.successors[..succ_len.saturating_sub(1)].to_vec();
+        let improved_successor = info.predecessor.filter(|new_succ| {
+            *new_succ != self.did
+                && old_head.is_none_or(|head| self.bias(*new_succ) < self.bias(head))
+        });
         if let Some(new_succ) = info.predecessor {
             successors.update(new_succ)?;
         }
         successors.extend(but_last)?;
-        // Check if the new successor is between  new_succ and head(successors).
-        if let Some(new_succ) = info.predecessor {
-            if self.bias(new_succ) < self.bias(successors.min()?) {
-                // If new_succ is between self.did and the head of the successor list,
-                // query newSucc for its successor list.
-                ret.push(PeerRingAction::RemoteAction(
-                    new_succ,
-                    RemoteAction::QueryForSuccessorList,
-                ));
-            }
-            // Notify the node's minimum successor of its existence.
+        // Check if new_succ was between self.did and the old head of successors.
+        if let Some(new_succ) = improved_successor {
             ret.push(PeerRingAction::RemoteAction(
-                successors.min()?,
+                new_succ,
+                RemoteAction::QueryForSuccessorList,
+            ));
+        }
+        // Notify the node's minimum successor of its existence.
+        let head = successors.min()?;
+        if head != self.did {
+            ret.push(PeerRingAction::RemoteAction(
+                head,
                 RemoteAction::Notify(self.did),
             ));
         }
@@ -867,6 +875,22 @@ mod tests {
         assert!(
             node2.lock_finger()?.contains(Some(did1)),
             "did2:{did2:?} dont contains did1:{did1:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_correct_chord_stabilize_handles_empty_successor_info() -> Result<()> {
+        let did = Did::from_str("0x051cf4f8d020cb910474bef3e17f153fface2b5f").unwrap();
+        let node = PeerRing::new_with_storage(did, 3, Box::new(MemStorage::new()));
+
+        assert_eq!(
+            node.stabilize(TopoInfo {
+                successors: vec![],
+                predecessor: None,
+            })?,
+            PeerRingAction::MultiActions(vec![])
         );
 
         Ok(())

--- a/crates/core/src/dht/finger.rs
+++ b/crates/core/src/dht/finger.rs
@@ -27,7 +27,13 @@ pub struct FingerTable {
 
 impl FingerTable {
     /// builder
+    ///
+    /// `Did` is represented by H160, so finger slots above 160 would wrap the
+    /// `2^index` lookup target back into the same 160-bit space. Values above
+    /// [`DEFAULT_FINGER_TABLE_SIZE`] are clamped; zero is allowed for tests that
+    /// intentionally disable finger maintenance.
     pub fn new(did: Did, size: usize) -> Self {
+        let size = size.min(DEFAULT_FINGER_TABLE_SIZE);
         Self {
             did,
             size,
@@ -201,6 +207,17 @@ impl Index<usize> for FingerTable {
 mod test {
     use super::*;
     use crate::dht::tests::gen_ordered_dids;
+
+    #[test]
+    fn test_finger_table_size_bounds() {
+        let did = gen_ordered_dids(1)[0];
+
+        assert_eq!(
+            FingerTable::new(did, DEFAULT_FINGER_TABLE_SIZE + 1).slot_count(),
+            DEFAULT_FINGER_TABLE_SIZE
+        );
+        assert_eq!(FingerTable::new(did, 0).slot_count(), 0);
+    }
 
     #[test]
     fn test_finger_table_get_set_remove() {

--- a/crates/core/src/dht/finger.rs
+++ b/crates/core/src/dht/finger.rs
@@ -10,6 +10,9 @@ use serde::Serialize;
 
 use crate::dht::Did;
 
+/// Default number of Chord finger slots for a 160-bit `Did`.
+pub const DEFAULT_FINGER_TABLE_SIZE: usize = 160;
+
 /// Finger table of Chord DHT
 /// Ring's finger table is implemented with BiasRing
 #[derive(Derivative, Clone, Debug, Serialize, Deserialize)]
@@ -19,7 +22,7 @@ pub struct FingerTable {
     size: usize,
     finger: Vec<Option<Did>>,
     #[derivative(PartialEq = "ignore")]
-    pub(super) fix_finger_index: u8,
+    pub(super) fix_finger_index: usize,
 }
 
 impl FingerTable {
@@ -162,6 +165,11 @@ impl FingerTable {
     /// get length of finger
     pub fn len(&self) -> usize {
         self.finger.iter().flatten().count()
+    }
+
+    /// Get the number of slots in this finger table.
+    pub fn slot_count(&self) -> usize {
+        self.size
     }
 
     /// get finger list

--- a/crates/core/src/dht/finger.rs
+++ b/crates/core/src/dht/finger.rs
@@ -85,7 +85,7 @@ impl FingerTable {
 
     /// setter for fix_finger_index
     pub fn set_fix(&mut self, did: Did) {
-        let index = self.fix_finger_index as usize;
+        let index = self.fix_finger_index;
         self.set(index, did)
     }
 

--- a/crates/core/src/dht/mod.rs
+++ b/crates/core/src/dht/mod.rs
@@ -22,6 +22,7 @@ pub use chord::TopoInfo;
 pub use chord::VNodeStorage;
 pub use did::Did;
 pub use finger::FingerTable;
+pub use finger::DEFAULT_FINGER_TABLE_SIZE;
 pub use stabilization::Stabilizer;
 pub use successor::SuccessorReader;
 pub use successor::SuccessorWriter;

--- a/crates/core/src/dht/stabilization.rs
+++ b/crates/core/src/dht/stabilization.rs
@@ -55,14 +55,13 @@ impl Stabilizer {
             );
         }
         tracing::debug!("STABILIZATION clean_unavailable_connections end");
-        #[cfg(feature = "experimental")]
-        {
-            tracing::debug!("STABILIZATION correct_stabilize start");
-            if let Err(e) = self.correct_stabilize().await {
-                tracing::error!("[stabilize] Failed on call correct stabilize {:?}", e);
-            }
-            tracing::debug!("STABILIZATION correct_stabilize end");
+        // Default HMCC/Zave stabilization path. The pure operation is specified
+        // as `CorrectStabilize` in tests/default/dht_convergence.rs.
+        tracing::debug!("STABILIZATION correct_stabilize start");
+        if let Err(e) = self.correct_stabilize().await {
+            tracing::error!("[stabilize] Failed on call correct stabilize {:?}", e);
         }
+        tracing::debug!("STABILIZATION correct_stabilize end");
         Ok(())
     }
 

--- a/crates/core/src/dht/successor.rs
+++ b/crates/core/src/dht/successor.rs
@@ -232,6 +232,18 @@ mod tests {
     }
 
     #[test]
+    fn test_successor_extend_sorts_unordered_input() -> Result<()> {
+        let dids = gen_ordered_dids(6);
+        let succ = SuccessorSeq::new(dids[0], 3);
+
+        succ.extend(&[dids[4], dids[2], dids[5], dids[1], dids[3]])?;
+
+        assert_eq!(succ.list()?, dids[1..4]);
+        assert_eq!(succ.min()?, dids[1]);
+        Ok(())
+    }
+
+    #[test]
     fn test_successor_remove() -> Result<()> {
         let dids = gen_ordered_dids(4);
 

--- a/crates/core/src/dht/successor.rs
+++ b/crates/core/src/dht/successor.rs
@@ -244,6 +244,44 @@ mod tests {
     }
 
     #[test]
+    fn test_successor_extend_is_order_independent() -> Result<()> {
+        let dids = gen_ordered_dids(7);
+        let expected = vec![dids[1], dids[2], dids[3]];
+        let orders = [
+            vec![dids[6], dids[5], dids[4], dids[3], dids[2], dids[1]],
+            vec![dids[1], dids[2], dids[3], dids[4], dids[5], dids[6]],
+            vec![
+                dids[0], dids[3], dids[1], dids[6], dids[2], dids[1], dids[5],
+            ],
+            vec![dids[4], dids[2], dids[6], dids[1], dids[3], dids[0]],
+        ];
+
+        for order in orders {
+            let succ = SuccessorSeq::new(dids[0], 3);
+            succ.extend(&order)?;
+            assert_eq!(succ.list()?, expected, "order was {order:?}");
+            assert_eq!(succ.min()?, dids[1]);
+            assert_eq!(succ.max()?, dids[3]);
+            assert!(!succ.contains(&dids[0])?, "self must never be a successor");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_successor_extend_sorts_across_ring_wrap() -> Result<()> {
+        let dids = gen_ordered_dids(7);
+        let succ = SuccessorSeq::new(dids[4], 3);
+
+        succ.extend(&[dids[2], dids[6], dids[0], dids[5], dids[3], dids[1]])?;
+
+        assert_eq!(succ.list()?, vec![dids[5], dids[6], dids[0]]);
+        assert_eq!(succ.min()?, dids[5]);
+        assert_eq!(succ.max()?, dids[0]);
+        Ok(())
+    }
+
+    #[test]
     fn test_successor_remove() -> Result<()> {
         let dids = gen_ordered_dids(4);
 

--- a/crates/core/src/message/handlers/connection.rs
+++ b/crates/core/src/message/handlers/connection.rs
@@ -50,6 +50,8 @@ impl HandleMsg<QueryForTopoInfoReport> for MessageHandler {
                 }
             }
             <QueryForTopoInfoReport as Then>::Then::Stabilization => {
+                // Establish stabilization-learned candidates first so the
+                // resulting Notify/Query actions can usually send immediately.
                 if let Some(peer) = msg.info.predecessor {
                     self.connect_dht_peer(peer).await?;
                 }

--- a/crates/core/src/message/handlers/connection.rs
+++ b/crates/core/src/message/handlers/connection.rs
@@ -44,10 +44,18 @@ impl HandleMsg<QueryForTopoInfoReport> for MessageHandler {
         match msg.then {
             <QueryForTopoInfoReport as Then>::Then::SyncSuccessor => {
                 for peer in msg.info.successors.iter() {
-                    self.join_dht(*peer).await?;
+                    if self.transport.get_connection(*peer).is_some() {
+                        self.join_dht(*peer).await?;
+                    }
                 }
             }
             <QueryForTopoInfoReport as Then>::Then::Stabilization => {
+                if let Some(peer) = msg.info.predecessor {
+                    self.connect_dht_peer(peer).await?;
+                }
+                for peer in msg.info.successors.iter() {
+                    self.connect_dht_peer(*peer).await?;
+                }
                 let ev = self.dht.stabilize(msg.info.clone())?;
                 self.handle_dht_events(&ev).await?;
             }

--- a/crates/core/src/message/handlers/mod.rs
+++ b/crates/core/src/message/handlers/mod.rs
@@ -75,7 +75,13 @@ impl MessageHandler {
             .get_connection(peer)
             .ok_or(Error::SwarmMissDidInTable(peer))?;
         let dht_ev = self.dht.join_then_sync(conn).await?;
-        self.handle_dht_events(&dht_ev).await
+        // The local join has completed. Follow-up convergence messages are
+        // best-effort: a peer can churn before these sends complete, and that
+        // must not suppress the application-level Connected event.
+        if let Err(e) = self.handle_dht_events(&dht_ev).await {
+            tracing::warn!("Failed to handle dht events while joining {peer}: {e:?}");
+        }
+        Ok(())
     }
 
     pub(crate) async fn leave_dht(&self, peer: Did) -> Result<()> {

--- a/crates/core/src/message/handlers/mod.rs
+++ b/crates/core/src/message/handlers/mod.rs
@@ -7,7 +7,6 @@ use async_recursion::async_recursion;
 use async_trait::async_trait;
 
 use super::MessagePayload;
-use crate::dht::Chord;
 use crate::dht::CorrectChord;
 use crate::dht::Did;
 use crate::dht::PeerRing;
@@ -69,24 +68,14 @@ impl MessageHandler {
     }
 
     pub(crate) async fn join_dht(&self, peer: Did) -> Result<()> {
-        if cfg!(feature = "experimental") {
-            let conn = self
-                .transport
-                .get_connection(peer)
-                .ok_or(Error::SwarmMissDidInTable(peer))?;
-            let dht_ev = self.dht.join_then_sync(conn).await?;
-            self.handle_dht_events(&dht_ev).await
-        } else {
-            let dht_ev = self.dht.join(peer)?;
-            // `dht.join` already updated the local routing table synchronously;
-            // `handle_dht_events` only fires best-effort convergence messages.
-            // A send here can legitimately fail if the peer churned away, so log
-            // and continue instead of panicking.
-            if let Err(e) = self.handle_dht_events(&dht_ev).await {
-                tracing::warn!("Failed to handle dht events while joining {peer}: {e:?}");
-            }
-            Ok(())
-        }
+        // Default HMCC/Zave join path: maps to the JoinThenSync operation in
+        // the CorrectChord spec (see tests/default/dht_convergence.rs).
+        let conn = self
+            .transport
+            .get_connection(peer)
+            .ok_or(Error::SwarmMissDidInTable(peer))?;
+        let dht_ev = self.dht.join_then_sync(conn).await?;
+        self.handle_dht_events(&dht_ev).await
     }
 
     pub(crate) async fn leave_dht(&self, peer: Did) -> Result<()> {
@@ -146,14 +135,16 @@ impl MessageHandler {
                 self.transport.connect(*did, self.inner_callback()).await?;
                 Ok(())
             }
-            PeerRingAction::RemoteAction(did, PeerRingRemoteAction::Notify(target_id)) => {
-                if did == target_id {
-                    tracing::warn!("Did is equal to target_id, may implement wrong.");
+            PeerRingAction::RemoteAction(did, PeerRingRemoteAction::Notify(predecessor)) => {
+                if did == predecessor {
+                    tracing::warn!("Notify target is equal to predecessor, may implement wrong.");
                     return Ok(());
                 }
+                // `RemoteAction(target, Notify(pred))` means "send pred to target"
+                // and maps to CorrectStabilize.notify' in the TLA+ spec mirror.
                 let msg =
-                    Message::NotifyPredecessorSend(NotifyPredecessorSend { did: self.dht.did });
-                self.transport.send_message(msg, *target_id).await?;
+                    Message::NotifyPredecessorSend(NotifyPredecessorSend { did: *predecessor });
+                self.transport.send_message(msg, *did).await?;
                 Ok(())
             }
             PeerRingAction::MultiActions(acts) => {

--- a/crates/core/src/message/handlers/mod.rs
+++ b/crates/core/src/message/handlers/mod.rs
@@ -67,6 +67,17 @@ impl MessageHandler {
         InnerSwarmCallback::new(self.transport.clone(), self.swarm_callback.clone())
     }
 
+    pub(crate) async fn connect_dht_peer(&self, peer: Did) -> Result<bool> {
+        if peer == self.dht.did || self.transport.get_connection(peer).is_some() {
+            return Ok(false);
+        }
+
+        match self.transport.connect(peer, self.inner_callback()).await {
+            Ok(()) | Err(Error::AlreadyConnected) => Ok(true),
+            Err(e) => Err(e),
+        }
+    }
+
     pub(crate) async fn join_dht(&self, peer: Did) -> Result<()> {
         // Default HMCC/Zave join path: maps to the JoinThenSync operation in
         // the CorrectChord spec (see tests/default/dht_convergence.rs).
@@ -129,6 +140,10 @@ impl MessageHandler {
             }
             // A new successor is set, request the new successor for it's successor list
             PeerRingAction::RemoteAction(next, PeerRingRemoteAction::QueryForSuccessorList) => {
+                if !self.transport.is_connected(*next) {
+                    self.connect_dht_peer(*next).await?;
+                    return Ok(());
+                }
                 self.transport
                     .send_direct_message(
                         Message::QueryForTopoInfoSend(QueryForTopoInfoSend::new_for_sync(*next)),
@@ -138,12 +153,16 @@ impl MessageHandler {
                 Ok(())
             }
             PeerRingAction::RemoteAction(did, PeerRingRemoteAction::TryConnect) => {
-                self.transport.connect(*did, self.inner_callback()).await?;
+                self.connect_dht_peer(*did).await?;
                 Ok(())
             }
             PeerRingAction::RemoteAction(did, PeerRingRemoteAction::Notify(predecessor)) => {
                 if did == predecessor {
                     tracing::warn!("Notify target is equal to predecessor, may implement wrong.");
+                    return Ok(());
+                }
+                if !self.transport.is_connected(*did) {
+                    self.connect_dht_peer(*did).await?;
                     return Ok(());
                 }
                 // `RemoteAction(target, Notify(pred))` means "send pred to target"

--- a/crates/core/src/message/handlers/mod.rs
+++ b/crates/core/src/message/handlers/mod.rs
@@ -67,13 +67,18 @@ impl MessageHandler {
         InnerSwarmCallback::new(self.transport.clone(), self.swarm_callback.clone())
     }
 
-    pub(crate) async fn connect_dht_peer(&self, peer: Did) -> Result<bool> {
+    /// Idempotently establish a DHT-driven transport connection.
+    ///
+    /// Self and already-connected peers are no-ops. `AlreadyConnected` is treated
+    /// as success so concurrent DHT actions racing through `MultiActions` do not
+    /// fail the whole handler.
+    pub(crate) async fn connect_dht_peer(&self, peer: Did) -> Result<()> {
         if peer == self.dht.did || self.transport.get_connection(peer).is_some() {
-            return Ok(false);
+            return Ok(());
         }
 
         match self.transport.connect(peer, self.inner_callback()).await {
-            Ok(()) | Err(Error::AlreadyConnected) => Ok(true),
+            Ok(()) | Err(Error::AlreadyConnected) => Ok(()),
             Err(e) => Err(e),
         }
     }

--- a/crates/core/src/swarm/builder.rs
+++ b/crates/core/src/swarm/builder.rs
@@ -7,6 +7,7 @@ use std::sync::RwLock;
 
 use crate::dht::PeerRing;
 use crate::dht::VNodeStorage;
+use crate::dht::DEFAULT_FINGER_TABLE_SIZE;
 use crate::measure::MeasureImpl;
 use crate::session::SessionSk;
 use crate::swarm::callback::SharedSwarmCallback;
@@ -23,6 +24,7 @@ pub struct SwarmBuilder {
     ice_servers: String,
     external_address: Option<String>,
     dht_succ_max: u8,
+    dht_finger_table_size: usize,
     dht_storage: VNodeStorage,
     session_sk: SessionSk,
     session_ttl: Option<usize>,
@@ -43,6 +45,7 @@ impl SwarmBuilder {
             ice_servers: ice_servers.to_string(),
             external_address: None,
             dht_succ_max: 3,
+            dht_finger_table_size: DEFAULT_FINGER_TABLE_SIZE,
             dht_storage,
             session_sk,
             session_ttl: None,
@@ -54,6 +57,12 @@ impl SwarmBuilder {
     /// Sets up the maximum length of successors in the DHT.
     pub fn dht_succ_max(mut self, succ_max: u8) -> Self {
         self.dht_succ_max = succ_max;
+        self
+    }
+
+    /// Sets up the number of slots in the DHT finger table.
+    pub fn dht_finger_table_size(mut self, size: usize) -> Self {
+        self.dht_finger_table_size = size;
         self
     }
 
@@ -86,10 +95,11 @@ impl SwarmBuilder {
     pub fn build(self) -> Swarm {
         let dht_did = self.session_sk.account_did();
 
-        let dht = Arc::new(PeerRing::new_with_storage(
+        let dht = Arc::new(PeerRing::new_with_storage_and_finger_table_size(
             dht_did,
             self.dht_succ_max,
             self.dht_storage,
+            self.dht_finger_table_size,
         ));
 
         let callback = RwLock::new(

--- a/crates/core/src/swarm/builder.rs
+++ b/crates/core/src/swarm/builder.rs
@@ -61,6 +61,9 @@ impl SwarmBuilder {
     }
 
     /// Sets up the number of slots in the DHT finger table.
+    ///
+    /// `Did` is 160-bit, so values above `DEFAULT_FINGER_TABLE_SIZE` are clamped
+    /// by `FingerTable::new`. A size of zero disables finger maintenance.
     pub fn dht_finger_table_size(mut self, size: usize) -> Self {
         self.dht_finger_table_size = size;
         self

--- a/crates/core/src/tests/default/dht_convergence.rs
+++ b/crates/core/src/tests/default/dht_convergence.rs
@@ -37,12 +37,15 @@
 //!
 //! \* Rank of x among Others(n) by increasing clockwise distance (0-based).
 //! Rank(n, x) == Cardinality({ y \in Others(n) : dist(n,y) < dist(n,x) })
+//! SeqSet(s) == { s[i] : i \in 1..Len(s) }
+//! RankIn(S, n, x) == Cardinality({ y \in S \ {n} : dist(n,y) < dist(n,x) })
 //!
 //! \* Successors(n): the K nearest forward nodes, ordered by distance. Mirrors
 //! \* SuccessorSeq::update (keep the K smallest dist, sorted).
-//! Successors(n) ==
-//!   [ i \in 1..Min(K, Cardinality(Others(n))) |->
-//!       CHOOSE x \in Others(n) : Rank(n, x) = i - 1 ]
+//! SuccessorsOver(S, n) ==
+//!   [ i \in 1..Min(K, Cardinality(S \ {n})) |->
+//!       CHOOSE x \in S \ {n} : RankIn(S, n, x) = i - 1 ]
+//! Successors(n) == SuccessorsOver(Node, n)
 //!
 //! \* Predecessor(n): nearest node behind = farthest forward. Mirrors
 //! \* chord.rs `notify`: pred := d iff bias(pred) < bias(d).
@@ -64,6 +67,25 @@
 //!   LET C == { x \in Others(n) : dist(n,x) >= 2^k } IN
 //!   IF C = {} THEN none
 //!   ELSE CHOOSE x \in C : \A y \in C : dist(n,x) <= dist(n,y)
+//!
+//! \* CorrectChord stabilize operation (HMCC/Zave path). This is the default
+//! \* production path: `Stabilizer::stabilize` calls `correct_stabilize`, and
+//! \* message handling applies `PeerRing::stabilize` to the successor's TopoInfo.
+//! ButLast(s) == IF Len(s) = 0 THEN <<>> ELSE SubSeq(s, 1, Len(s)-1)
+//! InsertKnown(n, cur, candidates) ==
+//!   LET Known == {n} \cup SeqSet(cur) \cup candidates IN
+//!     SuccessorsOver(Known, n)
+//! Improved(n, cur, p) ==
+//!   /\ p # none
+//!   /\ p # n
+//!   /\ (Len(cur) = 0 \/ dist(n, p) < dist(n, Head(cur)))
+//! CorrectStabilize(n, cur, topoSucc, topoPred) ==
+//!   LET predSet == IF topoPred = none THEN {} ELSE {topoPred}
+//!       cand == SeqSet(ButLast(topoSucc)) \cup predSet
+//!       next == InsertKnown(n, cur, cand) IN
+//!   /\ succ'[n] = next
+//!   /\ query'  = IF Improved(n, cur, topoPred) THEN <<topoPred>> ELSE <<>>
+//!   /\ notify' = IF Len(next) = 0 THEN <<>> ELSE <<Head(next)>>
 //!
 //! \* Converged(n): the materialised local state equals the operators above.
 //! Converged(n) ==
@@ -92,9 +114,14 @@ use std::str::FromStr;
 use num_bigint::BigUint;
 
 use crate::dht::successor::SuccessorReader;
+use crate::dht::successor::SuccessorWriter;
 use crate::dht::Chord;
+use crate::dht::CorrectChord;
 use crate::dht::Did;
 use crate::dht::PeerRing;
+use crate::dht::PeerRingAction;
+use crate::dht::PeerRingRemoteAction;
+use crate::dht::TopoInfo;
 use crate::storage::MemStorage;
 
 /// Successor-list capacity; matches `SwarmBuilder::dht_succ_max` (production).
@@ -146,6 +173,60 @@ pub(super) mod spec {
     /// The full per-node finger table the spec predicts (one slot per ring bit).
     pub fn finger_table(all: &[Did], n: Did) -> Vec<Option<Did>> {
         (0..BITS).map(|bit| finger(all, n, bit)).collect()
+    }
+
+    fn push_unique(xs: &mut Vec<Did>, x: Did) {
+        if !xs.contains(&x) {
+            xs.push(x);
+        }
+    }
+
+    /// `CorrectStabilize` successor update: merge current successors with the
+    /// successor's predecessor and all but the last entry of the successor's
+    /// successor list, then keep the K nearest forward nodes.
+    pub fn correct_stabilize_successors(
+        me: Did,
+        current: &[Did],
+        topo_successors: &[Did],
+        topo_predecessor: Option<Did>,
+    ) -> Vec<Did> {
+        let mut known = vec![me];
+        for &did in current {
+            push_unique(&mut known, did);
+        }
+        if let Some(pred) = topo_predecessor {
+            push_unique(&mut known, pred);
+        }
+        for &did in topo_successors
+            .iter()
+            .take(topo_successors.len().saturating_sub(1))
+        {
+            push_unique(&mut known, did);
+        }
+        successors(&known, me)
+    }
+
+    /// `CorrectStabilize` query side effect: ask the successor's predecessor for
+    /// its successor list only when that predecessor is a strict improvement over
+    /// the old head of the local successor list.
+    pub fn correct_stabilize_query(
+        me: Did,
+        current: &[Did],
+        topo_predecessor: Option<Did>,
+    ) -> Option<Did> {
+        let pred = topo_predecessor?;
+        if pred == me {
+            return None;
+        }
+        match current.first() {
+            Some(&head) if dist(me, pred) >= dist(me, head) => None,
+            _ => Some(pred),
+        }
+    }
+
+    /// `CorrectStabilize` notify side effect: notify the new successor, if any.
+    pub fn correct_stabilize_notify(me: Did, next_successors: &[Did]) -> Option<Did> {
+        next_successors.first().copied().filter(|&did| did != me)
     }
 }
 
@@ -254,6 +335,59 @@ fn assert_converged_matches_spec(layout: &Layout) {
     }
 }
 
+fn dht_with_successors(me: Did, successors: &[Did]) -> PeerRing {
+    let dht = PeerRing::new_with_storage(me, K as u8, Box::new(MemStorage::new()));
+    for &successor in successors {
+        dht.successors().update(successor).unwrap();
+    }
+    dht
+}
+
+fn assert_correct_stabilize_matches_spec(
+    me: Did,
+    current_successors: &[Did],
+    topo_successors: &[Did],
+    topo_predecessor: Option<Did>,
+) {
+    let dht = dht_with_successors(me, current_successors);
+    let action = dht
+        .stabilize(TopoInfo {
+            successors: topo_successors.to_vec(),
+            predecessor: topo_predecessor,
+        })
+        .unwrap();
+    let expected_successors = spec::correct_stabilize_successors(
+        me,
+        current_successors,
+        topo_successors,
+        topo_predecessor,
+    );
+    let mut expected_actions = vec![];
+    if let Some(query) = spec::correct_stabilize_query(me, current_successors, topo_predecessor) {
+        expected_actions.push(PeerRingAction::RemoteAction(
+            query,
+            PeerRingRemoteAction::QueryForSuccessorList,
+        ));
+    }
+    if let Some(notify) = spec::correct_stabilize_notify(me, &expected_successors) {
+        expected_actions.push(PeerRingAction::RemoteAction(
+            notify,
+            PeerRingRemoteAction::Notify(me),
+        ));
+    }
+
+    assert_eq!(
+        dht.successors().list().unwrap(),
+        expected_successors,
+        "CorrectStabilize successor list mismatch"
+    );
+    assert_eq!(
+        action,
+        PeerRingAction::MultiActions(expected_actions),
+        "CorrectStabilize action mismatch"
+    );
+}
+
 /// Base case P(2): a single forward neighbour — the wrap-around case, where each
 /// node's only successor and its predecessor are the same peer.
 #[test]
@@ -299,4 +433,42 @@ fn convergence_clustered_n6() {
 #[test]
 fn convergence_dyadic_boundary() {
     assert_converged_matches_spec(&Layout::DyadicBoundary);
+}
+
+/// Operation conformance for the HMCC/Zave `CorrectStabilize` operator:
+/// a successor's predecessor that is closer than the old head is adopted,
+/// queried for its successor list, then notified as the new successor.
+#[test]
+fn correct_stabilize_improved_predecessor_matches_spec() {
+    let dids = Layout::Even(5).dids();
+    assert_correct_stabilize_matches_spec(
+        dids[0],
+        &[dids[2]],
+        &[dids[3], dids[4], dids[0]],
+        Some(dids[1]),
+    );
+}
+
+/// Even when the successor has no predecessor yet, `CorrectStabilize` still
+/// notifies the current successor; the predecessor absence only suppresses the
+/// improved-successor query.
+#[test]
+fn correct_stabilize_without_predecessor_still_notifies_successor() {
+    let dids = Layout::Even(4).dids();
+    assert_correct_stabilize_matches_spec(dids[0], &[dids[1]], &[dids[2], dids[3]], None);
+}
+
+/// A successor reporting this node as its predecessor is not an improved
+/// successor and must not trigger a self-query.
+#[test]
+fn correct_stabilize_self_predecessor_does_not_query_self() {
+    let dids = Layout::Even(3).dids();
+    assert_correct_stabilize_matches_spec(dids[0], &[dids[1]], &[dids[2]], Some(dids[0]));
+}
+
+/// Empty TopoInfo is a no-op when the node has no successor to notify.
+#[test]
+fn correct_stabilize_empty_topo_without_successor_is_noop() {
+    let dids = Layout::Even(2).dids();
+    assert_correct_stabilize_matches_spec(dids[0], &[], &[], None);
 }

--- a/crates/core/src/tests/default/dht_convergence.rs
+++ b/crates/core/src/tests/default/dht_convergence.rs
@@ -480,6 +480,42 @@ fn correct_stabilize_unsorted_current_successors_matches_spec() {
     );
 }
 
+/// A predecessor that is farther than the old successor head may still be
+/// learned as a backup successor, but must not trigger the improved-successor
+/// query side effect.
+#[test]
+fn correct_stabilize_farther_predecessor_does_not_query() {
+    let dids = Layout::Even(6).dids();
+    assert_correct_stabilize_matches_spec(
+        dids[0],
+        &[dids[3], dids[1]],
+        &[dids[4], dids[5]],
+        Some(dids[2]),
+    );
+}
+
+/// Duplicate candidates and self references are ignored by `SuccessorSeq`,
+/// then the merged known set is truncated to the K nearest forward nodes.
+#[test]
+fn correct_stabilize_deduplicates_self_and_truncates_candidates() {
+    let dids = Layout::Even(8).dids();
+    assert_correct_stabilize_matches_spec(
+        dids[0],
+        &[dids[4], dids[0], dids[2], dids[2]],
+        &[dids[1], dids[3], dids[5], dids[0]],
+        Some(dids[2]),
+    );
+}
+
+/// `CorrectStabilize` imports all but the last entry from the successor's
+/// successor list. A close node in the last position must not be learned from
+/// this operation.
+#[test]
+fn correct_stabilize_ignores_last_topo_successor() {
+    let dids = Layout::Even(6).dids();
+    assert_correct_stabilize_matches_spec(dids[0], &[dids[4]], &[dids[5], dids[1]], None);
+}
+
 /// Empty TopoInfo is a no-op when the node has no successor to notify.
 #[test]
 fn correct_stabilize_empty_topo_without_successor_is_noop() {

--- a/crates/core/src/tests/default/dht_convergence.rs
+++ b/crates/core/src/tests/default/dht_convergence.rs
@@ -218,8 +218,9 @@ pub(super) mod spec {
         if pred == me {
             return None;
         }
-        match current.first() {
-            Some(&head) if dist(me, pred) >= dist(me, head) => None,
+        let old_head = current.iter().copied().min_by_key(|&did| dist(me, did));
+        match old_head {
+            Some(head) if dist(me, pred) >= dist(me, head) => None,
             _ => Some(pred),
         }
     }
@@ -464,6 +465,19 @@ fn correct_stabilize_without_predecessor_still_notifies_successor() {
 fn correct_stabilize_self_predecessor_does_not_query_self() {
     let dids = Layout::Even(3).dids();
     assert_correct_stabilize_matches_spec(dids[0], &[dids[1]], &[dids[2]], Some(dids[0]));
+}
+
+/// The production successor list is distance-sorted by `SuccessorSeq::update`;
+/// the spec mirror must not depend on the raw order of test fixtures.
+#[test]
+fn correct_stabilize_unsorted_current_successors_matches_spec() {
+    let dids = Layout::Even(6).dids();
+    assert_correct_stabilize_matches_spec(
+        dids[0],
+        &[dids[3], dids[1]],
+        &[dids[4], dids[5], dids[0]],
+        Some(dids[2]),
+    );
 }
 
 /// Empty TopoInfo is a no-op when the node has no successor to notify.

--- a/crates/core/src/tests/default/dht_schedule.rs
+++ b/crates/core/src/tests/default/dht_schedule.rs
@@ -47,8 +47,8 @@
 //! That is reproducible evidence that convergence is insensitive to delivery
 //! order for this regime (not a proof over all orders). It replaces the old
 //! wall-clock-bounded flaky `test_stabilization_final_dht`, whose 90s deadline
-//! asserted bounded-time convergence — unsound without `correct_stabilize`
-//! (experimental/off). A schedule that did NOT converge would be a reproducible
+//! asserted bounded-time convergence — unsound without `correct_stabilize`.
+//! A schedule that did NOT converge would be a reproducible
 //! bug, pinned to its exact delivery sequence.
 //! ====================================================================
 

--- a/crates/core/src/tests/default/dht_schedule.rs
+++ b/crates/core/src/tests/default/dht_schedule.rs
@@ -34,8 +34,10 @@
 //!       immediate predecessor always keeps it as successor #1 and so never
 //!       stops notifying it — but that is a separate argument, not monotonicity.)
 //!   (2) the finger table is part of the asserted state, and `fix_fingers`
-//!       mutates it through a 160-slot ROTATING index — sequential state, not a
-//!       single join.
+//!       mutates it through an N-slot ROTATING index — sequential state, not a
+//!       single join. Production uses 160 slots; this controlled schedule uses a
+//!       smaller configured table to keep the async integration test bounded
+//!       while still asserting the full configured DHT state.
 //! A rigorous all-orders theorem would have to model truncation + the finger
 //! actions; we do not claim it. Exhaustive interleaving exploration lives in the
 //! stage-2 Stateright model (on its abstraction).
@@ -54,16 +56,21 @@
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+    use std::fmt::Write as _;
     use std::sync::Arc;
 
     use rings_transport::connections::dummy_controlled;
 
     use crate::dht::Chord;
+    use crate::dht::PeerRing;
     use crate::ecc::SecretKey;
     use crate::inspect::DHTInspect;
+    use crate::session::SessionSk;
+    use crate::storage::MemStorage;
     use crate::swarm::Swarm;
-    use crate::tests::default::gen_pure_dht;
-    use crate::tests::default::prepare_node;
+    use crate::swarm::SwarmBuilder;
+    use crate::tests::default::Node;
     use crate::tests::manually_establish_connection;
 
     /// The six fixed clustered production DIDs (= `Layout::Clustered`): the
@@ -78,11 +85,247 @@ mod tests {
         "e1d7f24e2b725df077627fc0337b9c53b37ce594ca84fccd0f36dc58423a0ed2",
     ];
 
-    /// Stabilize rounds before giving up. Generous: these schedules reach the
-    /// fixpoint far inside this bound; tripping it is a real non-convergence.
-    const MAX_ROUNDS: usize = 400;
+    /// The schedule still drives the production async DHT path and asserts the
+    /// full configured DHT state; using 16 finger slots keeps the test focused on
+    /// topology/finger convergence instead of spending most time rotating 160
+    /// production slots.
+    const SCHEDULE_FINGER_TABLE_SIZE: usize = 16;
+    /// Stabilize rounds before giving up. With 16 configured finger slots these
+    /// schedules should reach the fixpoint far inside this bound; tripping it is
+    /// a reproducible non-convergence.
+    const MAX_ROUNDS: usize = 120;
     /// Guard against a routing self-route delivery loop (non-termination).
     const MAX_DELIVERIES: usize = 2_000_000;
+    /// Guard against a single stabilization round that keeps producing messages
+    /// forever.
+    const MAX_DELIVERIES_PER_ROUND: usize = 100_000;
+    /// Guard against a schedule that is still delivering messages but no longer
+    /// changes any DHT state.
+    const MAX_STAGNANT_ROUNDS: usize = 20;
+    /// Number of recent round summaries retained for failure diagnostics.
+    const TRACE_WINDOW: usize = 16;
+
+    struct ControlledDeliveryGuard;
+
+    impl ControlledDeliveryGuard {
+        fn enable() -> Self {
+            dummy_controlled::enable(true);
+            Self
+        }
+    }
+
+    impl Drop for ControlledDeliveryGuard {
+        fn drop(&mut self) {
+            dummy_controlled::enable(false);
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct DrainStats {
+        deliveries: usize,
+        dropped: usize,
+        max_pending: usize,
+    }
+
+    #[derive(Debug)]
+    struct RoundTrace {
+        phase: String,
+        deliveries: usize,
+        dropped: usize,
+        total_delivered: usize,
+        max_pending: usize,
+        changed: bool,
+        topology_matches: usize,
+        full_matches: usize,
+        finger_known_slots: Vec<u64>,
+        first_mismatch: String,
+    }
+
+    #[derive(Debug, Default)]
+    struct ScheduleDiagnostics {
+        traces: VecDeque<RoundTrace>,
+    }
+
+    impl ScheduleDiagnostics {
+        fn push(&mut self, trace: RoundTrace) {
+            if self.traces.len() == TRACE_WINDOW {
+                self.traces.pop_front();
+            }
+            self.traces.push_back(trace);
+        }
+
+        fn render(&self, actual: &[DHTInspect], expected: &[DHTInspect]) -> String {
+            let mut out = String::new();
+            let _ = writeln!(
+                out,
+                "finger_table_size={SCHEDULE_FINGER_TABLE_SIZE}, max_rounds={MAX_ROUNDS}, \
+                 max_deliveries={MAX_DELIVERIES}, max_deliveries_per_round={MAX_DELIVERIES_PER_ROUND}"
+            );
+            let _ = writeln!(out, "recent rounds:");
+            for trace in &self.traces {
+                let _ = writeln!(
+                    out,
+                    "  {phase}: delivered={delivered} dropped={dropped} total={total} \
+                     max_pending={max_pending} changed={changed} topology={topology}/{nodes} \
+                     full={full}/{nodes} finger_known_slots={finger:?} first_mismatch={mismatch}",
+                    phase = trace.phase,
+                    delivered = trace.deliveries,
+                    dropped = trace.dropped,
+                    total = trace.total_delivered,
+                    max_pending = trace.max_pending,
+                    changed = trace.changed,
+                    topology = trace.topology_matches,
+                    nodes = expected.len(),
+                    full = trace.full_matches,
+                    finger = trace.finger_known_slots,
+                    mismatch = trace.first_mismatch,
+                );
+            }
+            let _ = writeln!(out, "current first mismatch:");
+            let _ = write!(out, "{}", describe_first_mismatch(actual, expected));
+            let _ = writeln!(out, "current topology mismatches:");
+            let _ = write!(out, "{}", describe_topology_mismatches(actual, expected));
+            out
+        }
+    }
+
+    fn inspect_all(swarms: &[Arc<Swarm>]) -> Vec<DHTInspect> {
+        swarms
+            .iter()
+            .map(|swarm| DHTInspect::inspect(&swarm.dht()))
+            .collect()
+    }
+
+    fn topology_matches(actual: &DHTInspect, expected: &DHTInspect) -> bool {
+        actual.successors == expected.successors && actual.predecessor == expected.predecessor
+    }
+
+    fn known_finger_slots(dht: &DHTInspect) -> u64 {
+        dht.finger_table
+            .iter()
+            .filter(|(did, _, _)| did.is_some())
+            .map(|(_, start, end)| end - start + 1)
+            .sum()
+    }
+
+    fn short_did(did: &str) -> &str {
+        did.get(..10).unwrap_or(did)
+    }
+
+    fn mismatch_summary(actual: &[DHTInspect], expected: &[DHTInspect]) -> String {
+        actual
+            .iter()
+            .zip(expected)
+            .enumerate()
+            .find(|(_, (act, exp))| act != exp)
+            .map(|(i, (act, exp))| {
+                let topic = if !topology_matches(act, exp) {
+                    "topology"
+                } else {
+                    "finger"
+                };
+                format!("node{i}/{}:{topic}", short_did(&act.did))
+            })
+            .unwrap_or_else(|| "none".to_string())
+    }
+
+    fn describe_first_mismatch(actual: &[DHTInspect], expected: &[DHTInspect]) -> String {
+        for (i, (act, exp)) in actual.iter().zip(expected).enumerate() {
+            if act == exp {
+                continue;
+            }
+            return format!(
+                "node{i} {}\nactual:   successors={:?} predecessor={:?} finger={:?}\n\
+                 expected: successors={:?} predecessor={:?} finger={:?}\n",
+                act.did,
+                act.successors,
+                act.predecessor,
+                act.finger_table,
+                exp.successors,
+                exp.predecessor,
+                exp.finger_table,
+            );
+        }
+        "none\n".to_string()
+    }
+
+    fn describe_topology_mismatches(actual: &[DHTInspect], expected: &[DHTInspect]) -> String {
+        let mut out = String::new();
+        for (i, (act, exp)) in actual.iter().zip(expected).enumerate() {
+            if topology_matches(act, exp) {
+                continue;
+            }
+            let _ = writeln!(
+                out,
+                "node{i} {} actual_succ={:?} actual_pred={:?} expected_succ={:?} expected_pred={:?}",
+                short_did(&act.did),
+                act.successors,
+                act.predecessor,
+                exp.successors,
+                exp.predecessor,
+            );
+        }
+        if out.is_empty() {
+            out.push_str("none\n");
+        }
+        out
+    }
+
+    fn round_trace(
+        phase: impl Into<String>,
+        stats: DrainStats,
+        total_delivered: usize,
+        before: &[DHTInspect],
+        actual: &[DHTInspect],
+        expected: &[DHTInspect],
+    ) -> RoundTrace {
+        RoundTrace {
+            phase: phase.into(),
+            deliveries: stats.deliveries,
+            dropped: stats.dropped,
+            total_delivered,
+            max_pending: stats.max_pending,
+            changed: before != actual,
+            topology_matches: actual
+                .iter()
+                .zip(expected)
+                .filter(|(act, exp)| topology_matches(act, exp))
+                .count(),
+            full_matches: actual
+                .iter()
+                .zip(expected)
+                .filter(|(act, exp)| act == exp)
+                .count(),
+            finger_known_slots: actual.iter().map(known_finger_slots).collect(),
+            first_mismatch: mismatch_summary(actual, expected),
+        }
+    }
+
+    async fn prepare_schedule_node(key: SecretKey) -> Node {
+        let stun = "stun://stun.l.google.com:19302";
+        let storage = Box::new(MemStorage::new());
+        let session_sk = SessionSk::new_with_seckey(&key).unwrap();
+        let swarm = Arc::new(
+            SwarmBuilder::new(0, stun, storage, session_sk)
+                .dht_finger_table_size(SCHEDULE_FINGER_TABLE_SIZE)
+                .build(),
+        );
+
+        println!("key: {:?}", key.to_string());
+        println!("did: {:?}", swarm.did());
+
+        Node::new(swarm)
+    }
+
+    fn gen_schedule_dht(did: crate::dht::Did) -> PeerRing {
+        let storage = Box::new(MemStorage::new());
+        PeerRing::new_with_storage_and_finger_table_size(
+            did,
+            3,
+            storage,
+            SCHEDULE_FINGER_TABLE_SIZE,
+        )
+    }
 
     /// The unique converged DHT each node must reach, built via the production
     /// join/notify path over the full DID set — the same fixpoint checked by
@@ -91,7 +334,7 @@ mod tests {
         swarms
             .iter()
             .map(|swarm| {
-                let dht = gen_pure_dht(swarm.did());
+                let dht = gen_schedule_dht(swarm.did());
                 for other in swarms {
                     if dht.did != other.did() {
                         dht.join(other.did()).unwrap();
@@ -103,25 +346,31 @@ mod tests {
             .collect()
     }
 
-    fn converged(swarms: &[Arc<Swarm>], expected: &[DHTInspect]) -> bool {
-        swarms
-            .iter()
-            .zip(expected)
-            .all(|(sw, exp)| &DHTInspect::inspect(&sw.dht()) == exp)
-    }
-
     /// Drain the controlled queue to quiescence, choosing the next index via
     /// `pick` (the delivery-order strategy under test).
-    async fn drain(pick: fn(usize) -> usize, delivered: &mut usize) {
+    async fn drain(pick: fn(usize) -> usize, delivered: &mut usize) -> DrainStats {
+        let mut stats = DrainStats::default();
         while dummy_controlled::pending() > 0 {
-            let idx = pick(dummy_controlled::pending());
-            dummy_controlled::deliver(idx).await;
+            let pending = dummy_controlled::pending();
+            stats.max_pending = stats.max_pending.max(pending);
+            let idx = pick(pending);
+            if !dummy_controlled::deliver(idx).await {
+                stats.dropped += 1;
+            }
             *delivered += 1;
+            stats.deliveries += 1;
             assert!(
                 *delivered < MAX_DELIVERIES,
-                "runaway delivery — likely a routing self-route loop"
+                "runaway delivery - likely a routing self-route loop"
+            );
+            assert!(
+                stats.deliveries < MAX_DELIVERIES_PER_ROUND,
+                "round delivery budget exceeded: delivered {} in one drain, max_pending {}",
+                stats.deliveries,
+                stats.max_pending
             );
         }
+        stats
     }
 
     /// Drive the full 6-node bootstrap + stabilization under ONE controlled
@@ -132,38 +381,74 @@ mod tests {
     async fn run_schedule(pick: fn(usize) -> usize) {
         let mut nodes = vec![];
         for k in KEYS {
-            nodes.push(prepare_node(SecretKey::try_from(k).unwrap()).await);
+            nodes.push(prepare_schedule_node(SecretKey::try_from(k).unwrap()).await);
         }
         let swarms: Vec<Arc<Swarm>> = nodes.iter().map(|n| n.swarm.clone()).collect();
         let expected = expected_dhts(&swarms);
+        let mut diagnostics = ScheduleDiagnostics::default();
 
-        dummy_controlled::enable(true);
+        let _controlled = ControlledDeliveryGuard::enable();
 
-        // Star bootstrap — queues each connection's setup events.
+        // Star bootstrap - queues each connection's setup events.
         for sw in swarms.iter().skip(1) {
             manually_establish_connection(&swarms[0], sw).await;
         }
 
         let mut delivered = 0usize;
-        drain(pick, &mut delivered).await; // process bootstrap (DataChannelOpen -> join_dht -> ...)
+        let before_bootstrap = inspect_all(&swarms);
+        let bootstrap_stats = drain(pick, &mut delivered).await;
+        let mut actual = inspect_all(&swarms);
+        diagnostics.push(round_trace(
+            "bootstrap",
+            bootstrap_stats,
+            delivered,
+            &before_bootstrap,
+            &actual,
+            &expected,
+        ));
 
         let mut ok = false;
-        for _ in 0..MAX_ROUNDS {
+        let mut stagnant_rounds = 0usize;
+        for round in 1..=MAX_ROUNDS {
+            let before = actual.clone();
             for sw in &swarms {
                 let _ = sw.stabilizer().stabilize().await;
             }
-            drain(pick, &mut delivered).await;
-            if converged(&swarms, &expected) {
+            let stats = drain(pick, &mut delivered).await;
+            actual = inspect_all(&swarms);
+            let changed = before != actual;
+            diagnostics.push(round_trace(
+                format!("round{round}"),
+                stats,
+                delivered,
+                &before,
+                &actual,
+                &expected,
+            ));
+
+            if actual == expected {
                 ok = true;
                 break;
             }
+            if changed {
+                stagnant_rounds = 0;
+            } else {
+                stagnant_rounds += 1;
+                assert!(
+                    stagnant_rounds < MAX_STAGNANT_ROUNDS,
+                    "schedule made no DHT progress for {stagnant_rounds} rounds\n{}",
+                    diagnostics.render(&actual, &expected)
+                );
+            }
         }
 
-        dummy_controlled::enable(false);
-
-        assert!(ok, "did not converge under the chosen delivery schedule");
-        for (i, (sw, exp)) in swarms.iter().zip(&expected).enumerate() {
-            pretty_assertions::assert_eq!(DHTInspect::inspect(&sw.dht()), exp.clone(), "node{i}");
+        assert!(
+            ok,
+            "did not converge under the chosen delivery schedule\n{}",
+            diagnostics.render(&actual, &expected)
+        );
+        for (i, (act, exp)) in actual.iter().zip(&expected).enumerate() {
+            pretty_assertions::assert_eq!(act, exp, "node{i}");
         }
 
         // Keep the monitoring receivers alive to the end (dropping a Node makes

--- a/crates/core/src/tests/default/test_message_handler.rs
+++ b/crates/core/src/tests/default/test_message_handler.rs
@@ -6,10 +6,16 @@ use std::sync::Arc;
 use rings_transport::connections::dummy_controlled;
 use rings_transport::core::transport::WebrtcConnectionState;
 use tokio::time::sleep;
+#[cfg(feature = "dummy")]
+use tokio::time::timeout;
 use tokio::time::Duration;
 
 use crate::dht::successor::SuccessorReader;
 use crate::dht::vnode::VirtualNode;
+#[cfg(feature = "dummy")]
+use crate::dht::PeerRingAction;
+#[cfg(feature = "dummy")]
+use crate::dht::PeerRingRemoteAction;
 use crate::ecc::tests::gen_ordered_keys;
 use crate::ecc::SecretKey;
 use crate::error::Result;
@@ -78,6 +84,45 @@ async fn test_join_dht_keeps_local_join_when_convergence_send_fails() -> Result<
         "join must not fail when follow-up convergence sends fail: {join_result:?}"
     );
     assert!(node1.dht().successors().list()?.contains(&node2.did()));
+
+    Ok(())
+}
+
+#[cfg(feature = "dummy")]
+#[tokio::test]
+async fn test_handle_dht_notify_remote_action_sends_predecessor_to_target() -> Result<()> {
+    dummy_controlled::enable(true);
+
+    let keys = gen_ordered_keys(3);
+    let node1 = prepare_node(keys[0]).await;
+    let node2 = prepare_node(keys[1]).await;
+    let node3 = prepare_node(keys[2]).await;
+    manually_establish_connection(&node1.swarm, &node2.swarm).await;
+
+    // Clear queued connection-open callbacks so this test exercises only the
+    // explicit handler action below, not automatic join/stabilization traffic.
+    dummy_controlled::enable(false);
+
+    let handler = MessageHandler::new(node1.swarm.transport.clone(), Arc::new(NoopCallback));
+    handler
+        .handle_dht_events(&PeerRingAction::RemoteAction(
+            node2.did(),
+            PeerRingRemoteAction::Notify(node3.did()),
+        ))
+        .await?;
+
+    let payload = timeout(Duration::from_secs(1), node2.listen_once())
+        .await
+        .expect("notify target should receive a message")
+        .expect("notify target message stream should stay open");
+
+    assert_eq!(payload.transaction.destination, node2.did());
+    match payload.transaction.data::<Message>()? {
+        Message::NotifyPredecessorSend(message::NotifyPredecessorSend { did }) => {
+            assert_eq!(did, node3.did());
+        }
+        other => panic!("expected NotifyPredecessorSend, got {other:?}"),
+    }
 
     Ok(())
 }

--- a/crates/core/src/tests/default/test_message_handler.rs
+++ b/crates/core/src/tests/default/test_message_handler.rs
@@ -1,5 +1,9 @@
 use std::str::FromStr;
+#[cfg(feature = "dummy")]
+use std::sync::Arc;
 
+#[cfg(feature = "dummy")]
+use rings_transport::connections::dummy_controlled;
 use rings_transport::core::transport::WebrtcConnectionState;
 use tokio::time::sleep;
 use tokio::time::Duration;
@@ -14,9 +18,19 @@ use crate::message::Encoder;
 use crate::message::FindSuccessorReportHandler;
 use crate::message::FindSuccessorThen;
 use crate::message::Message;
+#[cfg(feature = "dummy")]
+use crate::message::MessageHandler;
 use crate::prelude::vnode::VNodeOperation;
+#[cfg(feature = "dummy")]
+use crate::swarm::callback::SwarmCallback;
 use crate::tests::default::prepare_node;
 use crate::tests::manually_establish_connection;
+
+#[cfg(feature = "dummy")]
+struct NoopCallback;
+
+#[cfg(feature = "dummy")]
+impl SwarmCallback for NoopCallback {}
 
 #[tokio::test]
 async fn test_handle_join() -> Result<()> {
@@ -31,6 +45,40 @@ async fn test_handle_join() -> Result<()> {
         .successors()
         .list()?
         .contains(&key2.address().into()));
+    Ok(())
+}
+
+#[cfg(feature = "dummy")]
+#[tokio::test]
+async fn test_join_dht_keeps_local_join_when_convergence_send_fails() -> Result<()> {
+    dummy_controlled::enable(true);
+    dummy_controlled::set_max_message_size(0);
+
+    let key1 = SecretKey::random();
+    let key2 = SecretKey::random();
+    let node1 = prepare_node(key1).await;
+    let node2 = prepare_node(key2).await;
+    manually_establish_connection(&node1.swarm, &node2.swarm).await;
+
+    assert!(
+        node1.dht().successors().list()?.is_empty(),
+        "controlled delivery should prevent automatic DataChannelOpen join"
+    );
+
+    dummy_controlled::enable(false);
+    dummy_controlled::set_max_message_size(1);
+
+    let handler = MessageHandler::new(node1.swarm.transport.clone(), Arc::new(NoopCallback));
+    let join_result = handler.join_dht(node2.did()).await;
+
+    dummy_controlled::set_max_message_size(0);
+
+    assert!(
+        join_result.is_ok(),
+        "join must not fail when follow-up convergence sends fail: {join_result:?}"
+    );
+    assert!(node1.dht().successors().list()?.contains(&node2.did()));
+
     Ok(())
 }
 

--- a/crates/core/src/tests/default/test_message_handler.rs
+++ b/crates/core/src/tests/default/test_message_handler.rs
@@ -147,8 +147,11 @@ async fn test_handle_connect_node() -> Result<()> {
         WebrtcConnectionState::Connected,
     );
 
-    // node1.dht() send msg to node2.dht() ask for connecting node3.dht()
-    node1.swarm.connect(node3.did()).await.unwrap();
+    // node1 may already have connected node3 while syncing successor-list
+    // candidates. If not, ask DHT to connect it through node2.
+    if node1.swarm.transport.get_connection(node3.did()).is_none() {
+        node1.swarm.connect(node3.did()).await.unwrap();
+    }
     sleep(Duration::from_millis(10000)).await;
 
     let connection_1_to_3 = node1.swarm.transport.get_connection(node3.did());

--- a/crates/transport/src/connections/dummy/mod.rs
+++ b/crates/transport/src/connections/dummy/mod.rs
@@ -185,7 +185,7 @@ impl DummyConnection {
             Event::DataChannelOpen => self.callback.on_data_channel_open().await,
             Event::DataChannelClose => self.callback.on_data_channel_close().await,
             Event::Message(data) => {
-                if SEND_MESSAGE_DELAY {
+                if SEND_MESSAGE_DELAY && !CONTROLLED.with(|c| c.get()) {
                     random_delay().await;
                 }
                 self.callback.on_message(&data).await

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "RND <dev@ringsnetwork.io>"
   ],
   "description": "Rings is a structured peer-to-peer network implementation using WebRTC, Chord algorithm, and full WebAssembly (WASM) support.\n",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "GPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Fixes #388.

- make the HMCC/Zave CorrectChord join and stabilize paths the default instead of gating them behind `experimental`
- keep join-time convergence messages best-effort so transient send failures do not suppress the application-level `Connected` event
- fix `RemoteAction::Notify` delivery so the predecessor payload is sent to the remote target
- align `PeerRing::stabilize` with the `CorrectStabilize` operation, including empty successor info, improved-predecessor query behavior, and successor notify behavior
- ensure stabilization-learned successor/predecessor candidates become live transport connections before direct topology/notify maintenance depends on them
- expose configurable DHT finger-table size while keeping the production default at 160 slots and clamping out-of-range sizes for 160-bit `Did`
- keep the full async FIFO/LIFO DHT schedule test, but run it with a 16-slot configured finger table and actionable convergence diagnostics
- remove random dummy message delay while controlled delivery is enabled, so schedule tests measure deterministic protocol progress instead of wall-clock jitter
- add TLA+-style `CorrectStabilize` comments plus Rust spec mirror tests for the default path
- add stronger successor-list validation for order independence, duplicate/self filtering, truncation to K nearest successors, and ring wrap-around ordering
- add a dummy-transport regression test proving `join_dht` keeps the local join when follow-up convergence sends fail
- add a direct handler regression test for `RemoteAction(target, Notify(pred))` delivery direction and payload semantics
- note that `CorrectStabilize` now emits `NotifyPredecessor` for the current successor each stabilize round when the head is not self, matching the spec while increasing steady-state notify traffic versus the old default path
- bump the Rust workspace and npm package version to `0.10.0`

## Checks

- `cargo +nightly fmt --all`
- `cargo +nightly fmt --all --check`
- `cargo check -p rings-core --features dummy`
- `cargo check -p rings-transport --features dummy`
- `cargo clippy --all --tests -- -D warnings`
- `cargo clippy -p rings-core --features dummy --tests -- -D warnings`
- `cargo clippy -p rings-core --features wasm --no-deps --no-default-features --target=wasm32-unknown-unknown --tests -- -D warnings`
- `cargo test -p rings-core --features dummy successor`
- `cargo test -p rings-core --features dummy dht_convergence`
- `cargo test -p rings-core --features dummy dht_convergence -- --test-threads=1`
- `cargo test -p rings-core --features dummy correct_chord`
- `cargo test -p rings-core --features dummy test_finger_table_size_bounds -- --test-threads=1`
- `cargo test -p rings-core --features dummy test_handle_dht_notify_remote_action_sends_predecessor_to_target -- --test-threads=1`
- `cargo test -p rings-core --features dummy test_join_dht_keeps_local_join_when_convergence_send_fails -- --test-threads=1`
- `cargo test -p rings-core --features dummy test_stabilization -- --test-threads=1`
- `cargo test -p rings-core --features dummy test_handle_join -- --test-threads=1`
- `cargo test -p rings-core --features dummy dht_stateright -- --test-threads=1`
- `cargo test -p rings-core --features dummy dht_trace_replay`
- `cargo test -p rings-core --features dummy dht_schedule -- --test-threads=1`
- `cargo test -p rings-core --features dummy test_message_handler -- --test-threads=1`
- `cargo test -p rings-core --features dummy message::handlers::connection::tests -- --test-threads=1`
- `cargo test -p rings-core --features dummy message::handlers::stabilization::test -- --test-threads=1`
- `cargo test -p rings-core --features dummy tests::default::test_connection -- --test-threads=1`
- `cargo test -p rings-core --features dummy -- --test-threads=1`
