### PR TITLE
Make DHT storage and topology algebraic

### DIFF
--- a/crates/core/src/algebra.rs
+++ b/crates/core/src/algebra.rs
@@ -28,6 +28,8 @@
 //! - [`Field`] is a commutative ring whose non-zero elements have inverses.
 //! - [`Module`] is a right scalar action of a commutative ring on an abelian
 //!   group.
+//! - [`JoinSemilattice`] is the CRDT merge structure used by replicated DHT
+//!   state.
 //!
 //! ## Rings DHT
 //!
@@ -65,6 +67,24 @@ use std::ops::Add;
 use std::ops::Mul;
 use std::ops::Neg;
 use std::ops::Sub;
+
+/// Join-semilattice for state-based CRDT merge.
+///
+/// `join` returns the least upper bound of two states from the same carrier.
+/// Implementors must make this operation inflationary with respect to the
+/// carrier's partial order; because Rust does not expose that order here, the
+/// obligation is witnessed through the idempotence, commutativity, and
+/// associativity laws below.
+///
+/// Law: `a.join(a) == a`.
+///
+/// Law: `a.join(b) == b.join(a)`.
+///
+/// Law: `a.join(b).join(c) == a.join(b.join(c))`.
+pub trait JoinSemilattice: Sized {
+    /// Return the least upper bound of `self` and `other`.
+    fn join(self, other: Self) -> Self;
+}
 
 /// Additive identity for an additive carrier.
 ///
@@ -192,6 +212,56 @@ where T: AbelianGroup + Clone + Eq + Debug {
             }
         }
     }
+}
+
+/// Assert join-semilattice laws for a representative finite sample.
+///
+/// This helper checks the state-based CRDT merge laws that imply strong
+/// eventual consistency for replicas that observe the same set of deltas in any
+/// order, with any duplication.
+#[cfg(test)]
+pub fn assert_join_semilattice_laws<T>(values: &[T])
+where T: JoinSemilattice + Clone + Eq + Debug {
+    for a in values {
+        assert_eq!(a.clone().join(a.clone()), *a);
+
+        for b in values {
+            assert_eq!(a.clone().join(b.clone()), b.clone().join(a.clone()));
+
+            for c in values {
+                let lhs = a.clone().join(b.clone()).join(c.clone());
+                let rhs = a.clone().join(b.clone().join(c.clone()));
+                assert_eq!(lhs, rhs);
+            }
+        }
+    }
+}
+
+/// Assert strong eventual consistency for one base state and a finite delta set.
+///
+/// The witness applies the same deltas in forward, reverse, and duplicated
+/// schedules. A lawful join-semilattice must materialize the same least upper
+/// bound for each schedule.
+#[cfg(test)]
+pub fn assert_strong_eventual_consistency<T>(base: T, deltas: &[T])
+where T: JoinSemilattice + Clone + Eq + Debug {
+    let forward = deltas
+        .iter()
+        .cloned()
+        .fold(base.clone(), JoinSemilattice::join);
+    let reverse = deltas
+        .iter()
+        .rev()
+        .cloned()
+        .fold(base.clone(), JoinSemilattice::join);
+    let duplicated = deltas
+        .iter()
+        .cloned()
+        .chain(deltas.iter().cloned())
+        .fold(base, JoinSemilattice::join);
+
+    assert_eq!(forward, reverse);
+    assert_eq!(forward, duplicated);
 }
 
 /// Assert the commutative-ring laws for a representative finite sample.

--- a/crates/core/src/algebra.rs
+++ b/crates/core/src/algebra.rs
@@ -72,9 +72,14 @@ use std::ops::Sub;
 ///
 /// `join` returns the least upper bound of two states from the same carrier.
 /// Implementors must make this operation inflationary with respect to the
-/// carrier's partial order; because Rust does not expose that order here, the
-/// obligation is witnessed through the idempotence, commutativity, and
-/// associativity laws below.
+/// carrier's induced partial order `a <= b iff a.join(b) == b`; because Rust
+/// does not expose that order here, the obligation is witnessed through the
+/// idempotence, commutativity, and associativity laws below.
+///
+/// The operation takes both arguments by value to model a pure state transition
+/// into a canonical least upper bound. Implementations that need an in-place
+/// merge can provide that adapter separately and keep this law-facing
+/// signature as the common algebraic surface.
 ///
 /// Law: `a.join(a) == a`.
 ///
@@ -152,6 +157,8 @@ pub trait CommutativeRing: AbelianGroup + Mul<Self, Output = Self> + One {}
 /// A field is a commutative ring whose non-zero values form a multiplicative
 /// group. `try_inverse` is fallible only because zero has no multiplicative
 /// inverse; returning `None` for a non-zero value violates the trait law.
+///
+/// Law: [`Zero::zero`] is distinct from [`One::one`].
 ///
 /// Law: non-zero values have a multiplicative inverse.
 pub trait Field: CommutativeRing {
@@ -300,12 +307,14 @@ where T: CommutativeRing + Clone + Eq + Debug {
 
 /// Assert the field inverse laws for a representative finite sample.
 ///
-/// This helper first checks the commutative-ring laws. It then checks that zero
-/// has no inverse and every sampled non-zero value has a two-sided inverse.
+/// This helper first checks the commutative-ring laws and the field
+/// non-degeneracy law `zero() != one()`. It then checks that zero has no inverse
+/// and every sampled non-zero value has a two-sided inverse.
 #[cfg(test)]
 pub fn assert_field_laws<T>(values: &[T])
 where T: Field + Clone + Eq + Debug {
     assert_commutative_ring_laws(values);
+    assert_ne!(T::zero(), T::one());
 
     for a in values {
         if a.is_zero() {

--- a/crates/core/src/dht/chord.rs
+++ b/crates/core/src/dht/chord.rs
@@ -353,13 +353,13 @@ impl PeerRing {
     /// value and `incoming` when a previous value exists; otherwise it is
     /// `incoming` normalized for storage.
     pub(crate) async fn join_storage_entry(&self, key: Did, incoming: Entry) -> Result<Entry> {
-        let incoming = incoming.into_storage_entry();
+        let incoming = incoming.try_into_storage_entry()?;
         let stored = if let Some(local) = self.storage.get(&key.to_string()).await? {
             local.join(incoming)?
         } else {
             incoming
         }
-        .into_storage_entry();
+        .try_into_storage_entry()?;
         self.storage.put(&key.to_string(), &stored).await?;
         Ok(stored)
     }
@@ -540,7 +540,7 @@ impl<const REDUNDANT: u16> ChordStorage<PeerRingAction, REDUNDANT> for PeerRing 
                         Some(this) => this,
                         None => op.clone().gen_default_entry()?,
                     };
-                    let entry = this.operate(op.clone())?;
+                    let entry = this.operate(op.clone(), self.did)?;
                     self.join_storage_entry(entry_key, entry).await?;
                     Ok(PeerRingAction::None)
                 }

--- a/crates/core/src/dht/chord.rs
+++ b/crates/core/src/dht/chord.rs
@@ -18,6 +18,7 @@ use super::entry::PlacementMiss;
 use super::finger::DEFAULT_FINGER_TABLE_SIZE;
 use super::successor::SuccessorSeq;
 use super::topology;
+use super::topology::FindSuccessorStep;
 use super::topology::TopologyAction;
 use super::topology::TopologyEvent;
 use super::topology::TopologyState;
@@ -118,7 +119,12 @@ pub enum RemoteAction {
     FindSuccessorForConnect(Did),
 
     /// Need `did_a` to find `did_b` then send back with `for finger table fixing` flag.
-    FindSuccessorForFix(Did),
+    FindSuccessorForFix {
+        /// DID whose successor should populate the finger slot.
+        did: Did,
+        /// Finger slot that should be updated by the report.
+        index: usize,
+    },
 
     /// Fetch successor_list from successor
     QueryForSuccessorList,
@@ -257,22 +263,12 @@ impl PeerRing {
     /// Also remove it from successor sequence.
     /// If successor_seq become empty, try setting the closest node to it.
     pub fn remove(&self, did: Did) -> Result<()> {
-        let mut finger = self.lock_finger()?;
-        let successor = self.successors();
-        let mut predecessor = self.lock_predecessor()?;
-        if let Some(pid) = *predecessor {
-            if pid == did {
-                *predecessor = None;
-            }
-        }
-        finger.remove(did);
-        successor.remove(did)?;
-        if successor.is_empty()? {
-            if let Some(x) = finger.first() {
-                successor.update(x)?;
-            }
-        }
-        Ok(())
+        let next = topology::step(
+            &self.topology_state()?,
+            TopologyEvent::Remove { peer: did },
+            self.successors().capacity(),
+        );
+        self.interpret_topology_state(&next.state)
     }
 
     /// Calculate bias of the Did on the ring.
@@ -281,20 +277,74 @@ impl PeerRing {
     }
 
     fn topology_state(&self) -> Result<TopologyState> {
+        let finger = self.lock_finger()?;
         Ok(TopologyState::new(
             self.did,
             self.successors().list()?,
             *self.lock_predecessor()?,
+            finger.list().clone(),
+            finger.fix_finger_index(),
         ))
     }
 
-    fn replace_successors(&self, next: &[Did]) -> Result<()> {
+    fn interpret_topology_state(&self, next: &TopologyState) -> Result<()> {
         let successors = self.successors();
         for did in successors.list()? {
             successors.remove(did)?;
         }
-        successors.extend(next)?;
+        successors.extend(&next.successors)?;
+        *self.lock_predecessor()? = next.predecessor;
+        self.lock_finger()?
+            .replace_state(&next.fingers, next.fix_finger_index);
         Ok(())
+    }
+
+    fn topology_action(&self, action: TopologyAction) -> PeerRingAction {
+        match action {
+            TopologyAction::FindSuccessorForConnect { next, did } => {
+                PeerRingAction::RemoteAction(next, RemoteAction::FindSuccessorForConnect(did))
+            }
+            TopologyAction::FindSuccessorForFix { next, did, index } => {
+                PeerRingAction::RemoteAction(next, RemoteAction::FindSuccessorForFix { did, index })
+            }
+            TopologyAction::QuerySuccessorList(did) => {
+                PeerRingAction::RemoteAction(did, RemoteAction::QueryForSuccessorList)
+            }
+            TopologyAction::Notify(did) => {
+                PeerRingAction::RemoteAction(did, RemoteAction::Notify(self.did))
+            }
+        }
+    }
+
+    fn topology_leaf_actions(&self, actions: Vec<TopologyAction>) -> PeerRingAction {
+        let mut actions = actions
+            .into_iter()
+            .map(|action| self.topology_action(action))
+            .collect::<Vec<_>>();
+        match actions.len() {
+            0 => PeerRingAction::None,
+            1 => actions.pop().unwrap_or(PeerRingAction::None),
+            _ => PeerRingAction::MultiActions(actions),
+        }
+    }
+
+    fn topology_multi_actions(&self, actions: Vec<TopologyAction>) -> PeerRingAction {
+        PeerRingAction::MultiActions(
+            actions
+                .into_iter()
+                .map(|action| self.topology_action(action))
+                .collect(),
+        )
+    }
+
+    /// Apply a reported finger successor through the pure topology transition.
+    pub(crate) fn apply_fixed_finger(&self, index: usize, successor: Did) -> Result<()> {
+        let next = topology::step(
+            &self.topology_state()?,
+            TopologyEvent::ApplyFinger { index, successor },
+            self.successors().capacity(),
+        );
+        self.interpret_topology_state(&next.state)
     }
 
     /// Join an incoming replicated entry delta into local storage.
@@ -324,47 +374,38 @@ impl Chord<PeerRingAction> for PeerRing {
     /// The caller will send it to the node identified by `did`, and let the node find
     /// the successor of current node and make current node connect to that successor.
     fn join(&self, did: Did) -> Result<PeerRingAction> {
-        if did == self.did {
-            return Ok(PeerRingAction::None);
-        }
-
-        let mut finger = self.lock_finger()?;
-
-        finger.join(did);
-        // Always try update
-        self.successors().update(did)?;
-        Ok(PeerRingAction::RemoteAction(
-            did,
-            RemoteAction::FindSuccessorForConnect(self.did),
-        ))
+        let next = topology::step(
+            &self.topology_state()?,
+            TopologyEvent::Join { peer: did },
+            self.successors().capacity(),
+        );
+        self.interpret_topology_state(&next.state)?;
+        Ok(self.topology_leaf_actions(next.actions))
     }
 
     /// Find the successor of a Did.
     /// May return a remote action for the successor is recorded in another node.
     fn find_successor(&self, did: Did) -> Result<PeerRingAction> {
-        let successor = self.successors();
-        let finger = self.lock_finger()?;
-
-        let succ = {
-            if successor.is_empty()? || self.bias(did) <= self.bias(successor.min()?) {
-                // If the did is closer to self than successor, return successor as the
-                // successor of that did.
-                Ok(PeerRingAction::Some(successor.min()?))
-            } else {
-                // Otherwise, find the closest preceding node and ask it to find the successor.
-                let closest_predecessor = finger.closest_predecessor(did);
-                Ok(PeerRingAction::RemoteAction(
-                    closest_predecessor,
-                    RemoteAction::FindSuccessor(did),
-                ))
+        let state = self.topology_state()?;
+        let succ = match topology::find_successor(&state, did) {
+            FindSuccessorStep::Local(successor) => {
+                // If the DID is closer to self than the successor head, return
+                // that head as the successor. With an empty successor list, the
+                // pure topology model returns `self.did`, matching
+                // `SuccessorSeq::min`.
+                Ok(PeerRingAction::Some(successor))
             }
+            FindSuccessorStep::Remote { next, did } => Ok(PeerRingAction::RemoteAction(
+                next,
+                RemoteAction::FindSuccessor(did),
+            )),
         };
 
         tracing::debug!(
             "find_successor: self: {}, did: {}, successor: {:?}, result: {:?}",
             self.did,
             did,
-            successor,
+            state.successors,
             succ
         );
 
@@ -376,79 +417,29 @@ impl Chord<PeerRingAction> for PeerRing {
     /// If that node is closer to current node or current node has no predecessor, set it to the did.
     /// This method will return current predecessor after setting.
     fn notify(&self, did: Did) -> Result<Did> {
-        let mut predecessor = self.lock_predecessor()?;
-
-        match *predecessor {
-            Some(pre) => {
-                // If the did is closer to self than predecessor, set it to the predecessor.
-                // Otherwise tell the real predecessor back.
-                if self.bias(pre) < self.bias(did) {
-                    *predecessor = Some(did);
-                    Ok(did)
-                } else {
-                    Ok(pre)
-                }
-            }
-            None => {
-                // Self has no predecessor, set it to the did directly.
-                *predecessor = Some(did);
-                Ok(did)
-            }
-        }
+        let next = topology::step(
+            &self.topology_state()?,
+            TopologyEvent::Notify { predecessor: did },
+            self.successors().capacity(),
+        );
+        let Some(predecessor) = next.state.predecessor else {
+            return Err(Error::PeerRingInvalidAction);
+        };
+        self.interpret_topology_state(&next.state)?;
+        Ok(predecessor)
     }
 
     /// Fix finger table by finding the successor for each finger.
     /// According to the paper, this method should be called periodically.
     /// According to the paper, only one finger should be fixed at a time.
     fn fix_fingers(&self) -> Result<PeerRingAction> {
-        let (mut fix_finger_index, finger_table_size) = {
-            let finger = self.lock_finger()?;
-            (finger.fix_finger_index, finger.slot_count())
-        };
-
-        if finger_table_size == 0 {
-            return Ok(PeerRingAction::None);
-        }
-
-        // Only one finger should be fixed at a time.
-        fix_finger_index = (fix_finger_index + 1) % finger_table_size;
-
-        // Get finger did.
-        let finger_did = Did::power_of_two(fix_finger_index);
-
-        // Caution here that there are also locks in find_successor.
-        // You cannot lock finger table before calling find_successor.
-        // Have to lock_finger in each branch of the match.
-        match self.find_successor(finger_did) {
-            Ok(res) => match res {
-                PeerRingAction::Some(v) => {
-                    let mut finger = self.lock_finger()?;
-                    finger.fix_finger_index = fix_finger_index;
-                    finger.set_fix(v);
-                    Ok(PeerRingAction::None)
-                }
-                PeerRingAction::RemoteAction(
-                    closest_predecessor,
-                    RemoteAction::FindSuccessor(finger_did),
-                ) => {
-                    let mut finger = self.lock_finger()?;
-                    finger.fix_finger_index = fix_finger_index;
-                    Ok(PeerRingAction::RemoteAction(
-                        closest_predecessor,
-                        RemoteAction::FindSuccessorForFix(finger_did),
-                    ))
-                }
-                _ => {
-                    tracing::error!("Invalid PeerRing Action");
-                    Err(Error::PeerRingInvalidAction)
-                }
-            },
-            Err(e) => {
-                let mut finger = self.lock_finger()?;
-                finger.fix_finger_index = fix_finger_index;
-                Err(Error::PeerRingFindSuccessor(e.to_string()))
-            }
-        }
+        let next = topology::step(
+            &self.topology_state()?,
+            TopologyEvent::FixFinger,
+            self.successors().capacity(),
+        );
+        self.interpret_topology_state(&next.state)?;
+        Ok(self.topology_leaf_actions(next.actions))
     }
 }
 
@@ -598,14 +589,15 @@ impl CorrectChord<PeerRingAction> for PeerRing {
                 RemoteAction::TryConnect,
             ));
         }
-        if let Some(new_succ) = self.successors().update(did.into())? {
-            Ok(PeerRingAction::RemoteAction(
-                new_succ,
-                RemoteAction::QueryForSuccessorList,
-            ))
-        } else {
-            Ok(PeerRingAction::None)
-        }
+        let next = topology::step(
+            &self.topology_state()?,
+            TopologyEvent::UpdateSuccessor {
+                successor: did.into(),
+            },
+            self.successors().capacity(),
+        );
+        self.interpret_topology_state(&next.state)?;
+        Ok(self.topology_leaf_actions(next.actions))
     }
 
     async fn extend_successor(&self, dids: &[impl LiveDid]) -> Result<PeerRingAction> {
@@ -653,12 +645,10 @@ impl CorrectChord<PeerRingAction> for PeerRing {
         // emits no follow-up action.
         let next = topology::step(
             &self.topology_state()?,
-            TopologyEvent::Rectify { predecessor: pred },
+            TopologyEvent::Notify { predecessor: pred },
             self.successors().capacity(),
         );
-        let mut predecessor = self.lock_predecessor()?;
-        *predecessor = next.state.predecessor;
-        Ok(())
+        self.interpret_topology_state(&next.state)
     }
 
     /// Pre-Stabilize Operation:
@@ -692,20 +682,8 @@ impl CorrectChord<PeerRingAction> for PeerRing {
             },
             self.successors().capacity(),
         );
-        self.replace_successors(&next.state.successors)?;
-        Ok(PeerRingAction::MultiActions(
-            next.actions
-                .into_iter()
-                .map(|action| match action {
-                    TopologyAction::QuerySuccessorList(did) => {
-                        PeerRingAction::RemoteAction(did, RemoteAction::QueryForSuccessorList)
-                    }
-                    TopologyAction::Notify(did) => {
-                        PeerRingAction::RemoteAction(did, RemoteAction::Notify(self.did))
-                    }
-                })
-                .collect(),
-        ))
+        self.interpret_topology_state(&next.state)?;
+        Ok(self.topology_multi_actions(next.actions))
     }
 
     /// A function to provide topological information about the chord.

--- a/crates/core/src/dht/chord.rs
+++ b/crates/core/src/dht/chord.rs
@@ -17,6 +17,10 @@ use super::entry::PlacedEntry;
 use super::entry::PlacementMiss;
 use super::finger::DEFAULT_FINGER_TABLE_SIZE;
 use super::successor::SuccessorSeq;
+use super::topology;
+use super::topology::TopologyAction;
+use super::topology::TopologyEvent;
+use super::topology::TopologyState;
 use super::types::Chord;
 use super::types::ChordStorage;
 use super::types::ChordStorageCache;
@@ -275,6 +279,40 @@ impl PeerRing {
     pub fn bias(&self, did: Did) -> BiasId {
         BiasId::new(self.did, did)
     }
+
+    fn topology_state(&self) -> Result<TopologyState> {
+        Ok(TopologyState::new(
+            self.did,
+            self.successors().list()?,
+            *self.lock_predecessor()?,
+        ))
+    }
+
+    fn replace_successors(&self, next: &[Did]) -> Result<()> {
+        let successors = self.successors();
+        for did in successors.list()? {
+            successors.remove(did)?;
+        }
+        successors.extend(next)?;
+        Ok(())
+    }
+
+    /// Join an incoming replicated entry delta into local storage.
+    ///
+    /// Post: the stored value is the least upper bound of the previous local
+    /// value and `incoming` when a previous value exists; otherwise it is
+    /// `incoming` normalized for storage.
+    pub(crate) async fn join_storage_entry(&self, key: Did, incoming: Entry) -> Result<Entry> {
+        let incoming = incoming.into_storage_entry();
+        let stored = if let Some(local) = self.storage.get(&key.to_string()).await? {
+            local.join(incoming)?
+        } else {
+            incoming
+        }
+        .into_storage_entry();
+        self.storage.put(&key.to_string(), &stored).await?;
+        Ok(stored)
+    }
 }
 
 impl Chord<PeerRingAction> for PeerRing {
@@ -492,6 +530,7 @@ impl<const REDUNDANT: u16> ChordStorage<PeerRingAction, REDUNDANT> for PeerRing 
     /// successor of current node, otherwise find the responsible node and return
     /// as Action.
     async fn entry_operate(&self, op: EntryOperation) -> Result<PeerRingAction> {
+        let op = op.stamped(self.did)?;
         let entry_key = op.did()?;
         let mut ret = vec![];
         // Pre: op.did() is the entry identity id(e), and REDUNDANT > 0 is
@@ -511,7 +550,7 @@ impl<const REDUNDANT: u16> ChordStorage<PeerRingAction, REDUNDANT> for PeerRing 
                         None => op.clone().gen_default_entry()?,
                     };
                     let entry = this.operate(op.clone())?;
-                    self.storage.put(&entry_key.to_string(), &entry).await?;
+                    self.join_storage_entry(entry_key, entry).await?;
                     Ok(PeerRingAction::None)
                 }
                 // `entry` should be on other nodes.
@@ -612,7 +651,13 @@ impl CorrectChord<PeerRingAction> for PeerRing {
         // unchanged. Delegating to Chord::notify is exactly this predecessor
         // choice rule; Rectify discards the returned predecessor because it
         // emits no follow-up action.
-        self.notify(pred)?;
+        let next = topology::step(
+            &self.topology_state()?,
+            TopologyEvent::Rectify { predecessor: pred },
+            self.successors().capacity(),
+        );
+        let mut predecessor = self.lock_predecessor()?;
+        *predecessor = next.state.predecessor;
         Ok(())
     }
 
@@ -639,42 +684,28 @@ impl CorrectChord<PeerRingAction> for PeerRing {
     /// query check; the remote successor list contributes `but_last`; and notify
     /// is emitted for the post-update head when that head is not self.
     fn stabilize(&self, info: TopoInfo) -> Result<PeerRingAction> {
-        let mut ret = vec![];
-        let successors = self.successors();
-        let old_head = if successors.is_empty()? {
-            None
-        } else {
-            Some(successors.min()?)
-        };
-        let but_last = info
-            .successors
-            .split_last()
-            .map(|(_, successors_before_last)| successors_before_last)
-            .unwrap_or(&[]);
-        let improved_successor = info.predecessor.filter(|new_succ| {
-            *new_succ != self.did
-                && old_head.is_none_or(|head| self.bias(*new_succ) < self.bias(head))
-        });
-        if let Some(new_succ) = info.predecessor {
-            successors.update(new_succ)?;
-        }
-        successors.extend(but_last)?;
-        // Check if new_succ was between self.did and the old head of successors.
-        if let Some(new_succ) = improved_successor {
-            ret.push(PeerRingAction::RemoteAction(
-                new_succ,
-                RemoteAction::QueryForSuccessorList,
-            ));
-        }
-        // Notify the node's minimum successor of its existence.
-        let head = successors.min()?;
-        if head != self.did {
-            ret.push(PeerRingAction::RemoteAction(
-                head,
-                RemoteAction::Notify(self.did),
-            ));
-        }
-        Ok(PeerRingAction::MultiActions(ret))
+        let next = topology::step(
+            &self.topology_state()?,
+            TopologyEvent::Stabilize {
+                successors: info.successors,
+                predecessor: info.predecessor,
+            },
+            self.successors().capacity(),
+        );
+        self.replace_successors(&next.state.successors)?;
+        Ok(PeerRingAction::MultiActions(
+            next.actions
+                .into_iter()
+                .map(|action| match action {
+                    TopologyAction::QuerySuccessorList(did) => {
+                        PeerRingAction::RemoteAction(did, RemoteAction::QueryForSuccessorList)
+                    }
+                    TopologyAction::Notify(did) => {
+                        PeerRingAction::RemoteAction(did, RemoteAction::Notify(self.did))
+                    }
+                })
+                .collect(),
+        ))
     }
 
     /// A function to provide topological information about the chord.

--- a/crates/core/src/dht/chord.rs
+++ b/crates/core/src/dht/chord.rs
@@ -499,7 +499,7 @@ impl<const REDUNDANT: u16> ChordStorage<PeerRingAction, REDUNDANT> for PeerRing 
                         RemoteAction::FindEntry(EntryLookupKey::new(entry_key, id)),
                     ))
                 }
-                Ok(a) => Err(Error::PeerRingUnexpectedAction(a)),
+                Ok(a) => Err(Error::unexpected_peer_ring_action(a)),
                 Err(e) => Err(e),
             }?;
             if act.is_remote() {
@@ -549,7 +549,7 @@ impl<const REDUNDANT: u16> ChordStorage<PeerRingAction, REDUNDANT> for PeerRing 
                 Ok(PeerRingAction::RemoteAction(n, RemoteAction::FindSuccessor(_))) => Ok(
                     PeerRingAction::RemoteAction(n, RemoteAction::FindEntryForOperate(op.clone())),
                 ),
-                Ok(a) => Err(Error::PeerRingUnexpectedAction(a)),
+                Ok(a) => Err(Error::unexpected_peer_ring_action(a)),
                 Err(e) => Err(e),
             }?;
             if act.is_remote() {

--- a/crates/core/src/dht/chord/storage_repair.rs
+++ b/crates/core/src/dht/chord/storage_repair.rs
@@ -23,7 +23,7 @@
 //!   `acknowledge_synced_entries`; the finite model
 //!   `storage_sync_model_preserves_no_update_loss` in `dht_stateright` checks
 //!   that ack-delete removes a local value only when the receiver state contains
-//!   the same joined value.
+//!   the same storage-canonical joined value.
 //! - S3 Idempotence: duplicate repair delivery is observationally equivalent to
 //!   one delivery because [`Entry::join`](crate::dht::entry::Entry::join) is
 //!   idempotent.
@@ -178,7 +178,7 @@ impl PeerRing {
             return Ok(PeerRingAction::None);
         }
 
-        let entry = entry.into_storage_entry();
+        let entry = entry.try_into_storage_entry()?;
         let mut actions = Vec::new();
         for placement_key in entry.did.rotate_affine(redundancy)? {
             let action = self.copy_entry_to_placement(placement_key, &entry).await?;

--- a/crates/core/src/dht/chord/storage_repair.rs
+++ b/crates/core/src/dht/chord/storage_repair.rs
@@ -8,24 +8,25 @@
 //! - `succ(k)` is the owner returned by Chord routing for placement key `k`.
 //!
 //! Invariant REPLICATED(e, N):
-//! `forall k in place(id(e), N), sigma_{succ(k)}[k] = e`.
+//! `forall k in place(id(e), N), sigma_{succ(k)}[k] >= e_delta`, where `>=`
+//! is the partial order induced by [`crate::algebra::JoinSemilattice`].
 //!
 //! Liveness S4:
 //! In a quiescent window, if at least one placement copy of `e` remains at the
-//! start of an anti-entropy period, one `republish_local_entries` round copies
-//! `e` to every current owner in `place(id(e), N)`.
+//! start of an anti-entropy period, one `republish_local_entries` round
+//! delivers the entry's join state to every current owner in `place(id(e), N)`.
 //!
 //! Safety:
-//! - S1 Additivity: repair transitions in this module never call
-//!   `storage.remove`.
-//! - S2' No-update-loss: the only deletion transition is
+//! - S1 Additivity (#612): repair transitions in this module never call
+//!   `storage.remove`; they only deliver additional joins.
+//! - S2' No-update-loss (#611/#614 cleanup): the only deletion transition is
 //!   `acknowledge_synced_entries`; the finite model
 //!   `storage_sync_model_preserves_no_update_loss` in `dht_stateright` checks
 //!   that ack-delete removes a local value only when the receiver state contains
-//!   the same value.
-//! - S3 Idempotence: copy transitions overwrite the same key with an equal
-//!   value, so applying the same repair twice is observationally equivalent to
-//!   applying it once.
+//!   the same joined value.
+//! - S3 Idempotence: duplicate repair delivery is observationally equivalent to
+//!   one delivery because [`Entry::join`](crate::dht::entry::Entry::join) is
+//!   idempotent.
 //!
 //! Read-repair:
 //! Given lookup observation `o : place(id(e), N) -> {Hit(e), Miss, Unknown}`,
@@ -102,8 +103,8 @@ impl PeerRing {
 
         // Departure repair is only an accelerator; periodic anti-entropy is
         // the authoritative backstop. This scan is O(entries * redundancy) and
-        // may race with another terminal-state trigger, but repair is
-        // copy-only, so duplicate triggers preserve storage state.
+        // may race with another terminal-state trigger, but repair only
+        // delivers joins, so duplicate triggers preserve storage state.
         for (_, entry) in self.storage.get_all().await? {
             for placement_key in entry.did.rotate_affine(redundancy)? {
                 match self.find_successor(placement_key)? {
@@ -124,8 +125,9 @@ impl PeerRing {
         // Pre: placement_key belongs to place(id(entry), redundancy) for the
         // caller's anti-entropy or republish transition.
         // Post S1: no local key is removed.
-        // Post S3: if self owns placement_key, sigma_self[placement_key] = entry
-        // after the transition; repeating the write preserves sigma.
+        // Post S3: if self owns placement_key, sigma_self[placement_key] is
+        // joined with entry after the transition; repeating the write preserves
+        // sigma by join idempotence.
         // Post: if another node owns placement_key, the returned action carries
         // PlacedEntry { key: placement_key, entry } so placement identity is not
         // recomputed by the receiver.
@@ -196,9 +198,9 @@ impl ChordStorageRepair<PeerRingAction> for PeerRing {
 
         // Pre: redundancy > 1 and every local storage value is an Entry.
         // Post S1: forall key in local_before, local_after[key] =
-        // local_before[key]. This transition only copies.
+        // local_before[key]. This transition only emits join deliveries.
         // Post S3: repeating this transition produces the same sigma mapping as
-        // one application because put(k, e) overwrites with equal e.
+        // one application because storage writes are Entry::join deliveries.
         // Post S4: for every local entry e, a copy action exists for each key
         // in place(id(e), redundancy) whose owner is not self; self-owned
         // placements are written locally.
@@ -223,7 +225,7 @@ impl ChordStorageRepair<PeerRingAction> for PeerRing {
         // action can target them. A local-hit short circuit has misses = [].
         // Post R4: no placement vector or successor is recomputed here.
         // Preservation S1/S3: this transition never removes and duplicate copy
-        // actions overwrite with equal Entry values.
+        // actions are duplicate Entry::join deliveries.
         let mut actions = Vec::new();
         for miss in misses.iter().copied() {
             let action = self.copy_entry_to_observed_miss(miss, &entry).await?;

--- a/crates/core/src/dht/chord/storage_repair.rs
+++ b/crates/core/src/dht/chord/storage_repair.rs
@@ -145,7 +145,7 @@ impl PeerRing {
                     RemoteAction::SyncEntriesWithSuccessor(vec![placed]),
                 ))
             }
-            action => Err(Error::PeerRingUnexpectedAction(action)),
+            action => Err(Error::unexpected_peer_ring_action(action)),
         }
     }
 

--- a/crates/core/src/dht/chord/storage_repair.rs
+++ b/crates/core/src/dht/chord/storage_repair.rs
@@ -132,11 +132,7 @@ impl PeerRing {
         let placed = PlacedEntry::new(placement_key, entry.clone());
         match self.find_successor(placement_key)? {
             PeerRingAction::Some(owner) if owner == self.did => {
-                self.storage
-                    .put(
-                        &placement_key.to_string(),
-                        &entry.clone().into_storage_entry(),
-                    )
+                self.join_storage_entry(placement_key, entry.clone())
                     .await?;
                 Ok(PeerRingAction::None)
             }
@@ -165,9 +161,7 @@ impl PeerRing {
         // reuses the owner observed by lookup and emits only a copy action.
         let placed = PlacedEntry::new(miss.key, entry.clone());
         if miss.owner == self.did {
-            self.storage
-                .put(&miss.key.to_string(), &entry.clone().into_storage_entry())
-                .await?;
+            self.join_storage_entry(miss.key, entry.clone()).await?;
             Ok(PeerRingAction::None)
         } else {
             Ok(PeerRingAction::RemoteAction(

--- a/crates/core/src/dht/chord/storage_sync.rs
+++ b/crates/core/src/dht/chord/storage_sync.rs
@@ -149,18 +149,18 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
         // Pre S2': each ack in acks is contained in a
         // SyncEntriesWithSuccessorReport sent only after the receiver persisted
         // SyncedEntryAck { key, entry } at key.
-        // Post S2': a local key is removed only if
-        // local_before[key] == ack.entry. If local_before[key] differs, the
+        // Post S2': a local key is removed only if canonical(local_before[key])
+        // == canonical(ack.entry). If the canonical local value differs, the
         // local value is preserved and will be offered again by a later
         // sync_entries_with_successor transition.
-        // Preservation #614: a write racing between copy and ack changes
-        // local_before[key], so confirms_local_value is false and delete is
-        // skipped.
+        // Preservation #614: a write racing between copy and ack changes the
+        // canonical local value, so confirms_local_value is false and delete
+        // is skipped.
         for ack in acks {
             let Some(local_entry) = self.storage.get(&ack.key.to_string()).await? else {
                 continue;
             };
-            if ack.confirms_local_value(&local_entry) {
+            if ack.confirms_local_value(&local_entry)? {
                 self.storage.remove(&ack.key.to_string()).await?;
             }
         }

--- a/crates/core/src/dht/chord/storage_sync.rs
+++ b/crates/core/src/dht/chord/storage_sync.rs
@@ -118,12 +118,13 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
 
         // Pre: new_successor is the successor adopted by stabilization.
         // Post S1: forall key in local_before, local_after[key] =
-        // local_before[key]; this transition emits copies only.
+        // local_before[key]; this transition emits join deliveries only.
         // Post S2(copy): every emitted PlacedEntry keeps the exact local
         // placement key, so an eventual ack names the key whose durable copy was
         // reported by the receiver.
-        // Preservation: sync is copy-before-ack-before-delete.
-        // acknowledge_synced_entries is the only delete transition.
+        // Preservation #611/#614: sync hand-off is join-before-ack-before-local
+        // cleanup. acknowledge_synced_entries is the only local cleanup
+        // transition and does not define storage convergence.
         for (entry_key_str, entry) in all_items.iter() {
             let entry_key = Did::from_str(entry_key_str)?;
             if self.bias(entry_key) > self.bias(new_successor) {
@@ -152,7 +153,7 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
         // local_before[key] == ack.entry. If local_before[key] differs, the
         // local value is preserved and will be offered again by a later
         // sync_entries_with_successor transition.
-        // Preservation: a write racing between copy and ack changes
+        // Preservation #614: a write racing between copy and ack changes
         // local_before[key], so confirms_local_value is false and delete is
         // skipped.
         for ack in acks {

--- a/crates/core/src/dht/chord/storage_tests.rs
+++ b/crates/core/src/dht/chord/storage_tests.rs
@@ -76,7 +76,7 @@ fn collect_sync_batches_into(
             }
             Ok(())
         }
-        act => Err(Error::PeerRingUnexpectedAction(act)),
+        act => Err(Error::unexpected_peer_ring_action(act)),
     }
 }
 
@@ -499,7 +499,7 @@ async fn local_hit_lookup_has_no_read_repair_targets() -> Result<()> {
     let action = <PeerRing as ChordStorage<_, 2>>::entry_lookup(&node, entry.did).await?;
     let evidence = match action {
         PeerRingAction::SomeEntry(evidence) => evidence,
-        action => return Err(Error::PeerRingUnexpectedAction(action)),
+        action => return Err(Error::unexpected_peer_ring_action(action)),
     };
     let repair = node
         .read_repair_entry(evidence.entry.clone(), &evidence.misses)
@@ -530,7 +530,7 @@ async fn read_repair_targets_only_observed_missing_placements() -> Result<()> {
     let action = <PeerRing as ChordStorage<_, 3>>::entry_lookup(&node, entry.did).await?;
     let evidence = match action {
         PeerRingAction::SomeEntry(evidence) => evidence,
-        action => return Err(Error::PeerRingUnexpectedAction(action)),
+        action => return Err(Error::unexpected_peer_ring_action(action)),
     };
     let repair = node
         .read_repair_entry(evidence.entry.clone(), &evidence.misses)

--- a/crates/core/src/dht/chord/storage_tests.rs
+++ b/crates/core/src/dht/chord/storage_tests.rs
@@ -28,27 +28,15 @@ use crate::storage::KvStorageInterface;
 use crate::storage::MemStorage;
 
 fn data_entry(did: Did) -> Entry {
-    Entry {
-        did,
-        data: vec![],
-        kind: EntryKind::Data,
-    }
+    Entry::new(did, vec![], EntryKind::Data)
 }
 
 fn data_entry_with_data(did: Did, data: &str) -> Entry {
-    Entry {
-        did,
-        data: vec![data.into()],
-        kind: EntryKind::Data,
-    }
+    Entry::new(did, vec![data.into()], EntryKind::Data)
 }
 
 fn data_entry_with_payload_len(did: Did, len: usize) -> Entry {
-    Entry {
-        did,
-        data: vec!["x".repeat(len).into()],
-        kind: EntryKind::Data,
-    }
+    Entry::new(did, vec!["x".repeat(len).into()], EntryKind::Data)
 }
 
 fn first_two_affine_keys(did: Did) -> Result<(Did, Did)> {

--- a/crates/core/src/dht/did.rs
+++ b/crates/core/src/dht/did.rs
@@ -390,6 +390,12 @@ impl FromStr for Did {
     }
 }
 
+impl Default for Did {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
 impl Zero for Did {
     fn zero() -> Self {
         Self::ZERO

--- a/crates/core/src/dht/entry.rs
+++ b/crates/core/src/dht/entry.rs
@@ -41,15 +41,9 @@ pub enum EntryKind {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct EntryElement {
-    value: Encoded,
-    dot: EntryDot,
-}
-
-fn append_digest_part(out: &mut String, part: &str) {
-    out.push_str(&part.len().to_string());
-    out.push(':');
-    out.push_str(part);
+enum EntryStampKind {
+    Overwrite,
+    Delta,
 }
 
 /// Operations supported by a DHT storage entry.
@@ -233,13 +227,19 @@ impl EntryOperation {
     /// origin's dot/version instead of being reissued by every routing hop.
     pub fn stamped(self, actor: Did) -> Result<Self> {
         Ok(match self {
-            EntryOperation::Overwrite(entry) => {
-                EntryOperation::Overwrite(entry.ensure_overwrite_stamp(actor)?)
-            }
-            EntryOperation::Extend(entry) => {
-                EntryOperation::Extend(entry.ensure_delta_stamp(actor)?)
-            }
-            EntryOperation::Touch(entry) => EntryOperation::Touch(entry.ensure_delta_stamp(actor)?),
+            EntryOperation::Overwrite(entry) => EntryOperation::Overwrite(
+                entry.ensure_stamp_after(actor, None, EntryStampKind::Overwrite)?,
+            ),
+            EntryOperation::Extend(entry) => EntryOperation::Extend(entry.ensure_stamp_after(
+                actor,
+                None,
+                EntryStampKind::Delta,
+            )?),
+            EntryOperation::Touch(entry) => EntryOperation::Touch(entry.ensure_stamp_after(
+                actor,
+                None,
+                EntryStampKind::Delta,
+            )?),
             EntryOperation::JoinSubring(name, did) => EntryOperation::JoinSubring(name, did),
             EntryOperation::Tombstone(entry) => EntryOperation::Tombstone(entry),
         })
@@ -325,13 +325,13 @@ impl Entry {
             .data
             .iter()
             .enumerate()
-            .map(|(index, value)| EntryDot::for_encoded(version, index, value))
+            .map(|(index, _)| EntryDot::for_index(version, index))
             .collect::<Result<Vec<_>>>()?;
         Ok(self)
     }
 
     fn stamp_overwrite(mut self, version: EntryVersion) -> Result<Self> {
-        self.crdt.register = version;
+        self.crdt.register = Some(version);
         self.with_element_dots(version)
     }
 
@@ -339,69 +339,56 @@ impl Entry {
         self.with_element_dots(version)
     }
 
+    fn stamp(self, version: EntryVersion, kind: EntryStampKind) -> Result<Self> {
+        match kind {
+            EntryStampKind::Overwrite => self.stamp_overwrite(version),
+            EntryStampKind::Delta => self.stamp_delta(version),
+        }
+    }
+
     fn operation_digest(&self) -> Result<Did> {
-        let kind = match self.kind {
-            EntryKind::Data => "data",
-            EntryKind::Subring => "subring",
-            EntryKind::RelayMessage => "relay",
+        #[derive(Serialize)]
+        struct OperationDigest<'a> {
+            kind: EntryKind,
+            did: Did,
+            data: &'a [Encoded],
+        }
+
+        let digest = OperationDigest {
+            kind: self.kind,
+            did: self.did,
+            data: &self.data,
         };
-        let mut input = String::new();
-        append_digest_part(&mut input, kind);
-        append_digest_part(&mut input, &self.did.to_string());
-        for data in &self.data {
-            append_digest_part(&mut input, data.value());
-        }
-        Self::gen_did(&input)
+        let bytes = bincode::serialize(&digest).map_err(Error::BincodeSerialize)?;
+        let encoded = bytes.encode()?;
+        Self::gen_did(encoded.value())
     }
 
-    fn ensure_overwrite_stamp(self, actor: Did) -> Result<Self> {
-        if self.crdt.has_witness() {
-            Ok(self)
-        } else {
-            let operation = self.operation_digest()?;
-            self.stamp_overwrite(EntryVersion::issued_by(actor, operation))
-        }
+    fn issue_version_after(&self, actor: Did, floor: Option<EntryVersion>) -> Result<EntryVersion> {
+        Ok(EntryVersion::issued_by(actor, self.operation_digest()?).after(floor))
     }
 
-    fn ensure_delta_stamp(self, actor: Did) -> Result<Self> {
-        if self.crdt.has_witness() {
-            Ok(self)
-        } else {
-            let operation = self.operation_digest()?;
-            self.stamp_delta(EntryVersion::issued_by(actor, operation))
+    fn ensure_stamp_after(
+        self,
+        actor: Did,
+        floor: Option<EntryVersion>,
+        kind: EntryStampKind,
+    ) -> Result<Self> {
+        if self.crdt.has_write_witness() {
+            return Ok(self);
         }
+        let version = self.issue_version_after(actor, floor)?;
+        self.stamp(version, kind)
     }
 
-    fn max_observed_version(&self) -> EntryVersion {
+    fn max_observed_version(&self) -> Option<EntryVersion> {
         self.crdt
             .dots
             .iter()
             .map(|dot| dot.version)
             .chain(self.crdt.tombstones.iter().map(|dot| dot.version))
-            .fold(self.crdt.register, EntryVersion::max)
-    }
-
-    fn observed_operation_version(&self, actor: Did) -> Result<EntryVersion> {
-        let issued = EntryVersion::issued_by(actor, self.operation_digest()?);
-        Ok(self
-            .crdt
-            .dots
-            .iter()
-            .map(|dot| dot.version)
-            .chain(std::iter::once(self.crdt.register))
+            .chain(self.crdt.register)
             .max()
-            .filter(|version| *version != EntryVersion::default())
-            .unwrap_or(issued))
-    }
-
-    fn ensure_overwrite_stamp_after(self, actor: Did, floor: EntryVersion) -> Result<Self> {
-        let version = self.observed_operation_version(actor)?.after(floor);
-        self.stamp_overwrite(version)
-    }
-
-    fn ensure_delta_stamp_after(self, actor: Did, floor: EntryVersion) -> Result<Self> {
-        let version = self.observed_operation_version(actor)?.after(floor);
-        self.stamp_delta(version)
     }
 
     fn validate_same_carrier(&self, other: &Self) -> Result<()> {
@@ -414,31 +401,23 @@ impl Entry {
         Ok(())
     }
 
-    fn elements(&self) -> Result<Vec<EntryElement>> {
-        self.data
-            .iter()
-            .cloned()
-            .enumerate()
-            .map(|(index, value)| {
-                let dot = if let Some(dot) = self.crdt.dots.get(index).copied() {
-                    dot
-                } else {
-                    EntryDot::for_encoded(self.crdt.register, index, &value)?
-                };
-                Ok(EntryElement { value, dot })
-            })
-            .collect()
+    fn dot_for_element(&self, index: usize) -> Result<EntryDot> {
+        if let Some(dot) = self.crdt.dots.get(index).copied() {
+            return Ok(dot);
+        }
+        EntryDot::for_index(self.crdt.legacy_floor(), index)
     }
 
     fn topic_buffer(&self) -> Result<DataTopicBuffer> {
         let mut values = BTreeMap::new();
-        for element in self.elements()? {
+        for (index, value) in self.data.iter().cloned().enumerate() {
+            let dot = self.dot_for_element(index)?;
             values
-                .entry(element.value)
+                .entry(value)
                 .and_modify(|current: &mut EntryDot| {
-                    *current = (*current).max(element.dot);
+                    *current = (*current).max(dot);
                 })
-                .or_insert(element.dot);
+                .or_insert(dot);
         }
         Ok(DataTopicBuffer::new(self.crdt.register, values))
     }
@@ -462,15 +441,22 @@ impl Entry {
     fn materialize_elements(
         did: Did,
         kind: EntryKind,
-        register: EntryVersion,
+        register: Option<EntryVersion>,
         elements: impl IntoIterator<Item = (Encoded, EntryDot)>,
         tombstones: BTreeSet<EntryDot>,
     ) -> Self {
         let mut visible = elements
             .into_iter()
-            .filter(|(_, dot)| dot.version >= register && !tombstones.contains(dot))
+            .filter(|(_, dot)| {
+                let visible_after_reset = register.is_none_or(|floor| dot.version >= floor);
+                visible_after_reset && !tombstones.contains(dot)
+            })
             .collect::<Vec<_>>();
-        visible.sort_by_key(|(value, dot)| (*dot, value.clone()));
+        visible.sort_by(|(left_value, left_dot), (right_value, right_dot)| {
+            left_dot
+                .cmp(right_dot)
+                .then_with(|| left_value.cmp(right_value))
+        });
         let skip_count = visible.len().saturating_sub(ENTRY_DATA_MAX_LEN);
         let visible = visible.into_iter().skip(skip_count).collect::<Vec<_>>();
         let (data, dots): (Vec<_>, Vec<_>) = visible.into_iter().unzip();
@@ -562,6 +548,10 @@ impl Entry {
         self.kind == EntryKind::Subring
     }
 
+    fn is_relay_entry(&self) -> bool {
+        self.kind == EntryKind::RelayMessage
+    }
+
     fn same_kind_as(&self, other: &Self) -> bool {
         self.kind == other.kind
     }
@@ -604,12 +594,22 @@ impl Entry {
     }
 
     /// Overwrite current data with new data.
+    ///
+    /// Preservation: the replacement is represented as a CRDT join. A newly
+    /// stamped overwrite carries a reset floor, and materialization keeps only
+    /// dots at or after that floor, so older payload dots are removed without a
+    /// non-monotone assignment.
+    ///
     /// The handler of [EntryOperation::Overwrite].
     pub fn overwrite(&self, other: Self, actor: Did) -> Result<Self> {
         if !self.is_data_entry() {
             return Err(Error::EntryNotOverwritable);
         }
-        self.join(other.ensure_overwrite_stamp_after(actor, self.max_observed_version())?)
+        self.join(other.ensure_stamp_after(
+            actor,
+            self.max_observed_version(),
+            EntryStampKind::Overwrite,
+        )?)
     }
 
     /// This method is used to extend data to a Data kind [`Entry`].
@@ -618,7 +618,11 @@ impl Entry {
         if !self.is_data_entry() {
             return Err(Error::EntryNotAppendable);
         }
-        self.join(other.ensure_delta_stamp_after(actor, self.max_observed_version())?)
+        self.join(other.ensure_stamp_after(
+            actor,
+            self.max_observed_version(),
+            EntryStampKind::Delta,
+        )?)
     }
 
     /// This method is used to extend data to a Data kind [`Entry`] uniquely.
@@ -628,7 +632,11 @@ impl Entry {
         if !self.is_data_entry() {
             return Err(Error::EntryNotAppendable);
         }
-        self.join(other.ensure_delta_stamp_after(actor, self.max_observed_version())?)
+        self.join(other.ensure_stamp_after(
+            actor,
+            self.max_observed_version(),
+            EntryStampKind::Delta,
+        )?)
     }
 
     /// This method is used to join a subring.
@@ -650,7 +658,7 @@ impl Entry {
     /// Post: every removed payload is represented by an add-dot tombstone, so
     /// future joins with stale add replicas cannot resurrect it.
     pub fn tombstone(&self, other: Self) -> Result<Self> {
-        if self.kind != EntryKind::RelayMessage {
+        if !self.is_relay_entry() {
             return Err(Error::EntryNotTombstonable);
         }
         self.validate_same_carrier(&other)?;
@@ -863,13 +871,13 @@ mod tests {
             .data
             .iter()
             .enumerate()
-            .map(|(index, value)| {
+            .map(|(index, _)| {
                 let counter = if index == 0 {
                     10_000
                 } else {
                     u32::try_from(index).map_err(|_| Error::EntryDotIndexOutOfBounds { index })?
                 };
-                EntryDot::for_encoded(version(counter), index, value)
+                EntryDot::for_index(version(counter), index)
             })
             .collect::<Result<Vec<_>>>()?;
 
@@ -893,7 +901,7 @@ mod tests {
                 .map(|i| format!("legacy{i}"))
                 .collect::<Vec<_>>(),
         )?;
-        entry.crdt.dots = vec![EntryDot::for_encoded(version(10_000), 0, &entry.data[0])?];
+        entry.crdt.dots = vec![EntryDot::for_index(version(10_000), 0)?];
 
         let normalized = entry.try_into_storage_entry()?;
 
@@ -908,11 +916,11 @@ mod tests {
         let stale = encoded("stale")?;
         let live = encoded("live")?;
         let mut values = BTreeMap::new();
-        values.insert(stale.clone(), EntryDot::for_encoded(version(1), 0, &stale)?);
-        let live_dot = EntryDot::for_encoded(version(11), 0, &live)?;
+        values.insert(stale.clone(), EntryDot::for_index(version(1), 0)?);
+        let live_dot = EntryDot::for_index(version(11), 0)?;
         values.insert(live.clone(), live_dot);
 
-        let buffer = DataTopicBuffer::new(register, values);
+        let buffer = DataTopicBuffer::new(Some(register), values);
         assert_eq!(buffer.values.len(), 1);
         assert!(buffer.values.contains_key(&live));
 
@@ -937,6 +945,17 @@ mod tests {
 
         assert_eq!(forward, reverse);
         assert_eq!(decode_entry_data(&forward)?, vec![String::from("higher")]);
+        Ok(())
+    }
+
+    #[test]
+    fn forwarded_overwrite_witness_is_not_reissued_after_local_floor() -> Result<()> {
+        let current = overwrite_delta("topic", "current", 10)?;
+        let stale_forwarded = overwrite_delta("topic", "stale", 1)?;
+
+        let updated = current.overwrite(stale_forwarded, actor())?;
+
+        assert_eq!(decode_entry_data(&updated)?, vec![String::from("current")]);
         Ok(())
     }
 

--- a/crates/core/src/dht/entry.rs
+++ b/crates/core/src/dht/entry.rs
@@ -46,6 +46,12 @@ struct EntryElement {
     dot: EntryDot,
 }
 
+fn append_digest_part(out: &mut String, part: &str) {
+    out.push_str(&part.len().to_string());
+    out.push(':');
+    out.push_str(part);
+}
+
 /// Operations supported by a DHT storage entry.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EntryOperation {
@@ -118,8 +124,9 @@ impl PlacedEntry {
 ///
 /// `key` is the placement key updated by the receiver. `entry` is the copied
 /// delta that the receiver joined into its local least upper bound. The sender
-/// uses equality with its current local value before deleting; if the sender has
-/// observed any newer delta meanwhile, deletion is skipped.
+/// compares the storage-normalized ack value with its current local value
+/// before deleting; if the sender has observed any newer durable delta
+/// meanwhile, deletion is skipped.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SyncedEntryAck {
     /// The placement key durably persisted by the sync receiver.
@@ -135,8 +142,13 @@ impl SyncedEntryAck {
     }
 
     /// Returns whether this ack proves that `local` equals the copied value.
-    pub fn confirms_local_value(&self, local: &Entry) -> bool {
-        &self.entry == local
+    ///
+    /// Post: comparison is performed on storage canonical forms, so legacy
+    /// entries without dots compare equal to the normalized value durably
+    /// persisted by the receiver.
+    pub fn confirms_local_value(&self, local: &Entry) -> Result<bool> {
+        Ok(self.entry.clone().try_into_storage_entry()?
+            == local.clone().try_into_storage_entry()?)
     }
 }
 
@@ -327,11 +339,27 @@ impl Entry {
         self.with_element_dots(version)
     }
 
+    fn operation_digest(&self) -> Result<Did> {
+        let kind = match self.kind {
+            EntryKind::Data => "data",
+            EntryKind::Subring => "subring",
+            EntryKind::RelayMessage => "relay",
+        };
+        let mut input = String::new();
+        append_digest_part(&mut input, kind);
+        append_digest_part(&mut input, &self.did.to_string());
+        for data in &self.data {
+            append_digest_part(&mut input, data.value());
+        }
+        Self::gen_did(&input)
+    }
+
     fn ensure_overwrite_stamp(self, actor: Did) -> Result<Self> {
         if self.crdt.has_witness() {
             Ok(self)
         } else {
-            self.stamp_overwrite(EntryVersion::issued_by(actor))
+            let operation = self.operation_digest()?;
+            self.stamp_overwrite(EntryVersion::issued_by(actor, operation))
         }
     }
 
@@ -339,7 +367,8 @@ impl Entry {
         if self.crdt.has_witness() {
             Ok(self)
         } else {
-            self.stamp_delta(EntryVersion::issued_by(actor))
+            let operation = self.operation_digest()?;
+            self.stamp_delta(EntryVersion::issued_by(actor, operation))
         }
     }
 
@@ -352,25 +381,26 @@ impl Entry {
             .fold(self.crdt.register, EntryVersion::max)
     }
 
-    fn observed_operation_version(&self, actor: Did) -> EntryVersion {
-        let issued = EntryVersion::issued_by(actor);
-        self.crdt
+    fn observed_operation_version(&self, actor: Did) -> Result<EntryVersion> {
+        let issued = EntryVersion::issued_by(actor, self.operation_digest()?);
+        Ok(self
+            .crdt
             .dots
             .iter()
             .map(|dot| dot.version)
             .chain(std::iter::once(self.crdt.register))
             .max()
             .filter(|version| *version != EntryVersion::default())
-            .unwrap_or(issued)
+            .unwrap_or(issued))
     }
 
     fn ensure_overwrite_stamp_after(self, actor: Did, floor: EntryVersion) -> Result<Self> {
-        let version = self.observed_operation_version(actor).after(floor);
+        let version = self.observed_operation_version(actor)?.after(floor);
         self.stamp_overwrite(version)
     }
 
     fn ensure_delta_stamp_after(self, actor: Did, floor: EntryVersion) -> Result<Self> {
-        let version = self.observed_operation_version(actor).after(floor);
+        let version = self.observed_operation_version(actor)?.after(floor);
         self.stamp_delta(version)
     }
 
@@ -540,41 +570,34 @@ impl Entry {
         self.did == other.did
     }
 
-    // Post: result is a suffix of `data` and result.len() <= ENTRY_DATA_MAX_LEN.
-    fn cap_recent_data(data: Vec<Encoded>) -> Vec<Encoded> {
-        let skip_count = data.len().saturating_sub(ENTRY_DATA_MAX_LEN);
-        data.into_iter().skip(skip_count).collect()
-    }
-
     /// Normalize an entry immediately before it is persisted.
     ///
+    /// Post: normalization uses the same carrier materialization as
+    /// [`Self::join`]; there is no second cap strategy outside the CRDT.
     /// Post: `result.data.len() <= ENTRY_DATA_MAX_LEN`.
-    pub fn into_storage_entry(self) -> Self {
-        let skip_count = self.data.len().saturating_sub(ENTRY_DATA_MAX_LEN);
-        let dots = if self.crdt.dots.len() == self.data.len() {
-            self.crdt.dots.into_iter().skip(skip_count).collect()
-        } else {
-            self.crdt.dots
-        };
-        Self {
-            did: self.did,
-            data: Self::cap_recent_data(self.data),
-            kind: self.kind,
-            crdt: EntryCrdt {
-                register: self.crdt.register,
-                dots,
-                tombstones: self.crdt.tombstones,
-            },
+    /// Post: `result.data.len() == result.crdt.dots.len()` for Data and
+    /// RelayMessage entries.
+    pub fn try_into_storage_entry(self) -> Result<Self> {
+        match self.kind {
+            EntryKind::Data => {
+                let buffer = self.topic_buffer()?;
+                Ok(self.materialize_topic_buffer(buffer))
+            }
+            EntryKind::RelayMessage => {
+                let set = self.relay_set()?;
+                Ok(self.materialize_relay_set(set))
+            }
+            EntryKind::Subring => Ok(self),
         }
     }
 
     /// The entry point of [EntryOperation].
     /// Will dispatch to different operation handlers according to the variant.
-    pub fn operate(&self, op: EntryOperation) -> Result<Self> {
+    pub fn operate(&self, op: EntryOperation, actor: Did) -> Result<Self> {
         match op {
-            EntryOperation::Overwrite(entry) => self.overwrite(entry),
-            EntryOperation::Extend(entry) => self.extend(entry),
-            EntryOperation::Touch(entry) => self.touch(entry),
+            EntryOperation::Overwrite(entry) => self.overwrite(entry, actor),
+            EntryOperation::Extend(entry) => self.extend(entry, actor),
+            EntryOperation::Touch(entry) => self.touch(entry, actor),
             EntryOperation::JoinSubring(_, did) => self.join_subring(did),
             EntryOperation::Tombstone(entry) => self.tombstone(entry),
         }
@@ -582,30 +605,30 @@ impl Entry {
 
     /// Overwrite current data with new data.
     /// The handler of [EntryOperation::Overwrite].
-    pub fn overwrite(&self, other: Self) -> Result<Self> {
+    pub fn overwrite(&self, other: Self, actor: Did) -> Result<Self> {
         if !self.is_data_entry() {
             return Err(Error::EntryNotOverwritable);
         }
-        self.join(other.ensure_overwrite_stamp_after(Did::default(), self.max_observed_version())?)
+        self.join(other.ensure_overwrite_stamp_after(actor, self.max_observed_version())?)
     }
 
     /// This method is used to extend data to a Data kind [`Entry`].
     /// The handler of [EntryOperation::Extend].
-    pub fn extend(&self, other: Self) -> Result<Self> {
+    pub fn extend(&self, other: Self, actor: Did) -> Result<Self> {
         if !self.is_data_entry() {
             return Err(Error::EntryNotAppendable);
         }
-        self.join(other.ensure_delta_stamp_after(Did::default(), self.max_observed_version())?)
+        self.join(other.ensure_delta_stamp_after(actor, self.max_observed_version())?)
     }
 
     /// This method is used to extend data to a Data kind [`Entry`] uniquely.
     /// If any element is already existed, move it to the end of the data vector.
     /// The handler of [EntryOperation::Touch].
-    pub fn touch(&self, other: Self) -> Result<Self> {
+    pub fn touch(&self, other: Self, actor: Did) -> Result<Self> {
         if !self.is_data_entry() {
             return Err(Error::EntryNotAppendable);
         }
-        self.join(other.ensure_delta_stamp_after(Did::default(), self.max_observed_version())?)
+        self.join(other.ensure_delta_stamp_after(actor, self.max_observed_version())?)
     }
 
     /// This method is used to join a subring.
@@ -713,22 +736,27 @@ mod tests {
         Subring::new(name, creator)?.try_into()
     }
 
-    fn version(counter: u128) -> EntryVersion {
+    fn actor() -> Did {
+        Did::from(42u32)
+    }
+
+    fn version(counter: u32) -> EntryVersion {
         EntryVersion::new(
-            counter,
-            Did::from(u32::try_from(counter).unwrap_or(u32::MAX)),
+            u128::from(counter),
+            Did::from(counter),
+            Did::from(counter.saturating_add(1000)),
         )
     }
 
-    fn data_delta(topic: &str, value: &str, counter: u128) -> Result<Entry> {
+    fn data_delta(topic: &str, value: &str, counter: u32) -> Result<Entry> {
         data_entry(topic, value)?.stamp_delta(version(counter))
     }
 
-    fn overwrite_delta(topic: &str, value: &str, counter: u128) -> Result<Entry> {
+    fn overwrite_delta(topic: &str, value: &str, counter: u32) -> Result<Entry> {
         data_entry(topic, value)?.stamp_overwrite(version(counter))
     }
 
-    fn relay_delta(did: Did, value: &str, counter: u128) -> Result<Entry> {
+    fn relay_delta(did: Did, value: &str, counter: u32) -> Result<Entry> {
         Entry::new(did, vec![encoded(value)?], EntryKind::RelayMessage)
             .stamp_delta(version(counter))
     }
@@ -823,10 +851,100 @@ mod tests {
     }
 
     #[test]
+    fn storage_normalization_uses_lattice_top_n_order() -> Result<()> {
+        let incoming_count = ENTRY_DATA_MAX_LEN + 3;
+        let mut entry = data_entry_from_values(
+            "topic",
+            (0..incoming_count)
+                .map(|i| format!("incoming{i}"))
+                .collect::<Vec<_>>(),
+        )?;
+        entry.crdt.dots = entry
+            .data
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                let counter = if index == 0 {
+                    10_000
+                } else {
+                    u32::try_from(index).map_err(|_| Error::EntryDotIndexOutOfBounds { index })?
+                };
+                EntryDot::for_encoded(version(counter), index, value)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let normalized = entry.try_into_storage_entry()?;
+        let decoded = decode_entry_data(&normalized)?;
+
+        assert_eq!(normalized.data.len(), ENTRY_DATA_MAX_LEN);
+        assert_eq!(normalized.data.len(), normalized.crdt.dots.len());
+        assert!(decoded.contains(&String::from("incoming0")));
+        assert!(!decoded.contains(&String::from("incoming1")));
+        assert!(!decoded.contains(&String::from("incoming2")));
+        assert!(!decoded.contains(&String::from("incoming3")));
+        Ok(())
+    }
+
+    #[test]
+    fn storage_normalization_realigns_legacy_mismatched_dots() -> Result<()> {
+        let mut entry = data_entry_from_values(
+            "topic",
+            (0..ENTRY_DATA_MAX_LEN + 2)
+                .map(|i| format!("legacy{i}"))
+                .collect::<Vec<_>>(),
+        )?;
+        entry.crdt.dots = vec![EntryDot::for_encoded(version(10_000), 0, &entry.data[0])?];
+
+        let normalized = entry.try_into_storage_entry()?;
+
+        assert_eq!(normalized.data.len(), ENTRY_DATA_MAX_LEN);
+        assert_eq!(normalized.data.len(), normalized.crdt.dots.len());
+        Ok(())
+    }
+
+    #[test]
+    fn crdt_constructors_normalize_carrier_invariants() -> Result<()> {
+        let register = version(10);
+        let stale = encoded("stale")?;
+        let live = encoded("live")?;
+        let mut values = BTreeMap::new();
+        values.insert(stale.clone(), EntryDot::for_encoded(version(1), 0, &stale)?);
+        let live_dot = EntryDot::for_encoded(version(11), 0, &live)?;
+        values.insert(live.clone(), live_dot);
+
+        let buffer = DataTopicBuffer::new(register, values);
+        assert_eq!(buffer.values.len(), 1);
+        assert!(buffer.values.contains_key(&live));
+
+        let relay = RelayMessageSet::new(buffer, BTreeSet::from([live_dot]));
+        assert!(relay.adds.values.is_empty());
+        assert!(relay.removes.contains(&live_dot));
+        Ok(())
+    }
+
+    #[test]
+    fn overwrite_register_tiebreaker_converges_for_same_timestamp_actor() -> Result<()> {
+        let did = Entry::gen_did("topic")?;
+        let issuer = actor();
+        let lower = Entry::new(did, vec![encoded("lower")?], EntryKind::Data)
+            .stamp_overwrite(EntryVersion::new(1, issuer, Did::from(1u32)))?;
+        let higher = Entry::new(did, vec![encoded("higher")?], EntryKind::Data)
+            .stamp_overwrite(EntryVersion::new(1, issuer, Did::from(2u32)))?;
+        let base = Entry::new(did, vec![], EntryKind::Data);
+
+        let forward = base.clone().join(lower.clone())?.join(higher.clone())?;
+        let reverse = base.join(higher)?.join(lower)?;
+
+        assert_eq!(forward, reverse);
+        assert_eq!(decode_entry_data(&forward)?, vec![String::from("higher")]);
+        Ok(())
+    }
+
+    #[test]
     fn overwrite_replaces_data_for_same_data_entry() -> Result<()> {
         let entry = data_entry("topic", "old")?;
         let other = data_entry("topic", "new")?;
-        let updated = entry.overwrite(other)?;
+        let updated = entry.overwrite(other, actor())?;
         assert_eq!(decode_entry_data(&updated)?, vec![String::from("new")]);
         Ok(())
     }
@@ -837,7 +955,7 @@ mod tests {
         let other = entry.clone();
 
         assert!(matches!(
-            entry.overwrite(other),
+            entry.overwrite(other, actor()),
             Err(Error::EntryNotOverwritable)
         ));
         Ok(())
@@ -850,7 +968,7 @@ mod tests {
         other.kind = EntryKind::RelayMessage;
 
         assert!(matches!(
-            entry.overwrite(other),
+            entry.overwrite(other, actor()),
             Err(Error::EntryKindNotEqual)
         ));
         Ok(())
@@ -862,7 +980,7 @@ mod tests {
         let other = data_entry("topic-b", "new")?;
 
         assert!(matches!(
-            entry.overwrite(other),
+            entry.overwrite(other, actor()),
             Err(Error::EntryDidNotEqual)
         ));
         Ok(())
@@ -873,7 +991,7 @@ mod tests {
         let overflow = 3;
         let (incoming, incoming_count) = overflowing_data_entry("topic", overflow)?;
         let entry = data_entry("topic", "base")?;
-        let updated = entry.overwrite(incoming)?;
+        let updated = entry.overwrite(incoming, actor())?;
         assert_entry_keeps_recent_overflow(&updated, incoming_count, overflow)
     }
 
@@ -881,7 +999,7 @@ mod tests {
     fn extend_appends_data_for_same_entry() -> Result<()> {
         let entry = data_entry("topic", "first")?;
         let other = data_entry("topic", "second")?;
-        let updated = entry.extend(other)?;
+        let updated = entry.extend(other, actor())?;
         assert_eq!(decode_entry_data(&updated)?, vec![
             String::from("first"),
             String::from("second")
@@ -895,14 +1013,14 @@ mod tests {
         for i in 1..ENTRY_DATA_MAX_LEN {
             let data = format!("test{i}");
             let other = data_entry("topic", &data)?;
-            entry = entry.extend(other)?;
+            entry = entry.extend(other, actor())?;
             assert_eq!(entry.data.len(), i + 1);
         }
 
         for i in ENTRY_DATA_MAX_LEN..ENTRY_DATA_MAX_LEN + 10 {
             let data = format!("test{i}");
             let other = data_entry("topic", &data)?;
-            entry = entry.extend(other)?;
+            entry = entry.extend(other, actor())?;
             assert_eq!(entry.data.len(), ENTRY_DATA_MAX_LEN);
             let decoded = decode_entry_data(&entry)?;
             assert_eq!(
@@ -919,7 +1037,7 @@ mod tests {
         let overflow = 3;
         let (incoming, incoming_count) = overflowing_data_entry("topic", overflow)?;
         let entry = data_entry("topic", "base")?;
-        let updated = entry.extend(incoming)?;
+        let updated = entry.extend(incoming, actor())?;
         assert_entry_keeps_recent_overflow(&updated, incoming_count, overflow)
     }
 
@@ -929,7 +1047,7 @@ mod tests {
         let other = entry.clone();
 
         assert!(matches!(
-            entry.extend(other),
+            entry.extend(other, actor()),
             Err(Error::EntryNotAppendable)
         ));
         Ok(())
@@ -938,10 +1056,10 @@ mod tests {
     #[test]
     fn touch_moves_existing_items_to_end_once() -> Result<()> {
         let entry = data_entry("topic", "a")?
-            .extend(data_entry("topic", "b")?)?
-            .extend(data_entry("topic", "c")?)?;
+            .extend(data_entry("topic", "b")?, actor())?
+            .extend(data_entry("topic", "c")?, actor())?;
         let touched = data_entry("topic", "b")?;
-        let updated = entry.touch(touched)?;
+        let updated = entry.touch(touched, actor())?;
         assert_eq!(decode_entry_data(&updated)?, vec![
             String::from("a"),
             String::from("c"),
@@ -954,9 +1072,9 @@ mod tests {
     fn touch_trims_oldest_non_touched_items_at_max_len() -> Result<()> {
         let mut entry = data_entry("topic", "test0")?;
         for i in 1..ENTRY_DATA_MAX_LEN {
-            entry = entry.extend(data_entry("topic", &format!("test{i}"))?)?;
+            entry = entry.extend(data_entry("topic", &format!("test{i}"))?, actor())?;
         }
-        let updated = entry.touch(data_entry("topic", "test0")?)?;
+        let updated = entry.touch(data_entry("topic", "test0")?, actor())?;
         assert_eq!(updated.data.len(), ENTRY_DATA_MAX_LEN);
         let decoded = decode_entry_data(&updated)?;
         assert_eq!(decoded.first(), Some(&String::from("test1")));
@@ -1000,7 +1118,7 @@ mod tests {
         let overflow = 3;
         let (incoming, incoming_count) = overflowing_data_entry("topic", overflow)?;
         let entry = data_entry("topic", "base")?;
-        let updated = entry.touch(incoming)?;
+        let updated = entry.touch(incoming, actor())?;
         assert_entry_keeps_recent_overflow(&updated, incoming_count, overflow)
     }
 

--- a/crates/core/src/dht/entry.rs
+++ b/crates/core/src/dht/entry.rs
@@ -360,8 +360,7 @@ impl Entry {
             data: &self.data,
         };
         let bytes = bincode::serialize(&digest).map_err(Error::BincodeSerialize)?;
-        let encoded = bytes.encode()?;
-        Self::gen_did(encoded.value())
+        Did::try_from(HashStr::from_bytes(&bytes))
     }
 
     fn issue_version_after(&self, actor: Did, floor: Option<EntryVersion>) -> Result<EntryVersion> {

--- a/crates/core/src/dht/entry.rs
+++ b/crates/core/src/dht/entry.rs
@@ -46,6 +46,17 @@ enum EntryStampKind {
     Delta,
 }
 
+// Canonical stamp input for EntryVersion.operation.
+//
+// This digest is an unreleased CRDT tie-break witness between nodes running the
+// same code, not a stable storage key or cross-version protocol identifier.
+#[derive(Serialize)]
+struct OperationDigest<'a> {
+    kind: EntryKind,
+    did: Did,
+    data: &'a [Encoded],
+}
+
 /// Operations supported by a DHT storage entry.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EntryOperation {
@@ -347,13 +358,6 @@ impl Entry {
     }
 
     fn operation_digest(&self) -> Result<Did> {
-        #[derive(Serialize)]
-        struct OperationDigest<'a> {
-            kind: EntryKind,
-            did: Did,
-            data: &'a [Encoded],
-        }
-
         let digest = OperationDigest {
             kind: self.kind,
             did: self.did,
@@ -944,6 +948,25 @@ mod tests {
 
         assert_eq!(forward, reverse);
         assert_eq!(decode_entry_data(&forward)?, vec![String::from("higher")]);
+        Ok(())
+    }
+
+    #[test]
+    fn operation_digest_hashes_canonical_bytes_not_legacy_base58() -> Result<()> {
+        let entry = data_entry("topic", "value")?;
+        let digest = OperationDigest {
+            kind: entry.kind,
+            did: entry.did,
+            data: &entry.data,
+        };
+        let bytes = bincode::serialize(&digest).map_err(Error::BincodeSerialize)?;
+
+        let direct = Did::try_from(HashStr::from_bytes(&bytes))?;
+        let legacy_encoded = bytes.encode()?;
+        let legacy_base58 = Entry::gen_did(legacy_encoded.value())?;
+
+        assert_eq!(entry.operation_digest()?, direct);
+        assert_ne!(direct, legacy_base58);
         Ok(())
     }
 

--- a/crates/core/src/dht/entry.rs
+++ b/crates/core/src/dht/entry.rs
@@ -60,6 +60,13 @@ pub enum EntryOperation {
     Touch(Entry),
     /// Join subring.
     JoinSubring(String, Did),
+    /// Tombstone observed relay-message payloads in a two-phase set.
+    ///
+    /// The payload identifies the relay-message carrier and the values to
+    /// remove. If CRDT dots are present, those dots are the remove witnesses;
+    /// otherwise the receiver tombstones currently observed dots with matching
+    /// payload bytes.
+    Tombstone(Entry),
 }
 
 /// A DHT storage entry with an [`EntryKind`] and a ring key represented as [`Did`].
@@ -222,6 +229,7 @@ impl EntryOperation {
             }
             EntryOperation::Touch(entry) => EntryOperation::Touch(entry.ensure_delta_stamp(actor)?),
             EntryOperation::JoinSubring(name, did) => EntryOperation::JoinSubring(name, did),
+            EntryOperation::Tombstone(entry) => EntryOperation::Tombstone(entry),
         })
     }
 
@@ -232,6 +240,7 @@ impl EntryOperation {
             EntryOperation::Extend(entry) => entry.did,
             EntryOperation::Touch(entry) => entry.did,
             EntryOperation::JoinSubring(name, _) => Entry::gen_did(name)?,
+            EntryOperation::Tombstone(entry) => entry.did,
         })
     }
 
@@ -242,6 +251,7 @@ impl EntryOperation {
             EntryOperation::Extend(entry) => entry.kind,
             EntryOperation::Touch(entry) => entry.kind,
             EntryOperation::JoinSubring(..) => EntryKind::Subring,
+            EntryOperation::Tombstone(entry) => entry.kind,
         }
     }
 
@@ -566,6 +576,7 @@ impl Entry {
             EntryOperation::Extend(entry) => self.extend(entry),
             EntryOperation::Touch(entry) => self.touch(entry),
             EntryOperation::JoinSubring(_, did) => self.join_subring(did),
+            EntryOperation::Tombstone(entry) => self.tombstone(entry),
         }
     }
 
@@ -608,6 +619,31 @@ impl Entry {
         subring.finger.join(did);
         let other: Entry = subring.try_into()?;
         self.join(other)
+    }
+
+    /// Tombstone observed relay messages.
+    ///
+    /// Pre: `self` and `other` are the same relay-message carrier.
+    /// Post: every removed payload is represented by an add-dot tombstone, so
+    /// future joins with stale add replicas cannot resurrect it.
+    pub fn tombstone(&self, other: Self) -> Result<Self> {
+        if self.kind != EntryKind::RelayMessage {
+            return Err(Error::EntryNotTombstonable);
+        }
+        self.validate_same_carrier(&other)?;
+
+        let mut set = self.relay_set()?;
+        let target_values = other.data.into_iter().collect::<BTreeSet<_>>();
+        let target_dots = other.crdt.dots.into_iter().collect::<BTreeSet<_>>();
+        let has_dot_witness = !target_dots.is_empty();
+
+        for (value, dot) in &set.adds.values {
+            if target_dots.contains(dot) || (!has_dot_witness && target_values.contains(value)) {
+                set.removes.insert(*dot);
+            }
+        }
+
+        Ok(self.materialize_relay_set(set))
     }
 }
 
@@ -692,6 +728,11 @@ mod tests {
         data_entry(topic, value)?.stamp_overwrite(version(counter))
     }
 
+    fn relay_delta(did: Did, value: &str, counter: u128) -> Result<Entry> {
+        Entry::new(did, vec![encoded(value)?], EntryKind::RelayMessage)
+            .stamp_delta(version(counter))
+    }
+
     #[test]
     fn gset_satisfies_join_semilattice_laws() {
         let mut a = GSet::new();
@@ -727,8 +768,12 @@ mod tests {
         let b = Entry::new(did, vec![encoded("b")?], EntryKind::RelayMessage)
             .stamp_delta(version(2))?
             .relay_set()?;
+        let ab = Entry::new(did, vec![], EntryKind::RelayMessage)
+            .join(relay_delta(did, "a", 1)?)?
+            .join(relay_delta(did, "b", 2)?)?;
+        let tombstoned_a = ab.tombstone(relay_delta(did, "a", 1)?)?.relay_set()?;
 
-        assert_join_semilattice_laws(&[RelayMessageSet::default(), a, b]);
+        assert_join_semilattice_laws(&[RelayMessageSet::default(), a, b, tombstoned_a]);
         Ok(())
     }
 
@@ -916,6 +961,37 @@ mod tests {
         let decoded = decode_entry_data(&updated)?;
         assert_eq!(decoded.first(), Some(&String::from("test1")));
         assert_eq!(decoded.last(), Some(&String::from("test0")));
+        Ok(())
+    }
+
+    #[test]
+    fn relay_tombstone_removes_observed_message_by_join() -> Result<()> {
+        let did = Did::from(30u32);
+        let first = relay_delta(did, "first", 1)?;
+        let second = relay_delta(did, "second", 2)?;
+        let carrier = Entry::new(did, vec![], EntryKind::RelayMessage)
+            .join(first.clone())?
+            .join(second.clone())?;
+
+        let removed = carrier.tombstone(first.clone())?;
+
+        assert_eq!(decode_entry_data(&removed)?, vec![String::from("second")]);
+        let joined_with_stale_add = removed.join(first)?;
+        assert_eq!(decode_entry_data(&joined_with_stale_add)?, vec![
+            String::from("second")
+        ]);
+        Ok(())
+    }
+
+    #[test]
+    fn relay_tombstone_rejects_non_relay_entry() -> Result<()> {
+        let entry = data_entry("topic", "value")?;
+        let other = entry.clone();
+
+        assert!(matches!(
+            entry.tombstone(other),
+            Err(Error::EntryNotTombstonable)
+        ));
         Ok(())
     }
 

--- a/crates/core/src/dht/entry.rs
+++ b/crates/core/src/dht/entry.rs
@@ -1,10 +1,13 @@
 #![warn(missing_docs)]
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::str::FromStr;
 
 use serde::Deserialize;
 use serde::Serialize;
 
 use super::subring::Subring;
+use crate::algebra::JoinSemilattice;
 use crate::consts::ENTRY_DATA_MAX_LEN;
 use crate::dht::Did;
 use crate::ecc::HashStr;
@@ -14,6 +17,16 @@ use crate::message::Encoded;
 use crate::message::Encoder;
 use crate::message::MessagePayload;
 use crate::message::MessageVerificationExt;
+
+mod crdt;
+
+pub use crdt::DataTopicBuffer;
+pub use crdt::EntryCrdt;
+pub use crdt::EntryDot;
+pub use crdt::EntryVersion;
+pub use crdt::GSet;
+pub use crdt::RelayMessageSet;
+pub use crdt::SubringMemberSet;
 
 /// DHT storage entry categories.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -25,6 +38,12 @@ pub enum EntryKind {
     /// A relayed but unreached message, which should be stored on
     /// the successor of the destination Did.
     RelayMessage,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct EntryElement {
+    value: Encoded,
+    dot: EntryDot,
 }
 
 /// Operations supported by a DHT storage entry.
@@ -64,6 +83,9 @@ pub struct Entry {
     pub data: Vec<Encoded>,
     /// The type indicates how the data is encoded and how the Did is generated.
     pub kind: EntryKind,
+    /// CRDT metadata that makes replicated merge a join-semilattice operation.
+    #[serde(default)]
+    pub crdt: EntryCrdt,
 }
 
 /// An [`Entry`] paired with its Chord placement key.
@@ -85,11 +107,12 @@ impl PlacedEntry {
     }
 }
 
-/// Durable-storage acknowledgement for an entry hand-off.
+/// Durable-storage acknowledgement for an entry hand-off delta.
 ///
-/// `key` is the placement key durably persisted by the receiver. `entry` is the
-/// exact value persisted there and therefore the equality witness used by the
-/// sender before deleting its local copy.
+/// `key` is the placement key updated by the receiver. `entry` is the copied
+/// delta that the receiver joined into its local least upper bound. The sender
+/// uses equality with its current local value before deleting; if the sender has
+/// observed any newer delta meanwhile, deletion is skipped.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SyncedEntryAck {
     /// The placement key durably persisted by the sync receiver.
@@ -99,7 +122,7 @@ pub struct SyncedEntryAck {
 }
 
 impl SyncedEntryAck {
-    /// Witness that `entry` was durably persisted at `key`.
+    /// Witness that `entry` was durably joined at `key`.
     pub fn new(key: Did, entry: Entry) -> Self {
         Self { key, entry }
     }
@@ -165,6 +188,16 @@ impl EntryLookupEvidence {
 }
 
 impl Entry {
+    /// Construct an entry with empty CRDT metadata.
+    pub fn new(did: Did, data: Vec<Encoded>, kind: EntryKind) -> Self {
+        Self {
+            did,
+            data,
+            kind,
+            crdt: EntryCrdt::default(),
+        }
+    }
+
     /// Generate did from topic.
     pub fn gen_did(topic: &str) -> Result<Did> {
         let hash: HashStr = topic.into();
@@ -175,6 +208,23 @@ impl Entry {
 }
 
 impl EntryOperation {
+    /// Return this operation with CRDT versions assigned at the operation boundary.
+    ///
+    /// Existing CRDT witnesses are preserved so forwarded operations keep the
+    /// origin's dot/version instead of being reissued by every routing hop.
+    pub fn stamped(self, actor: Did) -> Result<Self> {
+        Ok(match self {
+            EntryOperation::Overwrite(entry) => {
+                EntryOperation::Overwrite(entry.ensure_overwrite_stamp(actor)?)
+            }
+            EntryOperation::Extend(entry) => {
+                EntryOperation::Extend(entry.ensure_delta_stamp(actor)?)
+            }
+            EntryOperation::Touch(entry) => EntryOperation::Touch(entry.ensure_delta_stamp(actor)?),
+            EntryOperation::JoinSubring(name, did) => EntryOperation::JoinSubring(name, did),
+        })
+    }
+
     /// Extract the did of target Entry.
     pub fn did(&self) -> Result<Did> {
         Ok(match self {
@@ -199,11 +249,7 @@ impl EntryOperation {
     pub fn gen_default_entry(self) -> Result<Entry> {
         match self {
             EntryOperation::JoinSubring(name, did) => Subring::new(&name, did)?.try_into(),
-            _ => Ok(Entry {
-                did: self.did()?,
-                data: vec![],
-                kind: self.kind(),
-            }),
+            _ => Ok(Entry::new(self.did()?, vec![], self.kind())),
         }
     }
 }
@@ -219,6 +265,7 @@ impl TryFrom<MessagePayload> for Entry {
             did,
             data: vec![data],
             kind: EntryKind::RelayMessage,
+            crdt: EntryCrdt::default(),
         })
     }
 }
@@ -230,6 +277,7 @@ impl TryFrom<(String, Encoded)> for Entry {
             did: Self::gen_did(&topic)?,
             data: vec![e],
             kind: EntryKind::Data,
+            crdt: EntryCrdt::default(),
         })
     }
 }
@@ -250,6 +298,205 @@ impl TryFrom<String> for Entry {
 }
 
 impl Entry {
+    fn with_element_dots(mut self, version: EntryVersion) -> Result<Self> {
+        self.crdt.dots = self
+            .data
+            .iter()
+            .enumerate()
+            .map(|(index, value)| EntryDot::for_encoded(version, index, value))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(self)
+    }
+
+    fn stamp_overwrite(mut self, version: EntryVersion) -> Result<Self> {
+        self.crdt.register = version;
+        self.with_element_dots(version)
+    }
+
+    fn stamp_delta(self, version: EntryVersion) -> Result<Self> {
+        self.with_element_dots(version)
+    }
+
+    fn ensure_overwrite_stamp(self, actor: Did) -> Result<Self> {
+        if self.crdt.has_witness() {
+            Ok(self)
+        } else {
+            self.stamp_overwrite(EntryVersion::issued_by(actor))
+        }
+    }
+
+    fn ensure_delta_stamp(self, actor: Did) -> Result<Self> {
+        if self.crdt.has_witness() {
+            Ok(self)
+        } else {
+            self.stamp_delta(EntryVersion::issued_by(actor))
+        }
+    }
+
+    fn max_observed_version(&self) -> EntryVersion {
+        self.crdt
+            .dots
+            .iter()
+            .map(|dot| dot.version)
+            .chain(self.crdt.tombstones.iter().map(|dot| dot.version))
+            .fold(self.crdt.register, EntryVersion::max)
+    }
+
+    fn observed_operation_version(&self, actor: Did) -> EntryVersion {
+        let issued = EntryVersion::issued_by(actor);
+        self.crdt
+            .dots
+            .iter()
+            .map(|dot| dot.version)
+            .chain(std::iter::once(self.crdt.register))
+            .max()
+            .filter(|version| *version != EntryVersion::default())
+            .unwrap_or(issued)
+    }
+
+    fn ensure_overwrite_stamp_after(self, actor: Did, floor: EntryVersion) -> Result<Self> {
+        let version = self.observed_operation_version(actor).after(floor);
+        self.stamp_overwrite(version)
+    }
+
+    fn ensure_delta_stamp_after(self, actor: Did, floor: EntryVersion) -> Result<Self> {
+        let version = self.observed_operation_version(actor).after(floor);
+        self.stamp_delta(version)
+    }
+
+    fn validate_same_carrier(&self, other: &Self) -> Result<()> {
+        if !self.same_kind_as(other) {
+            return Err(Error::EntryKindNotEqual);
+        }
+        if !self.same_key_as(other) {
+            return Err(Error::EntryDidNotEqual);
+        }
+        Ok(())
+    }
+
+    fn elements(&self) -> Result<Vec<EntryElement>> {
+        self.data
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(index, value)| {
+                let dot = if let Some(dot) = self.crdt.dots.get(index).copied() {
+                    dot
+                } else {
+                    EntryDot::for_encoded(self.crdt.register, index, &value)?
+                };
+                Ok(EntryElement { value, dot })
+            })
+            .collect()
+    }
+
+    fn topic_buffer(&self) -> Result<DataTopicBuffer> {
+        let mut values = BTreeMap::new();
+        for element in self.elements()? {
+            values
+                .entry(element.value)
+                .and_modify(|current: &mut EntryDot| {
+                    *current = (*current).max(element.dot);
+                })
+                .or_insert(element.dot);
+        }
+        Ok(DataTopicBuffer::new(self.crdt.register, values))
+    }
+
+    fn relay_set(&self) -> Result<RelayMessageSet> {
+        Ok(RelayMessageSet::new(
+            self.topic_buffer()?,
+            self.crdt.tombstones.iter().copied().collect(),
+        ))
+    }
+
+    fn subring_member_set(&self) -> Result<SubringMemberSet> {
+        let subring: Subring = self.clone().try_into()?;
+        let mut members = SubringMemberSet::new();
+        for member in subring.finger.list().iter().flatten().copied() {
+            members.insert(member);
+        }
+        Ok(members)
+    }
+
+    fn materialize_elements(
+        did: Did,
+        kind: EntryKind,
+        register: EntryVersion,
+        elements: impl IntoIterator<Item = (Encoded, EntryDot)>,
+        tombstones: BTreeSet<EntryDot>,
+    ) -> Self {
+        let mut visible = elements
+            .into_iter()
+            .filter(|(_, dot)| dot.version >= register && !tombstones.contains(dot))
+            .collect::<Vec<_>>();
+        visible.sort_by_key(|(value, dot)| (*dot, value.clone()));
+        let skip_count = visible.len().saturating_sub(ENTRY_DATA_MAX_LEN);
+        let visible = visible.into_iter().skip(skip_count).collect::<Vec<_>>();
+        let (data, dots): (Vec<_>, Vec<_>) = visible.into_iter().unzip();
+
+        Self {
+            did,
+            data,
+            kind,
+            crdt: EntryCrdt {
+                register,
+                dots,
+                tombstones: tombstones.into_iter().collect(),
+            },
+        }
+    }
+
+    fn materialize_topic_buffer(&self, buffer: DataTopicBuffer) -> Self {
+        Self::materialize_elements(
+            self.did,
+            self.kind,
+            buffer.register,
+            buffer.values,
+            BTreeSet::new(),
+        )
+    }
+
+    fn materialize_relay_set(&self, set: RelayMessageSet) -> Self {
+        Self::materialize_elements(
+            self.did,
+            self.kind,
+            set.adds.register,
+            set.adds.values,
+            set.removes,
+        )
+    }
+
+    fn join_subring_entry(&self, other: &Self) -> Result<Self> {
+        let members = self.subring_member_set()?.join(other.subring_member_set()?);
+        let mut subring: Subring = self.clone().try_into()?;
+        for member in members.iter().copied() {
+            subring.finger.join(member);
+        }
+        let mut entry: Entry = subring.try_into()?;
+        entry.crdt.register = self.crdt.register.max(other.crdt.register);
+        Ok(entry)
+    }
+
+    /// Merge two entries from the same replicated carrier.
+    ///
+    /// Law: for a fixed `(did, kind)` carrier, this is the state-based CRDT
+    /// join. Data entries are bounded LWW element sets with an LWW overwrite
+    /// register; subring entries are grow-only member sets; relay entries are
+    /// two-phase sets whose remove side is carried by tombstones.
+    pub fn join(&self, other: Self) -> Result<Self> {
+        self.validate_same_carrier(&other)?;
+        match self.kind {
+            EntryKind::Data => {
+                Ok(self.materialize_topic_buffer(self.topic_buffer()?.join(other.topic_buffer()?)))
+            }
+            EntryKind::RelayMessage => {
+                Ok(self.materialize_relay_set(self.relay_set()?.join(other.relay_set()?)))
+            }
+            EntryKind::Subring => self.join_subring_entry(&other),
+        }
+    }
+
     /// Affine Transport entry to a list of affined did
     pub fn affine(&self, scalar: u16) -> Result<Vec<Entry>> {
         Ok(self
@@ -293,10 +540,21 @@ impl Entry {
     ///
     /// Post: `result.data.len() <= ENTRY_DATA_MAX_LEN`.
     pub fn into_storage_entry(self) -> Self {
+        let skip_count = self.data.len().saturating_sub(ENTRY_DATA_MAX_LEN);
+        let dots = if self.crdt.dots.len() == self.data.len() {
+            self.crdt.dots.into_iter().skip(skip_count).collect()
+        } else {
+            self.crdt.dots
+        };
         Self {
             did: self.did,
             data: Self::cap_recent_data(self.data),
             kind: self.kind,
+            crdt: EntryCrdt {
+                register: self.crdt.register,
+                dots,
+                tombstones: self.crdt.tombstones,
+            },
         }
     }
 
@@ -317,17 +575,7 @@ impl Entry {
         if !self.is_data_entry() {
             return Err(Error::EntryNotOverwritable);
         }
-        if !self.same_kind_as(&other) {
-            return Err(Error::EntryKindNotEqual);
-        }
-        if !self.same_key_as(&other) {
-            return Err(Error::EntryDidNotEqual);
-        }
-        Ok(Self {
-            did: other.did,
-            data: Self::cap_recent_data(other.data),
-            kind: other.kind,
-        })
+        self.join(other.ensure_overwrite_stamp_after(Did::default(), self.max_observed_version())?)
     }
 
     /// This method is used to extend data to a Data kind [`Entry`].
@@ -336,22 +584,7 @@ impl Entry {
         if !self.is_data_entry() {
             return Err(Error::EntryNotAppendable);
         }
-        if !self.same_kind_as(&other) {
-            return Err(Error::EntryKindNotEqual);
-        }
-        if !self.same_key_as(&other) {
-            return Err(Error::EntryDidNotEqual);
-        }
-
-        let mut data = self.data.clone();
-        data.extend_from_slice(&other.data);
-        let data = Self::cap_recent_data(data);
-
-        Ok(Self {
-            did: self.did,
-            data,
-            kind: self.kind,
-        })
+        self.join(other.ensure_delta_stamp_after(Did::default(), self.max_observed_version())?)
     }
 
     /// This method is used to extend data to a Data kind [`Entry`] uniquely.
@@ -361,27 +594,7 @@ impl Entry {
         if !self.is_data_entry() {
             return Err(Error::EntryNotAppendable);
         }
-        if !self.same_kind_as(&other) {
-            return Err(Error::EntryKindNotEqual);
-        }
-        if !self.same_key_as(&other) {
-            return Err(Error::EntryDidNotEqual);
-        }
-
-        let mut data = self
-            .data
-            .iter()
-            .filter(|e| !other.data.contains(e))
-            .cloned()
-            .collect::<Vec<_>>();
-        data.extend_from_slice(&other.data);
-        let data = Self::cap_recent_data(data);
-
-        Ok(Self {
-            did: self.did,
-            data,
-            kind: self.kind,
-        })
+        self.join(other.ensure_delta_stamp_after(Did::default(), self.max_observed_version())?)
     }
 
     /// This method is used to join a subring.
@@ -393,7 +606,8 @@ impl Entry {
 
         let mut subring: Subring = self.clone().try_into()?;
         subring.finger.join(did);
-        subring.try_into()
+        let other: Entry = subring.try_into()?;
+        self.join(other)
     }
 }
 
@@ -402,6 +616,8 @@ mod tests {
     use num_bigint::BigUint;
 
     use super::*;
+    use crate::algebra::assert_join_semilattice_laws;
+    use crate::algebra::assert_strong_eventual_consistency;
     use crate::ecc::SecretKey;
     use crate::message::Message;
     use crate::session::SessionSk;
@@ -419,11 +635,7 @@ mod tests {
             .into_iter()
             .map(|value| value.encode())
             .collect::<Result<Vec<_>>>()?;
-        Ok(Entry {
-            did: Entry::gen_did(topic)?,
-            data,
-            kind: EntryKind::Data,
-        })
+        Ok(Entry::new(Entry::gen_did(topic)?, data, EntryKind::Data))
     }
 
     fn overflowing_data_entry(topic: &str, overflow: usize) -> Result<(Entry, usize)> {
@@ -465,13 +677,111 @@ mod tests {
         Subring::new(name, creator)?.try_into()
     }
 
+    fn version(counter: u128) -> EntryVersion {
+        EntryVersion::new(
+            counter,
+            Did::from(u32::try_from(counter).unwrap_or(u32::MAX)),
+        )
+    }
+
+    fn data_delta(topic: &str, value: &str, counter: u128) -> Result<Entry> {
+        data_entry(topic, value)?.stamp_delta(version(counter))
+    }
+
+    fn overwrite_delta(topic: &str, value: &str, counter: u128) -> Result<Entry> {
+        data_entry(topic, value)?.stamp_overwrite(version(counter))
+    }
+
+    #[test]
+    fn gset_satisfies_join_semilattice_laws() {
+        let mut a = GSet::new();
+        a.insert(Did::from(1u32));
+        let mut b = GSet::new();
+        b.insert(Did::from(2u32));
+        let mut ab = GSet::new();
+        ab.insert(Did::from(1u32));
+        ab.insert(Did::from(2u32));
+
+        assert_join_semilattice_laws(&[GSet::new(), a, b, ab]);
+    }
+
+    #[test]
+    fn data_topic_buffer_satisfies_join_semilattice_laws() -> Result<()> {
+        let samples = [
+            Entry::new(Entry::gen_did("topic")?, vec![], EntryKind::Data).topic_buffer()?,
+            data_delta("topic", "a", 1)?.topic_buffer()?,
+            data_delta("topic", "b", 2)?.topic_buffer()?,
+            overwrite_delta("topic", "c", 3)?.topic_buffer()?,
+        ];
+
+        assert_join_semilattice_laws(&samples);
+        Ok(())
+    }
+
+    #[test]
+    fn relay_message_set_satisfies_join_semilattice_laws() -> Result<()> {
+        let did = Did::from(10u32);
+        let a = Entry::new(did, vec![encoded("a")?], EntryKind::RelayMessage)
+            .stamp_delta(version(1))?
+            .relay_set()?;
+        let b = Entry::new(did, vec![encoded("b")?], EntryKind::RelayMessage)
+            .stamp_delta(version(2))?
+            .relay_set()?;
+
+        assert_join_semilattice_laws(&[RelayMessageSet::default(), a, b]);
+        Ok(())
+    }
+
+    #[test]
+    fn entry_join_is_strongly_eventually_consistent_for_data_deltas() -> Result<()> {
+        let base = Entry::new(Entry::gen_did("topic")?, vec![], EntryKind::Data);
+        let deltas = vec![
+            data_delta("topic", "a", 1)?,
+            data_delta("topic", "b", 2)?,
+            data_delta("topic", "a", 3)?,
+        ];
+
+        let forward = deltas
+            .iter()
+            .cloned()
+            .try_fold(base.clone(), |acc, delta| acc.join(delta))?;
+        let reverse = deltas
+            .iter()
+            .rev()
+            .cloned()
+            .try_fold(base.clone(), |acc, delta| acc.join(delta))?;
+        let duplicated = deltas
+            .iter()
+            .cloned()
+            .chain(deltas.iter().cloned())
+            .try_fold(base, |acc, delta| acc.join(delta))?;
+
+        assert_eq!(forward, reverse);
+        assert_eq!(forward, duplicated);
+        assert_eq!(decode_entry_data(&forward)?, vec![
+            String::from("b"),
+            String::from("a")
+        ]);
+        Ok(())
+    }
+
+    #[test]
+    fn generic_sec_witness_accepts_data_topic_buffer_deltas() -> Result<()> {
+        let base = Entry::new(Entry::gen_did("topic")?, vec![], EntryKind::Data).topic_buffer()?;
+        let deltas = vec![
+            data_delta("topic", "a", 1)?.topic_buffer()?,
+            data_delta("topic", "b", 2)?.topic_buffer()?,
+        ];
+
+        assert_strong_eventual_consistency(base, &deltas);
+        Ok(())
+    }
+
     #[test]
     fn overwrite_replaces_data_for_same_data_entry() -> Result<()> {
         let entry = data_entry("topic", "old")?;
         let other = data_entry("topic", "new")?;
-
         let updated = entry.overwrite(other)?;
-
         assert_eq!(decode_entry_data(&updated)?, vec![String::from("new")]);
         Ok(())
     }
@@ -518,9 +828,7 @@ mod tests {
         let overflow = 3;
         let (incoming, incoming_count) = overflowing_data_entry("topic", overflow)?;
         let entry = data_entry("topic", "base")?;
-
         let updated = entry.overwrite(incoming)?;
-
         assert_entry_keeps_recent_overflow(&updated, incoming_count, overflow)
     }
 
@@ -528,9 +836,7 @@ mod tests {
     fn extend_appends_data_for_same_entry() -> Result<()> {
         let entry = data_entry("topic", "first")?;
         let other = data_entry("topic", "second")?;
-
         let updated = entry.extend(other)?;
-
         assert_eq!(decode_entry_data(&updated)?, vec![
             String::from("first"),
             String::from("second")
@@ -541,7 +847,6 @@ mod tests {
     #[test]
     fn extend_trims_oldest_items_at_max_len() -> Result<()> {
         let mut entry = data_entry("topic", "test0")?;
-
         for i in 1..ENTRY_DATA_MAX_LEN {
             let data = format!("test{i}");
             let other = data_entry("topic", &data)?;
@@ -553,9 +858,7 @@ mod tests {
             let data = format!("test{i}");
             let other = data_entry("topic", &data)?;
             entry = entry.extend(other)?;
-
             assert_eq!(entry.data.len(), ENTRY_DATA_MAX_LEN);
-
             let decoded = decode_entry_data(&entry)?;
             assert_eq!(
                 decoded.first(),
@@ -563,7 +866,6 @@ mod tests {
             );
             assert_eq!(decoded.last(), Some(&data));
         }
-
         Ok(())
     }
 
@@ -572,9 +874,7 @@ mod tests {
         let overflow = 3;
         let (incoming, incoming_count) = overflowing_data_entry("topic", overflow)?;
         let entry = data_entry("topic", "base")?;
-
         let updated = entry.extend(incoming)?;
-
         assert_entry_keeps_recent_overflow(&updated, incoming_count, overflow)
     }
 
@@ -596,9 +896,7 @@ mod tests {
             .extend(data_entry("topic", "b")?)?
             .extend(data_entry("topic", "c")?)?;
         let touched = data_entry("topic", "b")?;
-
         let updated = entry.touch(touched)?;
-
         assert_eq!(decode_entry_data(&updated)?, vec![
             String::from("a"),
             String::from("c"),
@@ -613,9 +911,7 @@ mod tests {
         for i in 1..ENTRY_DATA_MAX_LEN {
             entry = entry.extend(data_entry("topic", &format!("test{i}"))?)?;
         }
-
         let updated = entry.touch(data_entry("topic", "test0")?)?;
-
         assert_eq!(updated.data.len(), ENTRY_DATA_MAX_LEN);
         let decoded = decode_entry_data(&updated)?;
         assert_eq!(decoded.first(), Some(&String::from("test1")));
@@ -628,9 +924,7 @@ mod tests {
         let overflow = 3;
         let (incoming, incoming_count) = overflowing_data_entry("topic", overflow)?;
         let entry = data_entry("topic", "base")?;
-
         let updated = entry.touch(incoming)?;
-
         assert_entry_keeps_recent_overflow(&updated, incoming_count, overflow)
     }
 
@@ -638,10 +932,8 @@ mod tests {
     fn join_subring_adds_member_to_subring_entry() -> Result<()> {
         let entry = subring_entry("ring")?;
         let member = Entry::gen_did("member")?;
-
         let updated = entry.join_subring(member)?;
         let subring = Subring::try_from(updated)?;
-
         assert_eq!(subring.finger.first(), Some(member));
         Ok(())
     }
@@ -662,7 +954,6 @@ mod tests {
     fn operation_default_entry_matches_operation_kind() -> Result<()> {
         let target = data_entry("topic", "value")?;
         let default = EntryOperation::Extend(target.clone()).gen_default_entry()?;
-
         assert_eq!(default.did, target.did);
         assert_eq!(default.kind, EntryKind::Data);
         assert!(default.data.is_empty());
@@ -676,10 +967,8 @@ mod tests {
         let signer: Did = key.address().into();
         let payload =
             MessagePayload::new_send(Message::custom(b"relay")?, &session, signer, signer)?;
-
         let entry = Entry::try_from(payload)?;
         let expected = BigUint::from(signer) + BigUint::from(1u16);
-
         assert_eq!(entry.did, expected.into());
         assert_eq!(entry.kind, EntryKind::RelayMessage);
         Ok(())
@@ -689,7 +978,6 @@ mod tests {
     fn affine_preserves_payload_and_kind_while_rotating_keys() -> Result<()> {
         let entry = data_entry("topic", "value")?;
         let affined = entry.affine(3)?;
-
         assert_eq!(affined.len(), 3);
         for rotated in affined {
             assert_eq!(rotated.data, entry.data);

--- a/crates/core/src/dht/entry/crdt.rs
+++ b/crates/core/src/dht/entry/crdt.rs
@@ -1,18 +1,22 @@
 //! CRDT carriers for DHT entries.
 //!
 //! State variables:
-//! - `register` is an LWW reset floor for overwrite.
+//! - `register` is an optional LWW reset floor for overwrite.
 //! - `values` is an LWW element set keyed by encoded payload.
 //! - `removes` is a two-phase tombstone set for relay-message entries.
 //!
-//! Laws:
+//! Semilattice laws:
 //! - `GSet` join is set union.
+//! - `DataTopicBuffer` join is idempotent, commutative, and associative over
+//!   normalized LWW element sets.
+//! - `RelayMessageSet` join is idempotent, commutative, and associative over
+//!   normalized two-phase sets.
+//!
+//! Constructor postconditions:
 //! - `DataTopicBuffer::new` preserves only values whose dot is at or after the
-//!   reset floor.
-//! - `DataTopicBuffer` join is pointwise maximum plus the maximum reset floor.
+//!   reset floor when a reset floor exists.
 //! - `RelayMessageSet::new` preserves only adds whose dot has not been
 //!   tombstoned.
-//! - `RelayMessageSet` join is add-set join plus tombstone union.
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -20,23 +24,25 @@ use std::collections::BTreeSet;
 use serde::Deserialize;
 use serde::Serialize;
 
-use super::Entry;
 use crate::algebra::JoinSemilattice;
 use crate::dht::Did;
 use crate::error::Error;
 use crate::error::Result;
 use crate::message::Encoded;
 
-/// Version for LWW entry registers and element dots.
+/// Hybrid logical version for LWW entry registers and element dots.
 ///
-/// The timestamp and storage actor are assigned at the storage-operation
-/// boundary. `operation` is a deterministic content digest of that operation,
-/// giving registers and element dots a total tiebreak when one actor processes
-/// multiple writes in the same millisecond.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+/// `logical_time_ms` starts from the wall-clock millisecond observed at the
+/// storage-operation boundary, then advances beyond any local floor that would
+/// otherwise dominate it. `actor` and `operation` make concurrent writes from
+/// the same millisecond totally ordered without claiming wall-clock recency.
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
 pub struct EntryVersion {
-    /// Milliseconds since Unix epoch when the operation was issued.
-    pub epoch_ms: u128,
+    /// Hybrid logical time in milliseconds.
+    #[serde(alias = "epoch_ms")]
+    pub logical_time_ms: u128,
     /// Storage node that first stamped the operation.
     pub actor: Did,
     /// Deterministic digest of the stamped operation payload.
@@ -45,10 +51,10 @@ pub struct EntryVersion {
 }
 
 impl EntryVersion {
-    /// Construct a version from an explicit timestamp and actor.
-    pub fn new(epoch_ms: u128, actor: Did, operation: Did) -> Self {
+    /// Construct a version from an explicit hybrid logical time and actor.
+    pub fn new(logical_time_ms: u128, actor: Did, operation: Did) -> Self {
         Self {
-            epoch_ms,
+            logical_time_ms,
             actor,
             operation,
         }
@@ -59,42 +65,36 @@ impl EntryVersion {
         Self::new(crate::utils::get_epoch_ms(), actor, operation)
     }
 
-    pub(super) fn after(self, floor: Self) -> Self {
+    pub(super) fn after(self, floor: Option<Self>) -> Self {
+        let Some(floor) = floor else {
+            return self;
+        };
         if self > floor {
-            self
-        } else {
-            Self {
-                epoch_ms: floor.epoch_ms.saturating_add(1),
-                actor: self.actor,
-                operation: self.operation,
-            }
+            return self;
+        }
+        Self {
+            logical_time_ms: floor.logical_time_ms.saturating_add(1),
+            actor: self.actor,
+            operation: self.operation,
         }
     }
 }
 
 /// Unique add witness for one visible entry payload element.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
 pub struct EntryDot {
     /// LWW version that issued this element.
     pub version: EntryVersion,
     /// Element position inside the issuing operation.
     pub index: u32,
-    /// Stable digest of the encoded element.
-    pub digest: Did,
 }
 
 impl EntryDot {
-    pub(super) fn for_encoded(
-        version: EntryVersion,
-        index: usize,
-        value: &Encoded,
-    ) -> Result<Self> {
+    pub(super) fn for_index(version: EntryVersion, index: usize) -> Result<Self> {
         let index = u32::try_from(index).map_err(|_| Error::EntryDotIndexOutOfBounds { index })?;
-        Ok(Self {
-            version,
-            index,
-            digest: Entry::gen_did(value.value())?,
-        })
+        Ok(Self { version, index })
     }
 }
 
@@ -105,8 +105,8 @@ impl EntryDot {
 /// remove set for relay-message two-phase semantics.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EntryCrdt {
-    /// LWW reset floor for the entry payload.
-    pub register: EntryVersion,
+    /// Optional LWW reset floor for the entry payload.
+    pub register: Option<EntryVersion>,
     /// Per-element add dots. When absent, legacy entries synthesize dots from
     /// their payload order and value digest.
     pub dots: Vec<EntryDot>,
@@ -115,8 +115,13 @@ pub struct EntryCrdt {
 }
 
 impl EntryCrdt {
-    pub(super) fn has_witness(&self) -> bool {
-        *self != Self::default()
+    pub(super) fn has_write_witness(&self) -> bool {
+        self.register.is_some() || !self.dots.is_empty()
+    }
+
+    /// Return the bottom floor used only to lift legacy payloads without dots.
+    pub(super) fn legacy_floor(&self) -> EntryVersion {
+        self.register.unwrap_or_default()
     }
 }
 
@@ -155,14 +160,18 @@ impl<T: Ord> JoinSemilattice for GSet<T> {
 /// Bounded LWW element set used by data topic buffers.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct DataTopicBuffer {
-    pub(super) register: EntryVersion,
+    pub(super) register: Option<EntryVersion>,
     pub(super) values: BTreeMap<Encoded, EntryDot>,
 }
 
 impl DataTopicBuffer {
-    pub(super) fn new(register: EntryVersion, values: BTreeMap<Encoded, EntryDot>) -> Self {
-        let mut values = values;
-        values.retain(|_, dot| dot.version >= register);
+    pub(super) fn new(
+        register: Option<EntryVersion>,
+        mut values: BTreeMap<Encoded, EntryDot>,
+    ) -> Self {
+        if let Some(floor) = register {
+            values.retain(|_, dot| dot.version >= floor);
+        }
         Self { register, values }
     }
 }

--- a/crates/core/src/dht/entry/crdt.rs
+++ b/crates/core/src/dht/entry/crdt.rs
@@ -7,7 +7,11 @@
 //!
 //! Laws:
 //! - `GSet` join is set union.
+//! - `DataTopicBuffer::new` preserves only values whose dot is at or after the
+//!   reset floor.
 //! - `DataTopicBuffer` join is pointwise maximum plus the maximum reset floor.
+//! - `RelayMessageSet::new` preserves only adds whose dot has not been
+//!   tombstoned.
 //! - `RelayMessageSet` join is add-set join plus tombstone union.
 
 use std::collections::BTreeMap;
@@ -19,30 +23,40 @@ use serde::Serialize;
 use super::Entry;
 use crate::algebra::JoinSemilattice;
 use crate::dht::Did;
+use crate::error::Error;
 use crate::error::Result;
 use crate::message::Encoded;
 
 /// Version for LWW entry registers and element dots.
 ///
-/// The timestamp is assigned at the storage-operation boundary. The join
-/// operation only compares versions; it never reads clocks.
+/// The timestamp and storage actor are assigned at the storage-operation
+/// boundary. `operation` is a deterministic content digest of that operation,
+/// giving registers and element dots a total tiebreak when one actor processes
+/// multiple writes in the same millisecond.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct EntryVersion {
     /// Milliseconds since Unix epoch when the operation was issued.
     pub epoch_ms: u128,
-    /// Actor that issued the operation.
+    /// Storage node that first stamped the operation.
     pub actor: Did,
+    /// Deterministic digest of the stamped operation payload.
+    #[serde(default)]
+    pub operation: Did,
 }
 
 impl EntryVersion {
     /// Construct a version from an explicit timestamp and actor.
-    pub fn new(epoch_ms: u128, actor: Did) -> Self {
-        Self { epoch_ms, actor }
+    pub fn new(epoch_ms: u128, actor: Did, operation: Did) -> Self {
+        Self {
+            epoch_ms,
+            actor,
+            operation,
+        }
     }
 
     /// Construct a version at the current operation boundary.
-    pub fn issued_by(actor: Did) -> Self {
-        Self::new(crate::utils::get_epoch_ms(), actor)
+    pub fn issued_by(actor: Did, operation: Did) -> Self {
+        Self::new(crate::utils::get_epoch_ms(), actor, operation)
     }
 
     pub(super) fn after(self, floor: Self) -> Self {
@@ -52,6 +66,7 @@ impl EntryVersion {
             Self {
                 epoch_ms: floor.epoch_ms.saturating_add(1),
                 actor: self.actor,
+                operation: self.operation,
             }
         }
     }
@@ -65,7 +80,7 @@ pub struct EntryDot {
     /// Element position inside the issuing operation.
     pub index: u32,
     /// Stable digest of the encoded element.
-    pub value: Did,
+    pub digest: Did,
 }
 
 impl EntryDot {
@@ -74,11 +89,11 @@ impl EntryDot {
         index: usize,
         value: &Encoded,
     ) -> Result<Self> {
-        let index = u32::try_from(index).unwrap_or(u32::MAX);
+        let index = u32::try_from(index).map_err(|_| Error::EntryDotIndexOutOfBounds { index })?;
         Ok(Self {
             version,
             index,
-            value: Entry::gen_did(value.value())?,
+            digest: Entry::gen_did(value.value())?,
         })
     }
 }
@@ -87,8 +102,7 @@ impl EntryDot {
 ///
 /// `register` is the LWW reset floor used by overwrite. `dots` are per-element
 /// add witnesses used by data/topic and relay element sets. `tombstones` is the
-/// remove set for relay-message two-phase semantics; current production paths
-/// only add messages, but the remove carrier is part of the replicated state.
+/// remove set for relay-message two-phase semantics.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EntryCrdt {
     /// LWW reset floor for the entry payload.
@@ -147,6 +161,8 @@ pub struct DataTopicBuffer {
 
 impl DataTopicBuffer {
     pub(super) fn new(register: EntryVersion, values: BTreeMap<Encoded, EntryDot>) -> Self {
+        let mut values = values;
+        values.retain(|_, dot| dot.version >= register);
         Self { register, values }
     }
 }
@@ -160,8 +176,7 @@ impl JoinSemilattice for DataTopicBuffer {
                 .and_modify(|current| *current = (*current).max(dot))
                 .or_insert(dot);
         }
-        self.values.retain(|_, dot| dot.version >= self.register);
-        self
+        Self::new(self.register, self.values)
     }
 }
 
@@ -174,6 +189,8 @@ pub struct RelayMessageSet {
 
 impl RelayMessageSet {
     pub(super) fn new(adds: DataTopicBuffer, removes: BTreeSet<EntryDot>) -> Self {
+        let mut adds = adds;
+        adds.values.retain(|_, dot| !removes.contains(dot));
         Self { adds, removes }
     }
 }
@@ -182,10 +199,7 @@ impl JoinSemilattice for RelayMessageSet {
     fn join(mut self, other: Self) -> Self {
         self.adds = self.adds.join(other.adds);
         self.removes.extend(other.removes);
-        self.adds
-            .values
-            .retain(|_, dot| !self.removes.contains(dot));
-        self
+        Self::new(self.adds, self.removes)
     }
 }
 

--- a/crates/core/src/dht/entry/crdt.rs
+++ b/crates/core/src/dht/entry/crdt.rs
@@ -197,8 +197,7 @@ pub struct RelayMessageSet {
 }
 
 impl RelayMessageSet {
-    pub(super) fn new(adds: DataTopicBuffer, removes: BTreeSet<EntryDot>) -> Self {
-        let mut adds = adds;
+    pub(super) fn new(mut adds: DataTopicBuffer, removes: BTreeSet<EntryDot>) -> Self {
         adds.values.retain(|_, dot| !removes.contains(dot));
         Self { adds, removes }
     }

--- a/crates/core/src/dht/entry/crdt.rs
+++ b/crates/core/src/dht/entry/crdt.rs
@@ -1,0 +1,193 @@
+//! CRDT carriers for DHT entries.
+//!
+//! State variables:
+//! - `register` is an LWW reset floor for overwrite.
+//! - `values` is an LWW element set keyed by encoded payload.
+//! - `removes` is a two-phase tombstone set for relay-message entries.
+//!
+//! Laws:
+//! - `GSet` join is set union.
+//! - `DataTopicBuffer` join is pointwise maximum plus the maximum reset floor.
+//! - `RelayMessageSet` join is add-set join plus tombstone union.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::Entry;
+use crate::algebra::JoinSemilattice;
+use crate::dht::Did;
+use crate::error::Result;
+use crate::message::Encoded;
+
+/// Version for LWW entry registers and element dots.
+///
+/// The timestamp is assigned at the storage-operation boundary. The join
+/// operation only compares versions; it never reads clocks.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct EntryVersion {
+    /// Milliseconds since Unix epoch when the operation was issued.
+    pub epoch_ms: u128,
+    /// Actor that issued the operation.
+    pub actor: Did,
+}
+
+impl EntryVersion {
+    /// Construct a version from an explicit timestamp and actor.
+    pub fn new(epoch_ms: u128, actor: Did) -> Self {
+        Self { epoch_ms, actor }
+    }
+
+    /// Construct a version at the current operation boundary.
+    pub fn issued_by(actor: Did) -> Self {
+        Self::new(crate::utils::get_epoch_ms(), actor)
+    }
+
+    pub(super) fn after(self, floor: Self) -> Self {
+        if self > floor {
+            self
+        } else {
+            Self {
+                epoch_ms: floor.epoch_ms.saturating_add(1),
+                actor: self.actor,
+            }
+        }
+    }
+}
+
+/// Unique add witness for one visible entry payload element.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct EntryDot {
+    /// LWW version that issued this element.
+    pub version: EntryVersion,
+    /// Element position inside the issuing operation.
+    pub index: u32,
+    /// Stable digest of the encoded element.
+    pub value: Did,
+}
+
+impl EntryDot {
+    pub(super) fn for_encoded(
+        version: EntryVersion,
+        index: usize,
+        value: &Encoded,
+    ) -> Result<Self> {
+        let index = u32::try_from(index).unwrap_or(u32::MAX);
+        Ok(Self {
+            version,
+            index,
+            value: Entry::gen_did(value.value())?,
+        })
+    }
+}
+
+/// CRDT metadata carried beside the legacy entry payload.
+///
+/// `register` is the LWW reset floor used by overwrite. `dots` are per-element
+/// add witnesses used by data/topic and relay element sets. `tombstones` is the
+/// remove set for relay-message two-phase semantics; current production paths
+/// only add messages, but the remove carrier is part of the replicated state.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EntryCrdt {
+    /// LWW reset floor for the entry payload.
+    pub register: EntryVersion,
+    /// Per-element add dots. When absent, legacy entries synthesize dots from
+    /// their payload order and value digest.
+    pub dots: Vec<EntryDot>,
+    /// Remove dots for two-phase sets.
+    pub tombstones: Vec<EntryDot>,
+}
+
+impl EntryCrdt {
+    pub(super) fn has_witness(&self) -> bool {
+        *self != Self::default()
+    }
+}
+
+/// Grow-only set used by subring membership.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct GSet<T: Ord> {
+    members: BTreeSet<T>,
+}
+
+impl<T: Ord> GSet<T> {
+    /// Construct an empty grow-only set.
+    pub fn new() -> Self {
+        Self {
+            members: BTreeSet::new(),
+        }
+    }
+
+    /// Insert one member.
+    pub fn insert(&mut self, member: T) {
+        self.members.insert(member);
+    }
+
+    /// Iterate over members in deterministic order.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.members.iter()
+    }
+}
+
+impl<T: Ord> JoinSemilattice for GSet<T> {
+    fn join(mut self, other: Self) -> Self {
+        self.members.extend(other.members);
+        self
+    }
+}
+
+/// Bounded LWW element set used by data topic buffers.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DataTopicBuffer {
+    pub(super) register: EntryVersion,
+    pub(super) values: BTreeMap<Encoded, EntryDot>,
+}
+
+impl DataTopicBuffer {
+    pub(super) fn new(register: EntryVersion, values: BTreeMap<Encoded, EntryDot>) -> Self {
+        Self { register, values }
+    }
+}
+
+impl JoinSemilattice for DataTopicBuffer {
+    fn join(mut self, other: Self) -> Self {
+        self.register = self.register.max(other.register);
+        for (value, dot) in other.values {
+            self.values
+                .entry(value)
+                .and_modify(|current| *current = (*current).max(dot))
+                .or_insert(dot);
+        }
+        self.values.retain(|_, dot| dot.version >= self.register);
+        self
+    }
+}
+
+/// Two-phase set used by relay-message storage.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RelayMessageSet {
+    pub(super) adds: DataTopicBuffer,
+    pub(super) removes: BTreeSet<EntryDot>,
+}
+
+impl RelayMessageSet {
+    pub(super) fn new(adds: DataTopicBuffer, removes: BTreeSet<EntryDot>) -> Self {
+        Self { adds, removes }
+    }
+}
+
+impl JoinSemilattice for RelayMessageSet {
+    fn join(mut self, other: Self) -> Self {
+        self.adds = self.adds.join(other.adds);
+        self.removes.extend(other.removes);
+        self.adds
+            .values
+            .retain(|_, dot| !self.removes.contains(dot));
+        self
+    }
+}
+
+/// Grow-only subring membership CRDT.
+pub type SubringMemberSet = GSet<Did>;

--- a/crates/core/src/dht/finger.rs
+++ b/crates/core/src/dht/finger.rs
@@ -157,9 +157,29 @@ impl FingerTable {
         self.size
     }
 
+    /// Get the next finger index maintained by the periodic fixer.
+    pub fn fix_finger_index(&self) -> usize {
+        self.fix_finger_index
+    }
+
     /// get finger list
     pub fn list(&self) -> &Vec<Option<Did>> {
         &self.finger
+    }
+
+    /// Replace the full finger state with a value produced by the pure topology transition.
+    ///
+    /// Post: the table keeps its fixed slot count; entries beyond that count
+    /// are ignored, missing entries become `None`, and the fix cursor is
+    /// clamped to a valid slot when the table is non-empty.
+    pub(crate) fn replace_state(&mut self, fingers: &[Option<Did>], fix_finger_index: usize) {
+        self.finger = fingers.iter().copied().take(self.size).collect();
+        self.finger.resize(self.size, None);
+        self.fix_finger_index = if self.size == 0 {
+            0
+        } else {
+            fix_finger_index % self.size
+        };
     }
 
     /// Reset finger table to empty vector

--- a/crates/core/src/dht/mod.rs
+++ b/crates/core/src/dht/mod.rs
@@ -13,6 +13,8 @@ mod stabilization;
 /// Subring model stored through DHT entries.
 pub mod subring;
 pub mod successor;
+/// Pure Chord topology transition model.
+pub mod topology;
 pub mod types;
 
 pub use chord::EntryStorage;

--- a/crates/core/src/dht/stabilization.rs
+++ b/crates/core/src/dht/stabilization.rs
@@ -96,7 +96,7 @@ impl Stabilizer {
             }
             action => {
                 tracing::error!("Invalid storage repair action: {action:?}");
-                Err(crate::error::Error::PeerRingUnexpectedAction(action))
+                Err(crate::error::Error::unexpected_peer_ring_action(action))
             }
         }
     }

--- a/crates/core/src/dht/stabilization.rs
+++ b/crates/core/src/dht/stabilization.rs
@@ -13,6 +13,7 @@ use crate::dht::Did;
 use crate::dht::PeerRing;
 use crate::dht::PeerRingAction;
 use crate::dht::PeerRingRemoteAction;
+use crate::error::Error;
 use crate::error::Result;
 use crate::message::FindSuccessorReportHandler;
 use crate::message::FindSuccessorSend;
@@ -180,12 +181,17 @@ impl Stabilizer {
                 PeerRingAction::None => Ok(()),
                 PeerRingAction::RemoteAction(
                     closest_predecessor,
-                    PeerRingRemoteAction::FindSuccessorForFix(finger_did),
+                    PeerRingRemoteAction::FindSuccessorForFix {
+                        did: finger_did,
+                        index,
+                    },
                 ) => {
                     tracing::debug!("STABILIZATION fix_fingers: {:?}", finger_did);
                     let msg = Message::FindSuccessorSend(FindSuccessorSend {
                         did: finger_did,
-                        then: FindSuccessorThen::Report(FindSuccessorReportHandler::FixFingerTable),
+                        then: FindSuccessorThen::Report(
+                            FindSuccessorReportHandler::FixFingerTable { index },
+                        ),
                         strict: false,
                     });
                     let payload = MessagePayload::new_send(
@@ -199,7 +205,7 @@ impl Stabilizer {
                 }
                 _ => {
                     tracing::error!("Invalid PeerRing Action");
-                    unreachable!();
+                    Err(Error::PeerRingInvalidAction)
                 }
             },
             Err(e) => {

--- a/crates/core/src/dht/subring.rs
+++ b/crates/core/src/dht/subring.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use super::entry::Entry;
+use super::entry::EntryCrdt;
 use super::entry::EntryKind;
 use super::FingerTable;
 use crate::dht::Did;
@@ -44,6 +45,7 @@ impl TryFrom<Subring> for Entry {
             did: Self::gen_did(&ring.name)?,
             data: vec![data.encode()?],
             kind: EntryKind::Subring,
+            crdt: EntryCrdt::default(),
         })
     }
 }

--- a/crates/core/src/dht/successor.rs
+++ b/crates/core/src/dht/successor.rs
@@ -78,6 +78,11 @@ impl SuccessorSeq {
         BiasId::new(self.did, did)
     }
 
+    /// Maximum number of successors retained by this sequence.
+    pub fn capacity(&self) -> usize {
+        self.max.into()
+    }
+
     /// Check if a node should be inserted into the sequence.
     pub fn should_insert(&self, did: Did) -> Result<bool> {
         if (self.contains(&did)?) || (did == self.did) {

--- a/crates/core/src/dht/topology.rs
+++ b/crates/core/src/dht/topology.rs
@@ -1,0 +1,219 @@
+#![warn(missing_docs)]
+//! Pure topology transition model for Chord.
+//!
+//! This module is the production home of the algebraic operators previously
+//! mirrored only in convergence tests. The mutable [`PeerRing`](super::PeerRing)
+//! shell interprets these pure transitions by writing successor/predecessor
+//! fields and by turning [`TopologyAction`] values into transport actions.
+//!
+//! State variables:
+//! - `R = Z / 2^160`, represented by [`Did`].
+//! - `succ[n]` is the bounded successor sequence for node `n`.
+//! - `pred[n]` is the optional predecessor for node `n`.
+//!
+//! Law: stabilize and rectify are monotone refinements over the finite known
+//! topology set. Their least fixpoint is the converged Chord state.
+
+use num_bigint::BigUint;
+
+use super::Did;
+
+/// Ring bit-width; `Did` is `Z/2^160`.
+pub const RING_BITS: usize = 160;
+
+/// Default successor-list capacity used by the production builder and tests.
+pub const DEFAULT_SUCCESSOR_CAPACITY: usize = 3;
+
+/// Pure per-node topology state.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TopologyState {
+    /// Local node identifier.
+    pub local: Did,
+    /// Known successors, ordered by clockwise distance from `local`.
+    pub successors: Vec<Did>,
+    /// Known predecessor.
+    pub predecessor: Option<Did>,
+}
+
+impl TopologyState {
+    /// Construct a pure topology state.
+    pub fn new(local: Did, successors: Vec<Did>, predecessor: Option<Did>) -> Self {
+        Self {
+            local,
+            successors,
+            predecessor,
+        }
+    }
+}
+
+/// Pure topology input event.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TopologyEvent {
+    /// HMCC/Zave rectify input: one candidate predecessor notified this node.
+    Rectify {
+        /// Candidate predecessor.
+        predecessor: Did,
+    },
+    /// HMCC/Zave stabilize input: topological information returned by the
+    /// current successor.
+    Stabilize {
+        /// Successor list reported by the successor.
+        successors: Vec<Did>,
+        /// Predecessor reported by the successor.
+        predecessor: Option<Did>,
+    },
+}
+
+/// Pure topology side effect emitted by a transition.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TopologyAction {
+    /// Query this improved successor for its successor list.
+    QuerySuccessorList(Did),
+    /// Notify this successor that `local` is its predecessor candidate.
+    Notify(Did),
+}
+
+/// Result of applying one pure topology transition.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TopologyStep {
+    /// Next topology state.
+    pub state: TopologyState,
+    /// Actions to be interpreted by the effect layer.
+    pub actions: Vec<TopologyAction>,
+}
+
+/// `dist(a,b) == (b - a) mod 2^160`, the clockwise distance from `a` to `b`.
+pub fn dist(a: Did, b: Did) -> BigUint {
+    BigUint::from(b - a)
+}
+
+fn push_unique(xs: &mut Vec<Did>, x: Did) {
+    if !xs.contains(&x) {
+        xs.push(x);
+    }
+}
+
+/// `Successors(n)`: the nearest forward nodes, ordered by clockwise distance.
+pub fn successors(all: &[Did], n: Did, capacity: usize) -> Vec<Did> {
+    let mut others: Vec<Did> = all.iter().copied().filter(|&did| did != n).collect();
+    others.sort_by_key(|&did| dist(n, did));
+    others.truncate(capacity);
+    others
+}
+
+/// `Predecessor(n)`: the nearest node behind `n`.
+pub fn predecessor(all: &[Did], n: Did) -> Option<Did> {
+    all.iter()
+        .copied()
+        .filter(|&did| did != n)
+        .max_by_key(|&did| dist(n, did))
+}
+
+/// `Finger(n, bit)`: nearest forward node at distance `>= 2^bit`, else `None`.
+///
+/// This mirrors Rings' sparse/no-wrap finger table, not the Chord paper's
+/// wrapping finger definition.
+pub fn finger(all: &[Did], n: Did, bit: usize) -> Option<Did> {
+    let threshold = BigUint::from(1u8) << bit;
+    all.iter()
+        .copied()
+        .filter(|&did| did != n && dist(n, did) >= threshold)
+        .min_by_key(|&did| dist(n, did))
+}
+
+/// Full sparse/no-wrap finger table predicted by the topology operator.
+pub fn finger_table(all: &[Did], n: Did) -> Vec<Option<Did>> {
+    (0..RING_BITS).map(|bit| finger(all, n, bit)).collect()
+}
+
+/// Correct predecessor value after one HMCC/Zave rectify transition.
+pub fn rectify_predecessor(local: Did, current: Option<Did>, candidate: Did) -> Option<Did> {
+    match current {
+        Some(cur) if dist(local, cur) >= dist(local, candidate) => Some(cur),
+        _ => Some(candidate),
+    }
+}
+
+/// Correct successor list after one HMCC/Zave stabilize transition.
+pub fn stabilize_successors(
+    local: Did,
+    current: &[Did],
+    topo_successors: &[Did],
+    topo_predecessor: Option<Did>,
+    capacity: usize,
+) -> Vec<Did> {
+    let mut known = vec![local];
+    for &did in current {
+        push_unique(&mut known, did);
+    }
+    if let Some(pred) = topo_predecessor {
+        push_unique(&mut known, pred);
+    }
+    for &did in topo_successors
+        .iter()
+        .take(topo_successors.len().saturating_sub(1))
+    {
+        push_unique(&mut known, did);
+    }
+    successors(&known, local, capacity)
+}
+
+/// Improved-successor query emitted by one HMCC/Zave stabilize transition.
+pub fn stabilize_query(local: Did, current: &[Did], topo_predecessor: Option<Did>) -> Option<Did> {
+    let pred = topo_predecessor?;
+    if pred == local {
+        return None;
+    }
+    let old_head = current.iter().copied().min_by_key(|&did| dist(local, did));
+    match old_head {
+        Some(head) if dist(local, pred) >= dist(local, head) => None,
+        _ => Some(pred),
+    }
+}
+
+/// Notify action emitted after one HMCC/Zave stabilize transition.
+pub fn stabilize_notify(local: Did, next_successors: &[Did]) -> Option<Did> {
+    next_successors.first().copied().filter(|&did| did != local)
+}
+
+/// Apply one pure topology transition.
+///
+/// Post: the returned state depends only on `state` and `event`; no locks,
+/// storage, clocks, randomness, or transport effects are read here.
+pub fn step(state: &TopologyState, event: TopologyEvent, capacity: usize) -> TopologyStep {
+    match event {
+        TopologyEvent::Rectify { predecessor } => TopologyStep {
+            state: TopologyState {
+                predecessor: rectify_predecessor(state.local, state.predecessor, predecessor),
+                ..state.clone()
+            },
+            actions: Vec::new(),
+        },
+        TopologyEvent::Stabilize {
+            successors: topo_successors,
+            predecessor: topo_predecessor,
+        } => {
+            let next_successors = stabilize_successors(
+                state.local,
+                &state.successors,
+                &topo_successors,
+                topo_predecessor,
+                capacity,
+            );
+            let mut actions = Vec::new();
+            if let Some(query) = stabilize_query(state.local, &state.successors, topo_predecessor) {
+                actions.push(TopologyAction::QuerySuccessorList(query));
+            }
+            if let Some(notify) = stabilize_notify(state.local, &next_successors) {
+                actions.push(TopologyAction::Notify(notify));
+            }
+            TopologyStep {
+                state: TopologyState {
+                    successors: next_successors,
+                    ..state.clone()
+                },
+                actions,
+            }
+        }
+    }
+}

--- a/crates/core/src/dht/topology.rs
+++ b/crates/core/src/dht/topology.rs
@@ -2,12 +2,13 @@
 //! Pure topology transition model for Chord.
 //!
 //! This module is the production home of the algebraic operators previously
-//! mirrored only in convergence tests. The mutable [`PeerRing`](super::PeerRing)
+//! mirrored only in convergence tests. The mutable [`PeerRing`](crate::dht::PeerRing)
 //! shell interprets these pure transitions by writing successor/predecessor
-//! fields and by turning [`TopologyAction`] values into transport actions.
+//! fields and by turning [`TopologyAction`](crate::dht::topology::TopologyAction)
+//! values into transport actions.
 //!
 //! State variables:
-//! - `R = Z / 2^160`, represented by [`Did`].
+//! - `R = Z / 2^160`, represented by [`Did`](crate::dht::Did).
 //! - `succ[n]` is the bounded successor sequence for node `n`.
 //! - `pred[n]` is the optional predecessor for node `n`.
 //! - `finger[n][i]` is the optional sparse/no-wrap finger-table entry at slot `i`.

--- a/crates/core/src/dht/topology.rs
+++ b/crates/core/src/dht/topology.rs
@@ -398,7 +398,7 @@ fn step_fix_finger(state: &TopologyState) -> TopologyStep {
         };
     }
     let index = (state.fix_finger_index + 1) % state.fingers.len();
-    let did = Did::power_of_two(index);
+    let did = state.local + Did::power_of_two(index);
     match find_successor(state, did) {
         FindSuccessorStep::Local(successor) => TopologyStep {
             state: TopologyState {
@@ -629,6 +629,31 @@ mod tests {
         assert_eq!(next.actions, vec![TopologyAction::FindSuccessorForFix {
             next: next_hop,
             did: Did::power_of_two(3),
+            index: 3
+        }]);
+    }
+
+    #[test]
+    fn fix_finger_step_queries_local_relative_probe() {
+        let local = did(100);
+        let successor = did(104);
+        let next_hop = did(106);
+        let next = step(
+            &state(
+                local,
+                vec![successor],
+                None,
+                vec![None, None, Some(next_hop), None],
+                2,
+            ),
+            TopologyEvent::FixFinger,
+            DEFAULT_SUCCESSOR_CAPACITY,
+        );
+
+        assert_eq!(next.state.fix_finger_index, 3);
+        assert_eq!(next.actions, vec![TopologyAction::FindSuccessorForFix {
+            next: next_hop,
+            did: local + Did::power_of_two(3),
             index: 3
         }]);
     }

--- a/crates/core/src/dht/topology.rs
+++ b/crates/core/src/dht/topology.rs
@@ -10,9 +10,12 @@
 //! - `R = Z / 2^160`, represented by [`Did`].
 //! - `succ[n]` is the bounded successor sequence for node `n`.
 //! - `pred[n]` is the optional predecessor for node `n`.
+//! - `finger[n][i]` is the optional sparse/no-wrap finger-table entry at slot `i`.
 //!
-//! Law: stabilize and rectify are monotone refinements over the finite known
-//! topology set. Their least fixpoint is the converged Chord state.
+//! Law: join, remove, notify, stabilize, and finger maintenance are pure
+//! transitions over this state. Stabilize/notify/finger refinement are monotone
+//! over the finite known topology set; their least fixpoint is the converged
+//! Chord state plus a finger table derived from that topology.
 
 use num_bigint::BigUint;
 
@@ -33,24 +36,65 @@ pub struct TopologyState {
     pub successors: Vec<Did>,
     /// Known predecessor.
     pub predecessor: Option<Did>,
+    /// Sparse/no-wrap finger table.
+    pub fingers: Vec<Option<Did>>,
+    /// Next finger index maintained by the periodic finger fixer.
+    pub fix_finger_index: usize,
 }
 
 impl TopologyState {
     /// Construct a pure topology state.
-    pub fn new(local: Did, successors: Vec<Did>, predecessor: Option<Did>) -> Self {
+    pub fn new(
+        local: Did,
+        successors: Vec<Did>,
+        predecessor: Option<Did>,
+        fingers: Vec<Option<Did>>,
+        fix_finger_index: usize,
+    ) -> Self {
         Self {
             local,
             successors,
             predecessor,
+            fingers,
+            fix_finger_index,
         }
     }
+}
+
+/// Pure result of looking up the owner of a DID in local topology state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FindSuccessorStep {
+    /// The local state can answer with this successor.
+    Local(Did),
+    /// The query must be forwarded to `next`.
+    Remote {
+        /// Next hop.
+        next: Did,
+        /// DID whose successor is being searched.
+        did: Did,
+    },
 }
 
 /// Pure topology input event.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TopologyEvent {
-    /// HMCC/Zave rectify input: one candidate predecessor notified this node.
-    Rectify {
+    /// A connected peer is introduced to the topology state.
+    Join {
+        /// Peer learned by the local node.
+        peer: Did,
+    },
+    /// A peer is removed from successor, predecessor, and finger state.
+    Remove {
+        /// Peer that left or failed.
+        peer: Did,
+    },
+    /// A successor candidate was accepted by the liveness/interpreter boundary.
+    UpdateSuccessor {
+        /// Candidate successor.
+        successor: Did,
+    },
+    /// HMCC/Zave notify input: one candidate predecessor notified this node.
+    Notify {
         /// Candidate predecessor.
         predecessor: Did,
     },
@@ -62,11 +106,36 @@ pub enum TopologyEvent {
         /// Predecessor reported by the successor.
         predecessor: Option<Did>,
     },
+    /// Periodic finger-fix transition.
+    FixFinger,
+    /// Apply a reported successor to a fixed finger slot.
+    ApplyFinger {
+        /// Finger slot to update.
+        index: usize,
+        /// Successor reported for that slot.
+        successor: Did,
+    },
 }
 
 /// Pure topology side effect emitted by a transition.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TopologyAction {
+    /// Ask `next` to find `did` and report with the connect handler.
+    FindSuccessorForConnect {
+        /// Next hop.
+        next: Did,
+        /// DID being searched.
+        did: Did,
+    },
+    /// Ask `next` to find `did` and report with the finger-fix handler.
+    FindSuccessorForFix {
+        /// Next hop.
+        next: Did,
+        /// DID being searched.
+        did: Did,
+        /// Finger slot to update when the report returns.
+        index: usize,
+    },
     /// Query this improved successor for its successor list.
     QuerySuccessorList(Did),
     /// Notify this successor that `local` is its predecessor candidate.
@@ -93,12 +162,17 @@ fn push_unique(xs: &mut Vec<Did>, x: Did) {
     }
 }
 
+fn sorted_successors(mut candidates: Vec<Did>, local: Did, capacity: usize) -> Vec<Did> {
+    candidates.retain(|&did| did != local);
+    candidates.sort_by_key(|&did| dist(local, did));
+    candidates.dedup();
+    candidates.truncate(capacity);
+    candidates
+}
+
 /// `Successors(n)`: the nearest forward nodes, ordered by clockwise distance.
 pub fn successors(all: &[Did], n: Did, capacity: usize) -> Vec<Did> {
-    let mut others: Vec<Did> = all.iter().copied().filter(|&did| did != n).collect();
-    others.sort_by_key(|&did| dist(n, did));
-    others.truncate(capacity);
-    others
+    sorted_successors(all.to_vec(), n, capacity)
 }
 
 /// `Predecessor(n)`: the nearest node behind `n`.
@@ -124,6 +198,84 @@ pub fn finger(all: &[Did], n: Did, bit: usize) -> Option<Did> {
 /// Full sparse/no-wrap finger table predicted by the topology operator.
 pub fn finger_table(all: &[Did], n: Did) -> Vec<Option<Did>> {
     (0..RING_BITS).map(|bit| finger(all, n, bit)).collect()
+}
+
+/// Correct successor list after introducing one candidate successor.
+pub fn update_successors(local: Did, current: &[Did], candidate: Did, capacity: usize) -> Vec<Did> {
+    let mut candidates = current.to_vec();
+    push_unique(&mut candidates, candidate);
+    sorted_successors(candidates, local, capacity)
+}
+
+fn finger_join(local: Did, current: &[Option<Did>], peer: Did) -> Vec<Option<Did>> {
+    let bias = dist(local, peer);
+    current
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(slot, old)| {
+            let pos = BigUint::from(Did::power_of_two(slot));
+            if bias < pos || peer == local {
+                old
+            } else {
+                match old {
+                    Some(existing) if dist(local, existing) < bias => old,
+                    _ => Some(peer),
+                }
+            }
+        })
+        .collect()
+}
+
+fn finger_remove(current: &[Option<Did>], peer: Did) -> Vec<Option<Did>> {
+    let mut next = current.to_vec();
+    let indexes = next
+        .iter()
+        .enumerate()
+        .filter(|(_, did)| **did == Some(peer))
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    let (Some(first), Some(last)) = (indexes.first().copied(), indexes.last().copied()) else {
+        return next;
+    };
+    let replacement = next.get(last.saturating_add(1)).copied().flatten();
+    for slot in next.iter_mut().take(last.saturating_add(1)).skip(first) {
+        *slot = replacement;
+    }
+    next
+}
+
+fn finger_set(
+    local: Did,
+    current: &[Option<Did>],
+    index: usize,
+    successor: Did,
+) -> Vec<Option<Did>> {
+    let mut next = current.to_vec();
+    if successor != local {
+        if let Some(slot) = next.get_mut(index) {
+            *slot = Some(successor);
+        }
+    }
+    next
+}
+
+/// Pure Chord successor lookup against one topology state.
+pub fn find_successor(state: &TopologyState, did: Did) -> FindSuccessorStep {
+    let head = state.successors.first().copied().unwrap_or(state.local);
+    if state.successors.is_empty() || dist(state.local, did) <= dist(state.local, head) {
+        FindSuccessorStep::Local(head)
+    } else {
+        let next = state
+            .fingers
+            .iter()
+            .rev()
+            .flatten()
+            .copied()
+            .find(|peer| dist(state.local, *peer) < dist(state.local, did))
+            .unwrap_or(state.local);
+        FindSuccessorStep::Remote { next, did }
+    }
 }
 
 /// Correct predecessor value after one HMCC/Zave rectify transition.
@@ -176,13 +328,107 @@ pub fn stabilize_notify(local: Did, next_successors: &[Did]) -> Option<Did> {
     next_successors.first().copied().filter(|&did| did != local)
 }
 
+fn step_join(state: &TopologyState, peer: Did, capacity: usize) -> TopologyStep {
+    if peer == state.local {
+        return TopologyStep {
+            state: state.clone(),
+            actions: Vec::new(),
+        };
+    }
+    TopologyStep {
+        state: TopologyState {
+            successors: update_successors(state.local, &state.successors, peer, capacity),
+            fingers: finger_join(state.local, &state.fingers, peer),
+            ..state.clone()
+        },
+        actions: vec![TopologyAction::FindSuccessorForConnect {
+            next: peer,
+            did: state.local,
+        }],
+    }
+}
+
+fn step_remove(state: &TopologyState, peer: Did, capacity: usize) -> TopologyStep {
+    let mut next_successors = state
+        .successors
+        .iter()
+        .copied()
+        .filter(|&did| did != peer)
+        .collect::<Vec<_>>();
+    let fingers = finger_remove(&state.fingers, peer);
+    if next_successors.is_empty() {
+        if let Some(first_finger) = fingers.iter().flatten().copied().next() {
+            next_successors =
+                update_successors(state.local, &next_successors, first_finger, capacity);
+        }
+    }
+    TopologyStep {
+        state: TopologyState {
+            successors: next_successors,
+            predecessor: state.predecessor.filter(|&did| did != peer),
+            fingers,
+            ..state.clone()
+        },
+        actions: Vec::new(),
+    }
+}
+
+fn step_update_successor(state: &TopologyState, successor: Did, capacity: usize) -> TopologyStep {
+    let next_successors = update_successors(state.local, &state.successors, successor, capacity);
+    let inserted = !state.successors.contains(&successor) && next_successors.contains(&successor);
+    TopologyStep {
+        state: TopologyState {
+            successors: next_successors,
+            ..state.clone()
+        },
+        actions: if inserted {
+            vec![TopologyAction::QuerySuccessorList(successor)]
+        } else {
+            Vec::new()
+        },
+    }
+}
+
+fn step_fix_finger(state: &TopologyState) -> TopologyStep {
+    if state.fingers.is_empty() {
+        return TopologyStep {
+            state: state.clone(),
+            actions: Vec::new(),
+        };
+    }
+    let index = (state.fix_finger_index + 1) % state.fingers.len();
+    let did = Did::power_of_two(index);
+    match find_successor(state, did) {
+        FindSuccessorStep::Local(successor) => TopologyStep {
+            state: TopologyState {
+                fingers: finger_set(state.local, &state.fingers, index, successor),
+                fix_finger_index: index,
+                ..state.clone()
+            },
+            actions: Vec::new(),
+        },
+        FindSuccessorStep::Remote { next, did } => TopologyStep {
+            state: TopologyState {
+                fix_finger_index: index,
+                ..state.clone()
+            },
+            actions: vec![TopologyAction::FindSuccessorForFix { next, did, index }],
+        },
+    }
+}
+
 /// Apply one pure topology transition.
 ///
 /// Post: the returned state depends only on `state` and `event`; no locks,
 /// storage, clocks, randomness, or transport effects are read here.
 pub fn step(state: &TopologyState, event: TopologyEvent, capacity: usize) -> TopologyStep {
     match event {
-        TopologyEvent::Rectify { predecessor } => TopologyStep {
+        TopologyEvent::Join { peer } => step_join(state, peer, capacity),
+        TopologyEvent::Remove { peer } => step_remove(state, peer, capacity),
+        TopologyEvent::UpdateSuccessor { successor } => {
+            step_update_successor(state, successor, capacity)
+        }
+        TopologyEvent::Notify { predecessor } => TopologyStep {
             state: TopologyState {
                 predecessor: rectify_predecessor(state.local, state.predecessor, predecessor),
                 ..state.clone()
@@ -215,5 +461,162 @@ pub fn step(state: &TopologyState, event: TopologyEvent, capacity: usize) -> Top
                 actions,
             }
         }
+        TopologyEvent::FixFinger => step_fix_finger(state),
+        TopologyEvent::ApplyFinger { index, successor } => TopologyStep {
+            state: TopologyState {
+                fingers: finger_set(state.local, &state.fingers, index, successor),
+                ..state.clone()
+            },
+            actions: Vec::new(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn did(value: u32) -> Did {
+        Did::from(value)
+    }
+
+    fn state(
+        local: Did,
+        successors: Vec<Did>,
+        predecessor: Option<Did>,
+        fingers: Vec<Option<Did>>,
+        fix_finger_index: usize,
+    ) -> TopologyState {
+        TopologyState::new(local, successors, predecessor, fingers, fix_finger_index)
+    }
+
+    #[test]
+    fn join_step_updates_successors_fingers_and_connect_action() {
+        let local = did(0);
+        let peer = did(8);
+        let next = step(
+            &state(local, vec![], None, vec![None; 5], 0),
+            TopologyEvent::Join { peer },
+            DEFAULT_SUCCESSOR_CAPACITY,
+        );
+
+        assert_eq!(next.state.successors, vec![peer]);
+        assert_eq!(next.state.fingers, vec![
+            Some(peer),
+            Some(peer),
+            Some(peer),
+            Some(peer),
+            None
+        ]);
+        assert_eq!(next.actions, vec![
+            TopologyAction::FindSuccessorForConnect {
+                next: peer,
+                did: local
+            }
+        ]);
+    }
+
+    #[test]
+    fn remove_step_removes_peer_from_every_topology_slot() {
+        let local = did(0);
+        let peer = did(8);
+        let next = step(
+            &state(
+                local,
+                vec![peer],
+                Some(peer),
+                vec![Some(peer), Some(peer)],
+                0,
+            ),
+            TopologyEvent::Remove { peer },
+            DEFAULT_SUCCESSOR_CAPACITY,
+        );
+
+        assert!(next.state.successors.is_empty());
+        assert_eq!(next.state.predecessor, None);
+        assert_eq!(next.state.fingers, vec![None, None]);
+        assert!(next.actions.is_empty());
+    }
+
+    #[test]
+    fn fix_finger_step_updates_local_successor_slot() {
+        let local = did(0);
+        let successor = did(8);
+        let next = step(
+            &state(local, vec![successor], None, vec![None; 4], 2),
+            TopologyEvent::FixFinger,
+            DEFAULT_SUCCESSOR_CAPACITY,
+        );
+
+        assert_eq!(next.state.fix_finger_index, 3);
+        assert_eq!(next.state.fingers, vec![None, None, None, Some(successor)]);
+        assert!(next.actions.is_empty());
+    }
+
+    #[test]
+    fn fix_finger_step_emits_indexed_remote_action() {
+        let local = did(0);
+        let successor = did(4);
+        let next_hop = did(6);
+        let next = step(
+            &state(
+                local,
+                vec![successor],
+                None,
+                vec![None, None, Some(next_hop), None],
+                2,
+            ),
+            TopologyEvent::FixFinger,
+            DEFAULT_SUCCESSOR_CAPACITY,
+        );
+
+        assert_eq!(next.state.fix_finger_index, 3);
+        assert_eq!(next.actions, vec![TopologyAction::FindSuccessorForFix {
+            next: next_hop,
+            did: Did::power_of_two(3),
+            index: 3
+        }]);
+    }
+
+    #[test]
+    fn apply_finger_step_updates_exact_slot() {
+        let local = did(0);
+        let successor = did(8);
+        let next = step(
+            &state(local, vec![], None, vec![None; 4], 0),
+            TopologyEvent::ApplyFinger {
+                index: 2,
+                successor,
+            },
+            DEFAULT_SUCCESSOR_CAPACITY,
+        );
+
+        assert_eq!(next.state.fingers, vec![None, None, Some(successor), None]);
+        assert!(next.actions.is_empty());
+    }
+
+    #[test]
+    fn apply_finger_step_ignores_self_and_out_of_range_slot() {
+        let local = did(0);
+        let current = state(local, vec![], None, vec![None; 2], 0);
+        let self_update = step(
+            &current,
+            TopologyEvent::ApplyFinger {
+                index: 1,
+                successor: local,
+            },
+            DEFAULT_SUCCESSOR_CAPACITY,
+        );
+        let out_of_range = step(
+            &current,
+            TopologyEvent::ApplyFinger {
+                index: 9,
+                successor: did(9),
+            },
+            DEFAULT_SUCCESSOR_CAPACITY,
+        );
+
+        assert_eq!(self_update.state, current);
+        assert_eq!(out_of_range.state, current);
     }
 }

--- a/crates/core/src/dht/topology.rs
+++ b/crates/core/src/dht/topology.rs
@@ -474,6 +474,8 @@ pub fn step(state: &TopologyState, event: TopologyEvent, capacity: usize) -> Top
 
 #[cfg(test)]
 mod tests {
+    use num_bigint::BigUint;
+
     use super::*;
 
     fn did(value: u32) -> Did {
@@ -488,6 +490,29 @@ mod tests {
         fix_finger_index: usize,
     ) -> TopologyState {
         TopologyState::new(local, successors, predecessor, fingers, fix_finger_index)
+    }
+
+    fn successor_distances(local: Did, successors: &[Did], capacity: usize) -> Vec<BigUint> {
+        let infinity = BigUint::from(1u8) << RING_BITS;
+        (0..capacity)
+            .map(|index| {
+                successors
+                    .get(index)
+                    .map(|successor| dist(local, *successor))
+                    .unwrap_or_else(|| infinity.clone())
+            })
+            .collect()
+    }
+
+    fn refines_successor_distances(before: &TopologyState, after: &TopologyState) -> bool {
+        let before_distances =
+            successor_distances(before.local, &before.successors, DEFAULT_SUCCESSOR_CAPACITY);
+        let after_distances =
+            successor_distances(after.local, &after.successors, DEFAULT_SUCCESSOR_CAPACITY);
+        before_distances
+            .iter()
+            .zip(after_distances.iter())
+            .all(|(before, after)| after <= before)
     }
 
     #[test]
@@ -514,6 +539,35 @@ mod tests {
                 did: local
             }
         ]);
+    }
+
+    #[test]
+    fn join_step_refines_successor_distance_vector() {
+        let local = did(0);
+        let current = state(local, vec![did(20), did(40)], None, vec![None; 5], 0);
+        let next = step(
+            &current,
+            TopologyEvent::Join { peer: did(10) },
+            DEFAULT_SUCCESSOR_CAPACITY,
+        );
+
+        assert!(refines_successor_distances(&current, &next.state));
+    }
+
+    #[test]
+    fn stabilize_step_refines_successor_distance_vector() {
+        let local = did(0);
+        let current = state(local, vec![did(40)], None, vec![None; 5], 0);
+        let next = step(
+            &current,
+            TopologyEvent::Stabilize {
+                successors: vec![did(50), did(60)],
+                predecessor: Some(did(10)),
+            },
+            DEFAULT_SUCCESSOR_CAPACITY,
+        );
+
+        assert!(refines_successor_distances(&current, &next.state));
     }
 
     #[test]

--- a/crates/core/src/dht/types.rs
+++ b/crates/core/src/dht/types.rs
@@ -81,7 +81,7 @@ pub trait ChordStorageSync<Action>: Chord<Action> {
     /// `Entry`s that are no longer between current node and `new_successor`,
     /// and copy them to the new successor.
     ///
-    /// Post: this only copies entries. Deletion is performed by
+    /// Post: this only delivers entry joins. Local cleanup is performed by
     /// [`Self::acknowledge_synced_entries`] after the successor reports durable
     /// storage for specific placement keys.
     async fn sync_entries_with_successor(&self, new_successor: Did) -> Result<Action>;
@@ -97,14 +97,15 @@ pub trait ChordStorageSync<Action>: Chord<Action> {
 
 /// ChordStorageRepair defines additive repair for redundant DHT storage.
 ///
-/// Repair never deletes local copies. It only republishes a known [`Entry`] to
-/// the current affine placement set so missing owners can regain a copy.
+/// Repair never deletes local copies. It only republishes a known [`Entry`] as
+/// a join delivery to the current affine placement set so missing owners can
+/// regain a copy.
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
 pub trait ChordStorageRepair<Action>: Chord<Action> {
     /// Republish every locally stored entry to its current affine owners.
     ///
-    /// Post: no local key is removed. Remote actions, if any, are copy-only
+    /// Post: no local key is removed. Remote actions, if any, are join-delivery
     /// sync messages carrying explicit placement keys.
     async fn republish_local_entries(&self, redundancy: u16) -> Result<Action>;
 

--- a/crates/core/src/ecc/mod.rs
+++ b/crates/core/src/ecc/mod.rs
@@ -1,6 +1,5 @@
 //! ECDSA, EdDSA, and ElGamal
 use std::convert::TryFrom;
-use std::fmt::Write;
 use std::ops::Deref;
 use std::str::FromStr;
 
@@ -64,6 +63,13 @@ pub fn keccak256(bytes: &[u8]) -> [u8; 32] {
 impl HashStr {
     pub fn new<T: Into<String>>(s: T) -> Self {
         HashStr(s.into())
+    }
+
+    /// Compute the SHA-1 digest of raw bytes and encode it as lowercase hex.
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let mut hasher = Sha1::new();
+        hasher.update(bytes);
+        HashStr(hex::encode(hasher.finalize()))
     }
 
     pub fn inner(&self) -> String {
@@ -205,14 +211,7 @@ where T: Into<String>
 {
     fn from(s: T) -> Self {
         let inputs = s.into();
-        let mut hasher = Sha1::new();
-        hasher.update(inputs.as_bytes());
-        let bytes = hasher.finalize();
-        let mut ret = String::with_capacity(bytes.len() * 2);
-        for &b in &bytes {
-            write!(ret, "{b:02x}").unwrap();
-        }
-        HashStr(ret)
+        HashStr::from_bytes(inputs.as_bytes())
     }
 }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -195,7 +195,7 @@ pub enum Error {
     PeerRingInvalidEntry,
 
     #[error("Unexpected PeerRingAction, {0:?}")]
-    PeerRingUnexpectedAction(crate::dht::PeerRingAction),
+    PeerRingUnexpectedAction(Box<crate::dht::PeerRingAction>),
 
     #[error("PeerRing findsuccessor error, {0}")]
     PeerRingFindSuccessor(String),
@@ -414,6 +414,12 @@ pub enum Error {
 
     #[error("External Javascript error: {0}")]
     JsError(String),
+}
+
+impl Error {
+    pub(crate) fn unexpected_peer_ring_action(action: crate::dht::PeerRingAction) -> Self {
+        Self::PeerRingUnexpectedAction(Box::new(action))
+    }
 }
 
 #[cfg(feature = "wasm")]

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -58,6 +58,9 @@ pub enum Error {
     #[error("The type of Entry is not allowed to be joined as a subring")]
     EntryNotJoinable,
 
+    #[error("The type of Entry is not allowed to be tombstoned")]
+    EntryNotTombstonable,
+
     #[error("Affine rotation scalar must be greater than zero")]
     InvalidAffineScalar,
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -61,6 +61,12 @@ pub enum Error {
     #[error("The type of Entry is not allowed to be tombstoned")]
     EntryNotTombstonable,
 
+    #[error("Entry dot index {index} is out of bounds")]
+    EntryDotIndexOutOfBounds {
+        /// Dot index that could not be represented.
+        index: usize,
+    },
+
     #[error("Affine rotation scalar must be greater than zero")]
     InvalidAffineScalar,
 

--- a/crates/core/src/message/effects.rs
+++ b/crates/core/src/message/effects.rs
@@ -172,6 +172,15 @@ pub(crate) enum DhtActionFunctor {
         /// DID being searched.
         did: Did,
     },
+    /// Ask `next` to find `did` and report with the finger-fix handler.
+    FindSuccessorForFix {
+        /// Next hop to query.
+        next: Did,
+        /// DID being searched.
+        did: Did,
+        /// Finger slot fixed by this lookup.
+        index: usize,
+    },
     /// Query a successor for its successor list.
     QueryForSuccessorList {
         /// Successor to query.
@@ -204,6 +213,14 @@ impl TryFrom<&PeerRingAction> for DhtActionFunctor {
                 next: *next,
                 did: *did,
             }),
+            PeerRingAction::RemoteAction(
+                next,
+                PeerRingRemoteAction::FindSuccessorForFix { did, index },
+            ) => Ok(Self::FindSuccessorForFix {
+                next: *next,
+                did: *did,
+                index: *index,
+            }),
             PeerRingAction::RemoteAction(next, PeerRingRemoteAction::QueryForSuccessorList) => {
                 Ok(Self::QueryForSuccessorList { successor: *next })
             }
@@ -227,6 +244,12 @@ impl From<DhtActionFunctor> for PeerRingAction {
             DhtActionFunctor::None => Self::None,
             DhtActionFunctor::FindSuccessorForConnect { next, did } => {
                 Self::RemoteAction(next, PeerRingRemoteAction::FindSuccessorForConnect(did))
+            }
+            DhtActionFunctor::FindSuccessorForFix { next, did, index } => {
+                Self::RemoteAction(next, PeerRingRemoteAction::FindSuccessorForFix {
+                    did,
+                    index,
+                })
             }
             DhtActionFunctor::QueryForSuccessorList { successor } => {
                 Self::RemoteAction(successor, PeerRingRemoteAction::QueryForSuccessorList)
@@ -261,6 +284,25 @@ impl DhtActionFunctor {
                                 strict: false,
                                 then: FindSuccessorThen::Report(
                                     FindSuccessorReportHandler::Connect,
+                                ),
+                            }),
+                            next,
+                        )
+                        .into(),
+                    )
+                }
+            }
+            Self::FindSuccessorForFix { next, did, index } => {
+                if next == did {
+                    None
+                } else {
+                    Some(
+                        MessageSendFunctor::send_direct_message(
+                            Message::FindSuccessorSend(FindSuccessorSend {
+                                did,
+                                strict: false,
+                                then: FindSuccessorThen::Report(
+                                    FindSuccessorReportHandler::FixFingerTable { index },
                                 ),
                             }),
                             next,
@@ -449,6 +491,11 @@ mod tests {
             next: did(),
             did: did(),
         })?;
+        assert_dht_action_functor_section(DhtActionFunctor::FindSuccessorForFix {
+            next: did(),
+            did: did(),
+            index: 7,
+        })?;
 
         assert_dht_action_functor_section(DhtActionFunctor::QueryForSuccessorList {
             successor: did(),
@@ -464,6 +511,13 @@ mod tests {
         assert_dht_action_functor_retraction(PeerRingAction::RemoteAction(
             did(),
             PeerRingRemoteAction::FindSuccessorForConnect(did()),
+        ))?;
+        assert_dht_action_functor_retraction(PeerRingAction::RemoteAction(
+            did(),
+            PeerRingRemoteAction::FindSuccessorForFix {
+                did: did(),
+                index: 7,
+            },
         ))?;
         assert_dht_action_functor_retraction(PeerRingAction::RemoteAction(
             did(),
@@ -598,6 +652,56 @@ mod tests {
             |_| true,
         )?
         .is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn dht_find_successor_for_fix_sends_direct_indexed_report() -> Result<()> {
+        let next = did();
+        let target = did();
+        let index = 11;
+
+        let effect = single_effect(lower_dht_action(
+            &PeerRingAction::RemoteAction(next, PeerRingRemoteAction::FindSuccessorForFix {
+                did: target,
+                index,
+            }),
+            |_| true,
+        ))?;
+
+        match effect {
+            CoreEffect::Message(MessageSendFunctor::SendDirectMessage { msg, destination }) => {
+                match *msg {
+                    Message::FindSuccessorSend(msg) => {
+                        assert_eq!(destination, next);
+                        assert_eq!(msg.did, target);
+                        assert!(!msg.strict);
+                        match msg.then {
+                            FindSuccessorThen::Report(
+                                FindSuccessorReportHandler::FixFingerTable {
+                                    index: reported_index,
+                                },
+                            ) => assert_eq!(reported_index, index),
+                            handler => {
+                                return Err(Error::InvalidMessage(format!(
+                                    "expected fix-finger report handler, got {handler:?}"
+                                )))
+                            }
+                        }
+                    }
+                    msg => {
+                        return Err(Error::InvalidMessage(format!(
+                            "expected FindSuccessorSend, got {msg:?}"
+                        )))
+                    }
+                }
+            }
+            effect => {
+                return Err(Error::InvalidMessage(format!(
+                    "expected SendDirectMessage FindSuccessorSend, got {effect:?}"
+                )))
+            }
+        }
         Ok(())
     }
 

--- a/crates/core/src/message/effects.rs
+++ b/crates/core/src/message/effects.rs
@@ -233,7 +233,7 @@ impl TryFrom<&PeerRingAction> for DhtActionFunctor {
                     predecessor: *predecessor,
                 })
             }
-            act => Err(Error::PeerRingUnexpectedAction(act.clone())),
+            act => Err(Error::unexpected_peer_ring_action(act.clone())),
         }
     }
 }

--- a/crates/core/src/message/encoder.rs
+++ b/crates/core/src/message/encoder.rs
@@ -16,7 +16,7 @@ pub trait Decoder: Sized {
     fn from_encoded(encoded: &Encoded) -> Result<Self>;
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Encoded(String);
 
 impl Encoded {

--- a/crates/core/src/message/handlers/connection.rs
+++ b/crates/core/src/message/handlers/connection.rs
@@ -144,7 +144,7 @@ impl HandleMsg<FindSuccessorSend> for MessageHandler {
                 self.run_effects([PayloadRelayFunctor::reset_destination(ctx, next).into()])
                     .await
             }
-            act => Err(Error::PeerRingUnexpectedAction(act)),
+            act => Err(Error::unexpected_peer_ring_action(act)),
         }
     }
 }

--- a/crates/core/src/message/handlers/connection.rs
+++ b/crates/core/src/message/handlers/connection.rs
@@ -160,7 +160,22 @@ impl HandleMsg<FindSuccessorReport> for MessageHandler {
         }
 
         match &msg.handler {
-            FindSuccessorReportHandler::FixFingerTable | FindSuccessorReportHandler::Connect => {
+            FindSuccessorReportHandler::FixFingerTable { index } => {
+                self.dht.apply_fixed_finger(*index, msg.did)?;
+                if msg.reports_remote_successor(self.dht.did) {
+                    let offer_msg = self
+                        .transport
+                        .prepare_connection_offer(msg.did, self.inner_callback())
+                        .await?;
+                    self.run_effects([MessageSendFunctor::send_message(
+                        Message::ConnectNodeSend(offer_msg),
+                        msg.did,
+                    )
+                    .into()])
+                        .await?;
+                }
+            }
+            FindSuccessorReportHandler::Connect => {
                 if msg.reports_remote_successor(self.dht.did) {
                     let offer_msg = self
                         .transport

--- a/crates/core/src/message/handlers/stabilization.rs
+++ b/crates/core/src/message/handlers/stabilization.rs
@@ -38,7 +38,7 @@ fn collect_sync_entries_actions(
             }
             Ok(())
         }
-        action => Err(Error::PeerRingUnexpectedAction(action)),
+        action => Err(Error::unexpected_peer_ring_action(action)),
     }
 }
 

--- a/crates/core/src/message/handlers/stabilization.rs
+++ b/crates/core/src/message/handlers/stabilization.rs
@@ -188,6 +188,7 @@ mod test {
             vec![String::from("sync me").encode()?],
             EntryKind::Data,
         );
+        let stored_entry = entry.clone().try_into_storage_entry()?;
         node1
             .dht()
             .storage
@@ -248,7 +249,10 @@ mod test {
 
         match payload.transaction.data::<Message>()? {
             Message::SyncEntriesWithSuccessorReport(SyncEntriesWithSuccessorReport { acks }) => {
-                assert_eq!(acks, vec![SyncedEntryAck::new(entry.did, entry.clone())]);
+                assert_eq!(acks, vec![SyncedEntryAck::new(
+                    entry.did,
+                    stored_entry.clone()
+                )]);
             }
             message => {
                 return Err(Error::InvalidMessage(format!(
@@ -259,7 +263,7 @@ mod test {
         assert_eq!(node1.dht().storage.get(&entry.did.to_string()).await?, None);
         assert_eq!(
             node2.dht().storage.get(&entry.did.to_string()).await?,
-            Some(entry)
+            Some(stored_entry)
         );
 
         Ok(())

--- a/crates/core/src/message/handlers/stabilization.rs
+++ b/crates/core/src/message/handlers/stabilization.rs
@@ -183,11 +183,11 @@ mod test {
         wait_for_msgs([&node1, &node2]).await;
         assert_no_more_msg([&node1, &node2]).await;
 
-        let entry = Entry {
-            did: key3.address().into(),
-            data: vec![String::from("sync me").encode()?],
-            kind: EntryKind::Data,
-        };
+        let entry = Entry::new(
+            key3.address().into(),
+            vec![String::from("sync me").encode()?],
+            EntryKind::Data,
+        );
         node1
             .dht()
             .storage

--- a/crates/core/src/message/handlers/storage.rs
+++ b/crates/core/src/message/handlers/storage.rs
@@ -293,8 +293,7 @@ async fn persist_synced_entries(
         let entry = placed.entry.clone().into_storage_entry();
         handler
             .dht
-            .storage
-            .put(&placed.key.to_string(), &entry)
+            .join_storage_entry(placed.key, entry.clone())
             .await?;
         acks.push(SyncedEntryAck::new(placed.key, entry));
     }
@@ -514,6 +513,28 @@ mod test {
             .ok_or_else(|| Error::InvalidMessage("expected generated key".to_string()))
     }
 
+    async fn assert_cached_data_values(
+        node: &Node,
+        entry_key: Did,
+        expected: &[&str],
+    ) -> Result<()> {
+        let entry = node
+            .swarm
+            .storage_check_cache(entry_key)
+            .await
+            .ok_or_else(|| Error::InvalidMessage("expected cached entry".to_string()))?;
+        let expected_data = expected
+            .iter()
+            .map(|value| value.to_string().encode())
+            .collect::<Result<Vec<_>>>()?;
+
+        assert_eq!(entry.did, entry_key);
+        assert_eq!(entry.kind, EntryKind::Data);
+        assert_eq!(entry.data, expected_data);
+        assert_eq!(entry.crdt.dots.len(), entry.data.len());
+        Ok(())
+    }
+
     #[test]
     fn finish_storage_action_accepts_empty_action() -> Result<()> {
         finish_storage_action(PeerRingAction::None)?;
@@ -541,11 +562,11 @@ mod test {
         let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
         let resource_id = Did::from(10u32);
         let placement_key = Did::from(100u32);
-        let entry = Entry {
-            did: resource_id,
-            data: vec!["placed".to_string().encode()?],
-            kind: EntryKind::Data,
-        };
+        let entry = Entry::new(
+            resource_id,
+            vec!["placed".to_string().encode()?],
+            EntryKind::Data,
+        );
         let context_key = SecretKey::random();
         let context_session = SessionSk::new_with_seckey(&context_key)?;
         let context = MessagePayload::new_send(
@@ -577,13 +598,13 @@ mod test {
         let node = prepare_node(SecretKey::random()).await;
         let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
         let placement_key = Did::from(100u32);
-        let entry = Entry {
-            did: Did::from(10u32),
-            data: (0..ENTRY_DATA_MAX_LEN + 3)
+        let entry = Entry::new(
+            Did::from(10u32),
+            (0..ENTRY_DATA_MAX_LEN + 3)
                 .map(|i| format!("payload{i}").encode())
                 .collect::<Result<Vec<_>>>()?,
-            kind: EntryKind::Data,
-        };
+            EntryKind::Data,
+        );
         let context_key = SecretKey::random();
         let context_session = SessionSk::new_with_seckey(&context_key)?;
         let context = MessagePayload::new_send(
@@ -627,11 +648,11 @@ mod test {
 
         let handler = MessageHandler::new(node1.swarm.transport.clone(), Arc::new(NoopCallback));
         let placement_key = node2.did();
-        let entry = Entry {
-            did: Did::from(10u32),
-            data: vec!["routed repair".to_string().encode()?],
-            kind: EntryKind::Data,
-        };
+        let entry = Entry::new(
+            Did::from(10u32),
+            vec!["routed repair".to_string().encode()?],
+            EntryKind::Data,
+        );
         let msg = SyncEntriesWithSuccessor {
             data: vec![PlacedEntry::new(placement_key, entry.clone())],
         };
@@ -686,11 +707,7 @@ mod test {
         let node = Node::new(swarm);
         let departed = Did::from(100u32);
         node.dht().successors().update(departed)?;
-        let entry = Entry {
-            did: key.address().into(),
-            data: vec![],
-            kind: EntryKind::Data,
-        };
+        let entry = Entry::new(key.address().into(), vec![], EntryKind::Data);
         let placement_keys = entry.did.rotate_affine(2)?;
         node.dht()
             .storage
@@ -743,11 +760,11 @@ mod test {
             .build(),
         );
         let node = Node::new(swarm);
-        let entry = Entry {
-            did: key.address().into(),
-            data: vec!["local".to_string().encode()?],
-            kind: EntryKind::Data,
-        };
+        let entry = Entry::new(
+            key.address().into(),
+            vec!["local".to_string().encode()?],
+            EntryKind::Data,
+        );
         let first_key = entry
             .did
             .rotate_affine(2)?
@@ -770,11 +787,11 @@ mod test {
     async fn found_entry_repairs_buffered_misses_only() -> Result<()> {
         let node = prepare_node(SecretKey::random()).await;
         let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
-        let entry = Entry {
-            did: Did::from(10u32),
-            data: vec!["repair".to_string().encode()?],
-            kind: EntryKind::Data,
-        };
+        let entry = Entry::new(
+            Did::from(10u32),
+            vec!["repair".to_string().encode()?],
+            EntryKind::Data,
+        );
         let placement_key = Did::from(100u32);
         let unknown_key = Did::from(120u32);
         let context_key = SecretKey::random();
@@ -824,16 +841,16 @@ mod test {
         let node = prepare_node(SecretKey::random()).await;
         let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
         let resource = Did::from(10u32);
-        let first = Entry {
-            did: resource,
-            data: vec!["first".to_string().encode()?],
-            kind: EntryKind::Data,
-        };
-        let second = Entry {
-            did: resource,
-            data: vec!["second".to_string().encode()?],
-            kind: EntryKind::Data,
-        };
+        let first = Entry::new(
+            resource,
+            vec!["first".to_string().encode()?],
+            EntryKind::Data,
+        );
+        let second = Entry::new(
+            resource,
+            vec!["second".to_string().encode()?],
+            EntryKind::Data,
+        );
         let context_key = SecretKey::random();
         let context_session = SessionSk::new_with_seckey(&context_key)?;
         let context = MessagePayload::new_send(
@@ -904,11 +921,11 @@ mod test {
     async fn expired_storage_misses_do_not_trigger_late_repair() -> Result<()> {
         let node = prepare_node(SecretKey::random()).await;
         let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
-        let entry = Entry {
-            did: Did::from(10u32),
-            data: vec!["fresh".to_string().encode()?],
-            kind: EntryKind::Data,
-        };
+        let entry = Entry::new(
+            Did::from(10u32),
+            vec!["fresh".to_string().encode()?],
+            EntryKind::Data,
+        );
         let placement_key = Did::from(100u32);
         let context_key = SecretKey::random();
         let context_session = SessionSk::new_with_seckey(&context_key)?;
@@ -961,11 +978,11 @@ mod test {
 
         let handler = MessageHandler::new(receiver.swarm.transport.clone(), Arc::new(NoopCallback));
         let placement_key = Did::from(100u32);
-        let entry = Entry {
-            did: Did::from(10u32),
-            data: vec!["acked".to_string().encode()?],
-            kind: EntryKind::Data,
-        };
+        let entry = Entry::new(
+            Did::from(10u32),
+            vec!["acked".to_string().encode()?],
+            EntryKind::Data,
+        );
         let sync_msg = SyncEntriesWithSuccessor {
             data: vec![PlacedEntry::new(placement_key, entry.clone())],
         };
@@ -1009,16 +1026,8 @@ mod test {
         let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
         let acked_key = Did::from(100u32);
         let pending_key = Did::from(120u32);
-        let acked_entry = Entry {
-            did: Did::from(10u32),
-            data: vec![],
-            kind: EntryKind::Data,
-        };
-        let pending_entry = Entry {
-            did: Did::from(20u32),
-            data: vec![],
-            kind: EntryKind::Data,
-        };
+        let acked_entry = Entry::new(Did::from(10u32), vec![], EntryKind::Data);
+        let pending_entry = Entry::new(Did::from(20u32), vec![], EntryKind::Data);
         let context = MessagePayload::new_send(
             Message::custom(b"sync ack context")?,
             node.swarm.transport.session_sk(),
@@ -1111,14 +1120,7 @@ mod test {
                     && x.data.first().is_some_and(|entry| entry.did == entry_key)
         ));
 
-        assert_eq!(
-            node1.swarm.storage_check_cache(entry_key).await,
-            Some(Entry {
-                did: entry_key,
-                data: vec![data.encode()?],
-                kind: EntryKind::Data
-            })
-        );
+        assert_cached_data_values(&node1, entry_key, &[data.as_str()]).await?;
 
         Ok(())
     }
@@ -1182,14 +1184,7 @@ mod test {
         wait_for_msgs([&node1, &node2]).await;
         assert_no_more_msg([&node1, &node2]).await;
 
-        assert_eq!(
-            node1.swarm.storage_check_cache(entry_key).await,
-            Some(Entry {
-                did: entry_key,
-                data: vec!["111".to_string().encode()?, "222".to_string().encode()?],
-                kind: EntryKind::Data
-            })
-        );
+        assert_cached_data_values(&node1, entry_key, &["111", "222"]).await?;
 
         // Append more data
         <Swarm as ChordStorageInterface<1>>::storage_append_data(
@@ -1207,18 +1202,7 @@ mod test {
         wait_for_msgs([&node1, &node2]).await;
         assert_no_more_msg([&node1, &node2]).await;
 
-        assert_eq!(
-            node1.swarm.storage_check_cache(entry_key).await,
-            Some(Entry {
-                did: entry_key,
-                data: vec![
-                    "111".to_string().encode()?,
-                    "222".to_string().encode()?,
-                    "333".to_string().encode()?
-                ],
-                kind: EntryKind::Data
-            })
-        );
+        assert_cached_data_values(&node1, entry_key, &["111", "222", "333"]).await?;
 
         Ok(())
     }
@@ -1265,18 +1249,7 @@ mod test {
         wait_for_msgs([&node1, &node2]).await;
         assert_no_more_msg([&node1, &node2]).await;
 
-        assert_eq!(
-            node1.swarm.storage_check_cache(entry_key).await,
-            Some(Entry {
-                did: entry_key,
-                data: vec![
-                    "111".to_string().encode()?,
-                    "333".to_string().encode()?,
-                    "222".to_string().encode()?
-                ],
-                kind: EntryKind::Data
-            })
-        );
+        assert_cached_data_values(&node1, entry_key, &["111", "333", "222"]).await?;
 
         Ok(())
     }

--- a/crates/core/src/message/handlers/storage.rs
+++ b/crates/core/src/message/handlers/storage.rs
@@ -60,14 +60,14 @@ pub trait ChordStorageInterfaceCacheChecker {
 fn finish_storage_action(act: PeerRingAction) -> Result<()> {
     match act {
         PeerRingAction::None => Ok(()),
-        act => Err(Error::PeerRingUnexpectedAction(act)),
+        act => Err(Error::unexpected_peer_ring_action(act)),
     }
 }
 
 fn finish_storage_action_ref(act: &PeerRingAction) -> Result<()> {
     match act {
         PeerRingAction::None => Ok(()),
-        act => Err(Error::PeerRingUnexpectedAction(act.clone())),
+        act => Err(Error::unexpected_peer_ring_action(act.clone())),
     }
 }
 
@@ -314,7 +314,7 @@ fn next_hop_for_sync_entries(
         PeerRingAction::RemoteAction(next, PeerRingRemoteAction::FindSuccessor(_)) => {
             Ok(Some(next))
         }
-        action => Err(Error::PeerRingUnexpectedAction(action)),
+        action => Err(Error::unexpected_peer_ring_action(action)),
     }
 }
 
@@ -546,8 +546,8 @@ mod test {
     fn finish_storage_action_rejects_unhandled_action() -> Result<()> {
         let did = SecretKey::random().address().into();
         match finish_storage_action(PeerRingAction::Some(did)) {
-            Err(Error::PeerRingUnexpectedAction(PeerRingAction::Some(actual))) => {
-                assert_eq!(actual, did);
+            Err(Error::PeerRingUnexpectedAction(action)) => {
+                assert_eq!(*action, PeerRingAction::Some(did));
                 Ok(())
             }
             res => Err(Error::InvalidMessage(format!(

--- a/crates/core/src/message/handlers/storage.rs
+++ b/crates/core/src/message/handlers/storage.rs
@@ -290,7 +290,7 @@ async fn persist_synced_entries(
 ) -> Result<Vec<SyncedEntryAck>> {
     let mut acks = Vec::with_capacity(msg.data.len());
     for placed in msg.data.iter() {
-        let entry = placed.entry.clone().into_storage_entry();
+        let entry = placed.entry.clone().try_into_storage_entry()?;
         handler
             .dht
             .join_storage_entry(placed.key, entry.clone())
@@ -567,6 +567,7 @@ mod test {
             vec!["placed".to_string().encode()?],
             EntryKind::Data,
         );
+        let stored_entry = entry.clone().try_into_storage_entry()?;
         let context_key = SecretKey::random();
         let context_session = SessionSk::new_with_seckey(&context_key)?;
         let context = MessagePayload::new_send(
@@ -584,7 +585,7 @@ mod test {
 
         assert_eq!(
             node.dht().storage.get(&placement_key.to_string()).await?,
-            Some(entry)
+            Some(stored_entry)
         );
         assert_eq!(
             node.dht().storage.get(&resource_id.to_string()).await?,
@@ -653,6 +654,7 @@ mod test {
             vec!["routed repair".to_string().encode()?],
             EntryKind::Data,
         );
+        let stored_entry = entry.clone().try_into_storage_entry()?;
         let msg = SyncEntriesWithSuccessor {
             data: vec![PlacedEntry::new(placement_key, entry.clone())],
         };
@@ -677,7 +679,7 @@ mod test {
         assert!(matches!(
             ack.transaction.data()?,
             Message::SyncEntriesWithSuccessorReport(SyncEntriesWithSuccessorReport { acks })
-                if acks == vec![SyncedEntryAck::new(placement_key, entry.clone())]
+                if acks == vec![SyncedEntryAck::new(placement_key, stored_entry.clone())]
         ));
         assert_eq!(
             node1.dht().storage.get(&placement_key.to_string()).await?,
@@ -685,7 +687,7 @@ mod test {
         );
         assert_eq!(
             node2.dht().storage.get(&placement_key.to_string()).await?,
-            Some(entry)
+            Some(stored_entry)
         );
         Ok(())
     }
@@ -792,6 +794,7 @@ mod test {
             vec!["repair".to_string().encode()?],
             EntryKind::Data,
         );
+        let stored_entry = entry.clone().try_into_storage_entry()?;
         let placement_key = Did::from(100u32);
         let unknown_key = Did::from(120u32);
         let context_key = SecretKey::random();
@@ -827,7 +830,7 @@ mod test {
 
         assert_eq!(
             node.dht().storage.get(&placement_key.to_string()).await?,
-            Some(entry)
+            Some(stored_entry)
         );
         assert_eq!(
             node.dht().storage.get(&unknown_key.to_string()).await?,
@@ -983,6 +986,7 @@ mod test {
             vec!["acked".to_string().encode()?],
             EntryKind::Data,
         );
+        let stored_entry = entry.clone().try_into_storage_entry()?;
         let sync_msg = SyncEntriesWithSuccessor {
             data: vec![PlacedEntry::new(placement_key, entry.clone())],
         };
@@ -1000,7 +1004,7 @@ mod test {
             Message::SyncEntriesWithSuccessorReport(report) => {
                 assert_eq!(report.acks, vec![SyncedEntryAck::new(
                     placement_key,
-                    entry.clone()
+                    stored_entry.clone()
                 )]);
             }
             message => {
@@ -1015,7 +1019,7 @@ mod test {
                 .storage
                 .get(&placement_key.to_string())
                 .await?,
-            Some(entry)
+            Some(stored_entry)
         );
         Ok(())
     }

--- a/crates/core/src/message/types.rs
+++ b/crates/core/src/message/types.rs
@@ -233,8 +233,11 @@ pub enum FindSuccessorReportHandler {
     None,
     /// - Connect: connect origin node.
     Connect,
-    /// - FixFingerTable: update fingers table.
-    FixFingerTable,
+    /// - FixFingerTable: update one finger table slot.
+    FixFingerTable {
+        /// Finger slot that the original lookup was fixing.
+        index: usize,
+    },
     /// - CustomCallback: custom callback handle by `custom_message` method.
     CustomCallback(u8),
 }

--- a/crates/core/src/tests/default/dht_convergence.rs
+++ b/crates/core/src/tests/default/dht_convergence.rs
@@ -139,64 +139,31 @@ pub(super) const K: usize = 3;
 /// Ring bit-width; `Did` is `Z/2^160`, the finger table has one slot per bit.
 const BITS: usize = 160;
 
-/// The formal operators — a direct, independent Rust mirror of the TLA+ spec in
-/// the module doc. Kept deliberately tiny and obviously-correct so they serve as
-/// the *specification* that the production DHT code is checked against. Shared
-/// (the `mod spec` pivot) with the Stateright protocol model in `dht_stateright`.
+/// The formal operators used by the tests. This is deliberately only a thin
+/// wrapper over the production pure topology module, so convergence tests no
+/// longer maintain a second Chord oracle.
 pub(super) mod spec {
     use super::*;
-
-    /// `dist(a,b) == (Id[b] - Id[a]) % 2^160` — clockwise distance / `BiasId.pos()`.
-    pub fn dist(a: Did, b: Did) -> BigUint {
-        // `Did - Did` is already modular subtraction on Z/2^160 (see dht/did.rs).
-        BigUint::from(b - a)
-    }
+    pub use crate::dht::topology::dist;
 
     /// `Successors(n)` — the K nearest forward nodes, in increasing distance.
     pub fn successors(all: &[Did], n: Did) -> Vec<Did> {
-        let mut others: Vec<Did> = all.iter().copied().filter(|&d| d != n).collect();
-        others.sort_by_key(|&d| dist(n, d));
-        others.truncate(K);
-        others
+        crate::dht::topology::successors(all, n, K)
     }
 
     /// `Predecessor(n)` — the farthest-forward node (= nearest behind self).
     pub fn predecessor(all: &[Did], n: Did) -> Option<Did> {
-        all.iter()
-            .copied()
-            .filter(|&d| d != n)
-            .max_by_key(|&d| dist(n, d))
+        crate::dht::topology::predecessor(all, n)
     }
 
     /// `CorrectRectify` predecessor transition.
     pub fn correct_rectify_predecessor(me: Did, current: Option<Did>, pred: Did) -> Option<Did> {
-        match current {
-            Some(cur) if dist(me, cur) >= dist(me, pred) => Some(cur),
-            _ => Some(pred),
-        }
-    }
-
-    /// `Finger(n, bit)` — nearest forward node at distance `>= 2^bit`, else None.
-    /// Mirrors Rings' `finger.join` (no wrap: None when nothing is far enough),
-    /// which intentionally differs from the Chord paper's wrapping
-    /// `successor((n + 2^bit) mod M)`. See the module-doc DEVIATION note.
-    pub fn finger(all: &[Did], n: Did, bit: usize) -> Option<Did> {
-        let threshold = BigUint::from(1u8) << bit;
-        all.iter()
-            .copied()
-            .filter(|&d| d != n && dist(n, d) >= threshold)
-            .min_by_key(|&d| dist(n, d))
+        crate::dht::topology::rectify_predecessor(me, current, pred)
     }
 
     /// The full per-node finger table the spec predicts (one slot per ring bit).
     pub fn finger_table(all: &[Did], n: Did) -> Vec<Option<Did>> {
-        (0..BITS).map(|bit| finger(all, n, bit)).collect()
-    }
-
-    fn push_unique(xs: &mut Vec<Did>, x: Did) {
-        if !xs.contains(&x) {
-            xs.push(x);
-        }
+        crate::dht::topology::finger_table(all, n)
     }
 
     /// `CorrectStabilize` successor update: merge current successors with the
@@ -208,20 +175,13 @@ pub(super) mod spec {
         topo_successors: &[Did],
         topo_predecessor: Option<Did>,
     ) -> Vec<Did> {
-        let mut known = vec![me];
-        for &did in current {
-            push_unique(&mut known, did);
-        }
-        if let Some(pred) = topo_predecessor {
-            push_unique(&mut known, pred);
-        }
-        for &did in topo_successors
-            .iter()
-            .take(topo_successors.len().saturating_sub(1))
-        {
-            push_unique(&mut known, did);
-        }
-        successors(&known, me)
+        crate::dht::topology::stabilize_successors(
+            me,
+            current,
+            topo_successors,
+            topo_predecessor,
+            K,
+        )
     }
 
     /// `CorrectStabilize` query side effect: ask the successor's predecessor for
@@ -232,20 +192,12 @@ pub(super) mod spec {
         current: &[Did],
         topo_predecessor: Option<Did>,
     ) -> Option<Did> {
-        let pred = topo_predecessor?;
-        if pred == me {
-            return None;
-        }
-        let old_head = current.iter().copied().min_by_key(|&did| dist(me, did));
-        match old_head {
-            Some(head) if dist(me, pred) >= dist(me, head) => None,
-            _ => Some(pred),
-        }
+        crate::dht::topology::stabilize_query(me, current, topo_predecessor)
     }
 
     /// `CorrectStabilize` notify side effect: notify the new successor, if any.
     pub fn correct_stabilize_notify(me: Did, next_successors: &[Did]) -> Option<Did> {
-        next_successors.first().copied().filter(|&did| did != me)
+        crate::dht::topology::stabilize_notify(me, next_successors)
     }
 }
 

--- a/crates/core/src/tests/default/dht_convergence.rs
+++ b/crates/core/src/tests/default/dht_convergence.rs
@@ -2,13 +2,13 @@
 //!
 //! These tests pin down the **safety** half of stabilization: for any fixed set
 //! of DIDs the converged DHT (successor list, predecessor, finger table) is the
-//! *unique fixpoint* of Chord's invariants, and the production code path
-//! (`PeerRing::{join,notify}` + `finger.join`) must materialise exactly that
-//! fixpoint. There is no transport and no message ordering here, so the result
-//! is fully deterministic — the *liveness* half (does the async protocol reach
-//! the fixpoint under arbitrary message interleavings?) is intentionally NOT
-//! tested here; it is covered by the integration test (`test_stabilization_*`,
-//! which polls) and, in the future, by model-checking the TLA+ `Spec` below.
+//! *unique fixpoint* of Chord's invariants, and the production pure topology
+//! transition (`dht::topology::step`, interpreted by `PeerRing`) must
+//! materialise exactly that fixpoint. There is no transport and no message
+//! ordering here, so the result is fully deterministic — the *liveness* half
+//! (does the async protocol reach the fixpoint under arbitrary message
+//! interleavings?) is covered by the integration test (`test_stabilization_*`,
+//! which polls) and by the scoped StateRight models in `dht_stateright`.
 //!
 //! ====================================================================
 //! FORMAL SPEC (TLA+) — the constraint these tests discharge.

--- a/crates/core/src/tests/default/dht_stateright.rs
+++ b/crates/core/src/tests/default/dht_stateright.rs
@@ -34,6 +34,8 @@
 
 use std::borrow::Cow;
 use std::collections::BTreeSet;
+use std::hash::Hash;
+use std::hash::Hasher;
 
 use num_bigint::BigUint;
 use stateright::actor::model_timeout;
@@ -51,11 +53,18 @@ use super::dht_convergence::spec;
 use super::dht_convergence::K;
 use crate::algebra::assert_join_semilattice_laws;
 use crate::algebra::JoinSemilattice;
+use crate::consts::ENTRY_DATA_MAX_LEN;
+use crate::dht::entry::Entry;
+use crate::dht::entry::EntryCrdt;
+use crate::dht::entry::EntryDot;
+use crate::dht::entry::EntryKind;
+use crate::dht::entry::EntryVersion;
 use crate::dht::successor::SuccessorReader;
 use crate::dht::successor::SuccessorWriter;
 use crate::dht::Chord;
 use crate::dht::Did;
 use crate::dht::PeerRing;
+use crate::message::Encoded;
 use crate::storage::MemStorage;
 
 /// A DID at `num/den` of the way round the ring — deterministic test positions.
@@ -542,48 +551,353 @@ fn discovery_model(all: Vec<Did>, rounds: u8) -> ActorModel<DiscoveryNode, Cfg, 
 // State variables:
 //   phase    in {Partitioned, Merged}
 //   replica  in StorageJoinValue^3
-//   network  subset of {from, to, value}
 //
 // Initial state:
 //   replicas start with independent local writes A, B, C.
-//   phase = Partitioned, where only nodes 0 and 1 may exchange messages.
+//   phase = Partitioned, where only same-side nodes may exchange state.
 //
 // Next-state relation:
-//   Send(from, to) inserts the sender's current value when the topology allows
-//   that edge and no message on that edge is already pending.
-//   Deliver(msg) removes one pending message and applies replica[to] :=
-//   replica[to] join msg.value.
+//   Transfer(from, to) applies replica[to] := replica[to] join replica[from]
+//   whenever the topology allows that edge.
 //   Merge changes phase from Partitioned to Merged, enabling every edge.
 //
 // Invariant:
 //   forall node. replica[node] <= A join B join C.
 //
 // Liveness expectation under fair anti-entropy:
-//   from any reachable Merged state, repeated Send/Deliver steps reach the
-//   single least upper bound at every replica. Reordering and duplication are
-//   covered by the semilattice law: every delivery is a join.
+//   from any reachable Merged state, repeated Transfer steps reach the single
+//   least upper bound at every replica.
+//
+// Refinement:
+//   An asynchronous send/deliver trace projects to this Transfer model because
+//   delivery is a pure join of a sender snapshot into the receiver. Message
+//   reordering and duplication are covered by the semilattice law checked
+//   below: join is commutative and idempotent.
 // ===================================================================
 
 const STORAGE_REPLICA_COUNT: usize = 3;
+const STORAGE_PARTITION_MASKS: [StoragePartition; STORAGE_REPLICA_COUNT] = [
+    StoragePartition(0b001),
+    StoragePartition(0b010),
+    StoragePartition(0b011),
+];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-struct StorageJoinValue(u8);
+struct StoragePartition(u8);
+
+impl StoragePartition {
+    fn permits(self, from: usize, to: usize) -> bool {
+        if from == to {
+            return false;
+        }
+        self.side(from) == self.side(to)
+    }
+
+    fn side(self, node: usize) -> bool {
+        let shift = match u32::try_from(node) {
+            Ok(shift) => shift,
+            Err(_) => return false,
+        };
+        let Some(bit) = 1u8.checked_shl(shift) else {
+            return false;
+        };
+        self.0 & bit != 0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+enum StorageJoinCarrier {
+    DataBoundedTopN,
+    DataOverwriteReset,
+    RelayTombstone,
+}
+
+#[derive(Clone, Debug)]
+struct StorageJoinValue {
+    carrier: StorageJoinCarrier,
+    bits: u8,
+    entry: Entry,
+}
 
 impl StorageJoinValue {
-    const EMPTY: Self = Self(0);
-    const A: Self = Self(0b001);
-    const B: Self = Self(0b010);
-    const C: Self = Self(0b100);
-    const ALL: Self = Self(Self::A.0 | Self::B.0 | Self::C.0);
+    fn new(carrier: StorageJoinCarrier, bits: u8, entry: Entry) -> Self {
+        match entry.try_into_storage_entry() {
+            Ok(entry) => Self {
+                carrier,
+                bits,
+                entry,
+            },
+            Err(error) => panic!("storage model entry must normalize: {error}"),
+        }
+    }
 
-    fn is_subset_of(self, other: Self) -> bool {
-        self.join(other) == other
+    fn bottom_like(&self) -> Self {
+        storage_value_from_bits(self.carrier, 0)
+    }
+
+    fn is_subset_of(&self, other: &Self) -> bool {
+        self.clone().join(other.clone()) == *other
+    }
+}
+
+impl PartialEq for StorageJoinValue {
+    fn eq(&self, other: &Self) -> bool {
+        self.carrier == other.carrier && self.bits == other.bits
+    }
+}
+
+impl Eq for StorageJoinValue {}
+
+impl Hash for StorageJoinValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.carrier.hash(state);
+        self.bits.hash(state);
+    }
+}
+
+impl Ord for StorageJoinValue {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.carrier
+            .cmp(&other.carrier)
+            .then_with(|| self.bits.cmp(&other.bits))
+    }
+}
+
+impl PartialOrd for StorageJoinValue {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 
 impl JoinSemilattice for StorageJoinValue {
     fn join(self, other: Self) -> Self {
-        Self(self.0 | other.0)
+        if self.carrier != other.carrier {
+            panic!("storage model joins only one carrier");
+        }
+        let carrier = self.carrier;
+        let bits = self.bits | other.bits;
+        let joined = storage_join_entry(self.entry, other.entry);
+        Self::new(carrier, bits, joined)
+    }
+}
+
+struct StorageJoinScenario {
+    name: &'static str,
+    initial: [StorageJoinValue; STORAGE_REPLICA_COUNT],
+}
+
+impl StorageJoinScenario {
+    fn bottom(&self) -> StorageJoinValue {
+        self.initial[0].bottom_like()
+    }
+
+    fn global_lub(&self) -> StorageJoinValue {
+        self.initial
+            .iter()
+            .cloned()
+            .fold(self.bottom(), JoinSemilattice::join)
+    }
+}
+
+fn storage_model_did(offset: u32) -> Did {
+    Did::from(10_000u32.saturating_add(offset))
+}
+
+fn storage_version(time: u128, actor: u32, operation: u32) -> EntryVersion {
+    EntryVersion::new(time, Did::from(actor), Did::from(operation))
+}
+
+fn storage_index(index: usize) -> u32 {
+    match u32::try_from(index) {
+        Ok(index) => index,
+        Err(_) => panic!("storage model index must fit in u32"),
+    }
+}
+
+fn storage_dot(version: EntryVersion, index: usize) -> EntryDot {
+    let index = storage_index(index);
+    EntryDot { version, index }
+}
+
+fn storage_encoded(label: &str) -> Encoded {
+    Encoded::from(label)
+}
+
+fn storage_join_entry(left: Entry, right: Entry) -> Entry {
+    let joined = match left.join(right) {
+        Ok(entry) => entry,
+        Err(error) => panic!("storage model joins only compatible entries: {error}"),
+    };
+    match joined.try_into_storage_entry() {
+        Ok(entry) => entry,
+        Err(error) => panic!("storage model join result must normalize: {error}"),
+    }
+}
+
+fn data_value_range(did: Did, label: &'static str, start_time: u128, count: usize) -> Entry {
+    let data = (0..count)
+        .map(|index| storage_encoded(&format!("{label}-{index}")))
+        .collect::<Vec<_>>();
+    let dots = (0..count)
+        .map(|offset| {
+            let index = storage_index(offset);
+            let time = start_time.saturating_add(u128::from(index));
+            storage_dot(
+                storage_version(time, 1, 1_000u32.saturating_add(index)),
+                offset,
+            )
+        })
+        .collect::<Vec<_>>();
+    Entry {
+        did,
+        data,
+        kind: EntryKind::Data,
+        crdt: EntryCrdt {
+            register: None,
+            dots,
+            tombstones: Vec::new(),
+        },
+    }
+}
+
+fn data_overwrite_value(did: Did, label: &'static str, version: EntryVersion) -> Entry {
+    Entry {
+        did,
+        data: vec![storage_encoded(label)],
+        kind: EntryKind::Data,
+        crdt: EntryCrdt {
+            register: Some(version),
+            dots: vec![storage_dot(version, 0)],
+            tombstones: Vec::new(),
+        },
+    }
+}
+
+fn relay_add_value(did: Did, label: &'static str, dot: EntryDot) -> Entry {
+    Entry {
+        did,
+        data: vec![storage_encoded(label)],
+        kind: EntryKind::RelayMessage,
+        crdt: EntryCrdt {
+            register: None,
+            dots: vec![dot],
+            tombstones: Vec::new(),
+        },
+    }
+}
+
+fn relay_remove_value(did: Did, dot: EntryDot) -> Entry {
+    Entry {
+        did,
+        data: Vec::new(),
+        kind: EntryKind::RelayMessage,
+        crdt: EntryCrdt {
+            register: None,
+            dots: Vec::new(),
+            tombstones: vec![dot],
+        },
+    }
+}
+
+fn storage_delta_entry(carrier: StorageJoinCarrier, bit: u8) -> Entry {
+    match carrier {
+        StorageJoinCarrier::DataBoundedTopN => data_value_range(
+            storage_model_did(1),
+            match bit {
+                0b001 => "low",
+                0b010 => "mid",
+                0b100 => "high",
+                _ => panic!("storage model delta bit must be singleton"),
+            },
+            match bit {
+                0b001 => 1,
+                0b010 => 1_000,
+                0b100 => 2_000,
+                _ => panic!("storage model delta bit must be singleton"),
+            },
+            ENTRY_DATA_MAX_LEN,
+        ),
+        StorageJoinCarrier::DataOverwriteReset => match bit {
+            0b001 => data_value_range(storage_model_did(2), "stale-a", 1, 3),
+            0b010 => {
+                data_overwrite_value(storage_model_did(2), "reset", storage_version(100, 2, 200))
+            }
+            0b100 => data_value_range(storage_model_did(2), "stale-c", 10, 3),
+            _ => panic!("storage model delta bit must be singleton"),
+        },
+        StorageJoinCarrier::RelayTombstone => {
+            let relay_a_dot = storage_dot(storage_version(1, 1, 10), 0);
+            let relay_b_dot = storage_dot(storage_version(2, 2, 20), 0);
+            match bit {
+                0b001 => relay_add_value(storage_model_did(3), "relay-a", relay_a_dot),
+                0b010 => relay_add_value(storage_model_did(3), "relay-b", relay_b_dot),
+                0b100 => relay_remove_value(storage_model_did(3), relay_a_dot),
+                _ => panic!("storage model delta bit must be singleton"),
+            }
+        }
+    }
+}
+
+fn storage_bottom_entry(carrier: StorageJoinCarrier) -> Entry {
+    let (did, kind) = match carrier {
+        StorageJoinCarrier::DataBoundedTopN => (storage_model_did(1), EntryKind::Data),
+        StorageJoinCarrier::DataOverwriteReset => (storage_model_did(2), EntryKind::Data),
+        StorageJoinCarrier::RelayTombstone => (storage_model_did(3), EntryKind::RelayMessage),
+    };
+    Entry::new(did, Vec::new(), kind)
+}
+
+fn storage_value_from_bits(carrier: StorageJoinCarrier, bits: u8) -> StorageJoinValue {
+    let mut entry = storage_bottom_entry(carrier);
+    for bit in [0b001, 0b010, 0b100] {
+        if bits & bit != 0 {
+            entry = storage_join_entry(entry, storage_delta_entry(carrier, bit));
+        }
+    }
+    StorageJoinValue::new(carrier, bits, entry)
+}
+
+fn storage_join_scenarios() -> Vec<StorageJoinScenario> {
+    vec![
+        StorageJoinScenario {
+            name: "data bounded top-n",
+            initial: [
+                storage_value_from_bits(StorageJoinCarrier::DataBoundedTopN, 0b001),
+                storage_value_from_bits(StorageJoinCarrier::DataBoundedTopN, 0b010),
+                storage_value_from_bits(StorageJoinCarrier::DataBoundedTopN, 0b100),
+            ],
+        },
+        StorageJoinScenario {
+            name: "data overwrite reset floor",
+            initial: [
+                storage_value_from_bits(StorageJoinCarrier::DataOverwriteReset, 0b001),
+                storage_value_from_bits(StorageJoinCarrier::DataOverwriteReset, 0b010),
+                storage_value_from_bits(StorageJoinCarrier::DataOverwriteReset, 0b100),
+            ],
+        },
+        StorageJoinScenario {
+            name: "relay tombstone prevents resurrection",
+            initial: [
+                storage_value_from_bits(StorageJoinCarrier::RelayTombstone, 0b001),
+                storage_value_from_bits(StorageJoinCarrier::RelayTombstone, 0b010),
+                storage_value_from_bits(StorageJoinCarrier::RelayTombstone, 0b100),
+            ],
+        },
+    ]
+}
+
+fn storage_join_carriers() -> [StorageJoinCarrier; 3] {
+    [
+        StorageJoinCarrier::DataBoundedTopN,
+        StorageJoinCarrier::DataOverwriteReset,
+        StorageJoinCarrier::RelayTombstone,
+    ]
+}
+
+fn storage_value_by_bits(values: &[StorageJoinValue], bits: u8) -> &StorageJoinValue {
+    match values.get(usize::from(bits)) {
+        Some(value) => value,
+        None => panic!("storage model bitmask must be in the finite carrier"),
     }
 }
 
@@ -593,30 +907,22 @@ enum StorageJoinPhase {
     Merged,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-struct StorageJoinMessage {
-    from: usize,
-    to: usize,
-    value: StorageJoinValue,
-}
-
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 struct StorageJoinState {
+    partition: StoragePartition,
     phase: StorageJoinPhase,
     replicas: [StorageJoinValue; STORAGE_REPLICA_COUNT],
-    messages: BTreeSet<StorageJoinMessage>,
 }
 
 impl StorageJoinState {
-    fn initial() -> Self {
+    fn initial(
+        partition: StoragePartition,
+        replicas: [StorageJoinValue; STORAGE_REPLICA_COUNT],
+    ) -> Self {
         Self {
+            partition,
             phase: StorageJoinPhase::Partitioned,
-            replicas: [
-                StorageJoinValue::A,
-                StorageJoinValue::B,
-                StorageJoinValue::C,
-            ],
-            messages: BTreeSet::new(),
+            replicas,
         }
     }
 
@@ -625,35 +931,19 @@ impl StorageJoinState {
             return false;
         }
         match self.phase {
-            StorageJoinPhase::Partitioned => from < 2 && to < 2,
+            StorageJoinPhase::Partitioned => self.partition.permits(from, to),
             StorageJoinPhase::Merged => from < STORAGE_REPLICA_COUNT && to < STORAGE_REPLICA_COUNT,
         }
     }
 
-    fn has_pending_edge(&self, from: usize, to: usize) -> bool {
-        self.messages
-            .iter()
-            .any(|message| message.from == from && message.to == to)
-    }
-
-    fn send_current(&self, from: usize, to: usize) -> Option<Self> {
-        if !self.topology_permits(from, to) || self.has_pending_edge(from, to) {
+    fn transfer_current(&self, from: usize, to: usize) -> Option<Self> {
+        if !self.topology_permits(from, to) {
             return None;
         }
-        let value = self.replicas.get(from).copied()?;
+        let value = self.replicas.get(from).cloned()?;
         let mut next = self.clone();
-        next.messages.insert(StorageJoinMessage { from, to, value });
-        Some(next)
-    }
-
-    fn deliver(&self, message: StorageJoinMessage) -> Option<Self> {
-        if !self.messages.contains(&message) {
-            return None;
-        }
-        let mut next = self.clone();
-        next.messages.remove(&message);
-        let replica = next.replicas.get_mut(message.to)?;
-        *replica = replica.join(message.value);
+        let replica = next.replicas.get_mut(to)?;
+        *replica = replica.clone().join(value);
         Some(next)
     }
 
@@ -674,40 +964,29 @@ impl StorageJoinState {
         }
         for from in 0..STORAGE_REPLICA_COUNT {
             for to in 0..STORAGE_REPLICA_COUNT {
-                if let Some(sent) = self.send_current(from, to) {
-                    next.push(sent);
+                if let Some(transferred) = self.transfer_current(from, to) {
+                    next.push(transferred);
                 }
-            }
-        }
-        for message in self.messages.iter().copied().collect::<Vec<_>>() {
-            if let Some(delivered) = self.deliver(message) {
-                next.push(delivered);
             }
         }
         next
     }
 
-    fn preserves_lub_bound(&self) -> bool {
+    fn is_below_global_lub(&self, global_lub: &StorageJoinValue) -> bool {
         self.replicas
             .iter()
-            .copied()
-            .all(|value| value.is_subset_of(StorageJoinValue::ALL))
+            .all(|value| value.is_subset_of(global_lub))
     }
 
-    fn is_quiescent_lub(&self) -> bool {
-        self.messages.is_empty()
-            && self
-                .replicas
-                .iter()
-                .copied()
-                .all(|value| value == StorageJoinValue::ALL)
+    fn is_quiescent_lub(&self, global_lub: &StorageJoinValue) -> bool {
+        self.replicas.iter().all(|value| value == global_lub)
     }
 
-    fn send_all_current(&self) -> Self {
+    fn transfer_all_current(&self) -> Self {
         let mut state = self.clone();
         for from in 0..STORAGE_REPLICA_COUNT {
             for to in 0..STORAGE_REPLICA_COUNT {
-                if let Some(next) = state.send_current(from, to) {
+                if let Some(next) = state.transfer_current(from, to) {
                     state = next;
                 }
             }
@@ -715,23 +994,13 @@ impl StorageJoinState {
         state
     }
 
-    fn deliver_all(&self) -> Self {
-        let mut state = self.clone();
-        for message in self.messages.iter().copied().collect::<Vec<_>>() {
-            if let Some(next) = state.deliver(message) {
-                state = next;
-            }
-        }
-        state
-    }
-
-    fn drive_to_quiescent_lub(&self) -> Self {
+    fn drive_to_quiescent_lub(&self, global_lub: &StorageJoinValue) -> Self {
         let mut state = self.clone();
         for _ in 0..STORAGE_REPLICA_COUNT * 8 {
-            if state.is_quiescent_lub() {
+            if state.is_quiescent_lub(global_lub) {
                 return state;
             }
-            let next = state.send_all_current().deliver_all();
+            let next = state.transfer_all_current();
             if next == state {
                 return next;
             }
@@ -741,9 +1010,12 @@ impl StorageJoinState {
     }
 }
 
-fn reachable_storage_join_states() -> BTreeSet<StorageJoinState> {
+fn reachable_storage_join_states(
+    partition: StoragePartition,
+    replicas: [StorageJoinValue; STORAGE_REPLICA_COUNT],
+) -> BTreeSet<StorageJoinState> {
     let mut seen = BTreeSet::new();
-    let mut frontier = vec![StorageJoinState::initial()];
+    let mut frontier = vec![StorageJoinState::initial(partition, replicas)];
     while let Some(state) = frontier.pop() {
         if !seen.insert(state.clone()) {
             continue;
@@ -1028,37 +1300,67 @@ mod tests {
         }
     }
 
-    /// Stage 3 — CRDT SEC law. Storage values are bounded join-semilattice
-    /// states; anti-entropy messages only deliver more joins.
+    /// Stage 3 — CRDT SEC law. Storage values are real finite [`Entry`]
+    /// carriers; anti-entropy messages only deliver more joins.
     #[test]
-    fn storage_join_value_satisfies_semilattice_laws() {
-        assert_join_semilattice_laws(&[
-            StorageJoinValue::EMPTY,
-            StorageJoinValue::A,
-            StorageJoinValue::B,
-            StorageJoinValue::C,
-            StorageJoinValue::A.join(StorageJoinValue::B),
-            StorageJoinValue::ALL,
-        ]);
+    fn storage_entry_join_satisfies_semilattice_laws() {
+        for carrier in storage_join_carriers() {
+            let values = (0u8..8)
+                .map(|bits| storage_value_from_bits(carrier, bits))
+                .collect::<Vec<_>>();
+            assert_join_semilattice_laws(&values);
+
+            for left in &values {
+                let idempotent = storage_join_entry(left.entry.clone(), left.entry.clone());
+                assert_eq!(idempotent, left.entry);
+                for right in &values {
+                    let expected = storage_value_by_bits(&values, left.bits | right.bits);
+                    let left_right = storage_join_entry(left.entry.clone(), right.entry.clone());
+                    let right_left = storage_join_entry(right.entry.clone(), left.entry.clone());
+                    assert_eq!(left_right, expected.entry);
+                    assert_eq!(left_right, right_left);
+
+                    for third in &values {
+                        let left_assoc = storage_join_entry(
+                            storage_join_entry(left.entry.clone(), right.entry.clone()),
+                            third.entry.clone(),
+                        );
+                        let right_assoc = storage_join_entry(
+                            left.entry.clone(),
+                            storage_join_entry(right.entry.clone(), third.entry.clone()),
+                        );
+                        assert_eq!(left_assoc, right_assoc);
+                    }
+                }
+            }
+        }
     }
 
     /// Stage 3 — topology-aware SEC. Every reachable partition/merge state
     /// stays below the global lub, and every merged state reaches that lub under
-    /// fair repeated send/deliver. This is the storage convergence proof; the
-    /// copy/ack/delete model below is only local cleanup safety.
+    /// fair repeated send/deliver. The finite carriers cover bounded top-N data,
+    /// overwrite reset floors, and relay tombstones. The copy/ack/delete model
+    /// below is only local cleanup safety.
     #[test]
     fn storage_join_topology_model_converges_after_partition_merge() {
-        for state in reachable_storage_join_states() {
-            assert!(
-                state.preserves_lub_bound(),
-                "storage join exceeded global lub: {state:?}"
-            );
-            if state.phase == StorageJoinPhase::Merged {
-                let closed = state.drive_to_quiescent_lub();
-                assert!(
-                    closed.is_quiescent_lub(),
-                    "merged state did not close to global lub: start={state:?}, closed={closed:?}"
-                );
+        for scenario in storage_join_scenarios() {
+            let global_lub = scenario.global_lub();
+            for partition in STORAGE_PARTITION_MASKS {
+                for state in reachable_storage_join_states(partition, scenario.initial.clone()) {
+                    assert!(
+                        state.is_below_global_lub(&global_lub),
+                        "storage join exceeded global lub for {}: {state:?}",
+                        scenario.name
+                    );
+                    if state.phase == StorageJoinPhase::Merged {
+                        let closed = state.drive_to_quiescent_lub(&global_lub);
+                        assert!(
+                            closed.is_quiescent_lub(&global_lub),
+                            "merged state did not close to global lub for {}: start={state:?}, closed={closed:?}",
+                            scenario.name
+                        );
+                    }
+                }
             }
         }
     }

--- a/crates/core/src/tests/default/dht_stateright.rs
+++ b/crates/core/src/tests/default/dht_stateright.rs
@@ -51,7 +51,6 @@ use stateright::Model;
 
 use super::dht_convergence::spec;
 use super::dht_convergence::K;
-use crate::algebra::assert_join_semilattice_laws;
 use crate::algebra::JoinSemilattice;
 use crate::consts::ENTRY_DATA_MAX_LEN;
 use crate::dht::entry::Entry;
@@ -573,6 +572,13 @@ fn discovery_model(all: Vec<Did>, rounds: u8) -> ActorModel<DiscoveryNode, Cfg, 
 //   delivery is a pure join of a sender snapshot into the receiver. Message
 //   reordering and duplication are covered by the semilattice law checked
 //   below: join is commutative and idempotent.
+//
+// Quotient:
+//   `StorageJoinValue` hashes and compares only `(carrier, bits)` so BFS stays
+//   finite. The test `storage_entry_join_satisfies_semilattice_laws` is the
+//   refinement witness: for every finite carrier state, real Entry::join equals
+//   canonical(bits_a union bits_b). The topology model is therefore checked on
+//   the quotient, while carrier correctness is checked on the real entries.
 // ===================================================================
 
 const STORAGE_REPLICA_COUNT: usize = 3;
@@ -636,7 +642,10 @@ impl StorageJoinValue {
     }
 
     fn is_subset_of(&self, other: &Self) -> bool {
-        self.clone().join(other.clone()) == *other
+        if self.carrier != other.carrier {
+            return false;
+        }
+        storage_join_entry(self.entry.clone(), other.entry.clone()) == other.entry
     }
 }
 
@@ -1308,7 +1317,6 @@ mod tests {
             let values = (0u8..8)
                 .map(|bits| storage_value_from_bits(carrier, bits))
                 .collect::<Vec<_>>();
-            assert_join_semilattice_laws(&values);
 
             for left in &values {
                 let idempotent = storage_join_entry(left.entry.clone(), left.entry.clone());

--- a/crates/core/src/tests/default/dht_stateright.rs
+++ b/crates/core/src/tests/default/dht_stateright.rs
@@ -25,8 +25,11 @@
 //!     notified) — illustrating the order-sensitivity mechanism behind the
 //!     integration test's residual flakiness, not formally pinning the 6-node
 //!     configuration.
-//!   * Stage 3 — a finite storage-sync safety model for #613 S2. It abstracts
-//!     one placement key through copy -> ack -> delete and checks that local
+//!   * Stage 3 — a finite storage CRDT SEC topology model. It explores a
+//!     partition-then-merge shape where replicas exchange only join deltas and
+//!     checks that every merged state can close to one least upper bound.
+//!   * Stage 4 — hand-off cleanup safety for #614 S2'. It abstracts one
+//!     placement key through copy -> ack -> delete and checks that local
 //!     deletion is reachable only after the successor state contains the key.
 
 use std::borrow::Cow;
@@ -46,6 +49,8 @@ use stateright::Model;
 
 use super::dht_convergence::spec;
 use super::dht_convergence::K;
+use crate::algebra::assert_join_semilattice_laws;
+use crate::algebra::JoinSemilattice;
 use crate::dht::successor::SuccessorReader;
 use crate::dht::successor::SuccessorWriter;
 use crate::dht::Chord;
@@ -532,12 +537,234 @@ fn discovery_model(all: Vec<Did>, rounds: u8) -> ActorModel<DiscoveryNode, Cfg, 
 }
 
 // ===================================================================
-// Stage 3: storage sync safety for one placement key.
+// Stage 3: storage CRDT SEC topology model.
 //
-// SCOPE: this is the #614 S2' model, not a full storage liveness model. It
-// abstracts exactly one placement key, the copy -> ack -> delete hand-off, and
-// arbitrary local writes over a finite representative value domain while a
-// copy or ack is in flight:
+// State variables:
+//   phase    in {Partitioned, Merged}
+//   replica  in StorageJoinValue^3
+//   network  subset of {from, to, value}
+//
+// Initial state:
+//   replicas start with independent local writes A, B, C.
+//   phase = Partitioned, where only nodes 0 and 1 may exchange messages.
+//
+// Next-state relation:
+//   Send(from, to) inserts the sender's current value when the topology allows
+//   that edge and no message on that edge is already pending.
+//   Deliver(msg) removes one pending message and applies replica[to] :=
+//   replica[to] join msg.value.
+//   Merge changes phase from Partitioned to Merged, enabling every edge.
+//
+// Invariant:
+//   forall node. replica[node] <= A join B join C.
+//
+// Liveness expectation under fair anti-entropy:
+//   from any reachable Merged state, repeated Send/Deliver steps reach the
+//   single least upper bound at every replica. Reordering and duplication are
+//   covered by the semilattice law: every delivery is a join.
+// ===================================================================
+
+const STORAGE_REPLICA_COUNT: usize = 3;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+struct StorageJoinValue(u8);
+
+impl StorageJoinValue {
+    const EMPTY: Self = Self(0);
+    const A: Self = Self(0b001);
+    const B: Self = Self(0b010);
+    const C: Self = Self(0b100);
+    const ALL: Self = Self(Self::A.0 | Self::B.0 | Self::C.0);
+
+    fn is_subset_of(self, other: Self) -> bool {
+        self.join(other) == other
+    }
+}
+
+impl JoinSemilattice for StorageJoinValue {
+    fn join(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+enum StorageJoinPhase {
+    Partitioned,
+    Merged,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+struct StorageJoinMessage {
+    from: usize,
+    to: usize,
+    value: StorageJoinValue,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+struct StorageJoinState {
+    phase: StorageJoinPhase,
+    replicas: [StorageJoinValue; STORAGE_REPLICA_COUNT],
+    messages: BTreeSet<StorageJoinMessage>,
+}
+
+impl StorageJoinState {
+    fn initial() -> Self {
+        Self {
+            phase: StorageJoinPhase::Partitioned,
+            replicas: [
+                StorageJoinValue::A,
+                StorageJoinValue::B,
+                StorageJoinValue::C,
+            ],
+            messages: BTreeSet::new(),
+        }
+    }
+
+    fn topology_permits(&self, from: usize, to: usize) -> bool {
+        if from == to {
+            return false;
+        }
+        match self.phase {
+            StorageJoinPhase::Partitioned => from < 2 && to < 2,
+            StorageJoinPhase::Merged => from < STORAGE_REPLICA_COUNT && to < STORAGE_REPLICA_COUNT,
+        }
+    }
+
+    fn has_pending_edge(&self, from: usize, to: usize) -> bool {
+        self.messages
+            .iter()
+            .any(|message| message.from == from && message.to == to)
+    }
+
+    fn send_current(&self, from: usize, to: usize) -> Option<Self> {
+        if !self.topology_permits(from, to) || self.has_pending_edge(from, to) {
+            return None;
+        }
+        let value = self.replicas.get(from).copied()?;
+        let mut next = self.clone();
+        next.messages.insert(StorageJoinMessage { from, to, value });
+        Some(next)
+    }
+
+    fn deliver(&self, message: StorageJoinMessage) -> Option<Self> {
+        if !self.messages.contains(&message) {
+            return None;
+        }
+        let mut next = self.clone();
+        next.messages.remove(&message);
+        let replica = next.replicas.get_mut(message.to)?;
+        *replica = replica.join(message.value);
+        Some(next)
+    }
+
+    fn merge_partition(&self) -> Option<Self> {
+        if self.phase == StorageJoinPhase::Merged {
+            return None;
+        }
+        Some(Self {
+            phase: StorageJoinPhase::Merged,
+            ..self.clone()
+        })
+    }
+
+    fn successors(&self) -> Vec<Self> {
+        let mut next = Vec::new();
+        if let Some(merged) = self.merge_partition() {
+            next.push(merged);
+        }
+        for from in 0..STORAGE_REPLICA_COUNT {
+            for to in 0..STORAGE_REPLICA_COUNT {
+                if let Some(sent) = self.send_current(from, to) {
+                    next.push(sent);
+                }
+            }
+        }
+        for message in self.messages.iter().copied().collect::<Vec<_>>() {
+            if let Some(delivered) = self.deliver(message) {
+                next.push(delivered);
+            }
+        }
+        next
+    }
+
+    fn preserves_lub_bound(&self) -> bool {
+        self.replicas
+            .iter()
+            .copied()
+            .all(|value| value.is_subset_of(StorageJoinValue::ALL))
+    }
+
+    fn is_quiescent_lub(&self) -> bool {
+        self.messages.is_empty()
+            && self
+                .replicas
+                .iter()
+                .copied()
+                .all(|value| value == StorageJoinValue::ALL)
+    }
+
+    fn send_all_current(&self) -> Self {
+        let mut state = self.clone();
+        for from in 0..STORAGE_REPLICA_COUNT {
+            for to in 0..STORAGE_REPLICA_COUNT {
+                if let Some(next) = state.send_current(from, to) {
+                    state = next;
+                }
+            }
+        }
+        state
+    }
+
+    fn deliver_all(&self) -> Self {
+        let mut state = self.clone();
+        for message in self.messages.iter().copied().collect::<Vec<_>>() {
+            if let Some(next) = state.deliver(message) {
+                state = next;
+            }
+        }
+        state
+    }
+
+    fn drive_to_quiescent_lub(&self) -> Self {
+        let mut state = self.clone();
+        for _ in 0..STORAGE_REPLICA_COUNT * 8 {
+            if state.is_quiescent_lub() {
+                return state;
+            }
+            let next = state.send_all_current().deliver_all();
+            if next == state {
+                return next;
+            }
+            state = next;
+        }
+        state
+    }
+}
+
+fn reachable_storage_join_states() -> BTreeSet<StorageJoinState> {
+    let mut seen = BTreeSet::new();
+    let mut frontier = vec![StorageJoinState::initial()];
+    while let Some(state) = frontier.pop() {
+        if !seen.insert(state.clone()) {
+            continue;
+        }
+        for next in state.successors() {
+            if !seen.contains(&next) {
+                frontier.push(next);
+            }
+        }
+    }
+    seen
+}
+
+// ===================================================================
+// Stage 4: storage hand-off cleanup safety for one placement key.
+//
+// SCOPE: this is the #614 S2' cleanup model, not the storage convergence
+// theorem. Convergence is Stage 3's join-semilattice fact. This stage abstracts
+// exactly one placement key, the copy -> ack -> delete hand-off, and arbitrary
+// local writes over a finite representative value domain while a copy or ack is
+// in flight:
 //
 //   local(v) --SendCopy(v)--> copy_in_flight(v)
 //   copy_in_flight(v) --DeliverCopy--> successor(v) + ack_in_flight(v)
@@ -548,8 +775,6 @@ fn discovery_model(all: Vec<Did>, rounds: u8) -> ActorModel<DiscoveryNode, Cfg, 
 //
 //   Always S2': local(k) is removed only if successor(k) contains the same
 //   value at the moment of removal.
-//
-// This is the no-update-loss safety property required by #614.
 // ===================================================================
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -803,8 +1028,43 @@ mod tests {
         }
     }
 
-    /// Stage 3 — storage S2'. Exhaustively explores the finite state graph for
-    /// one placement hand-off and checks the formal safety predicate:
+    /// Stage 3 — CRDT SEC law. Storage values are bounded join-semilattice
+    /// states; anti-entropy messages only deliver more joins.
+    #[test]
+    fn storage_join_value_satisfies_semilattice_laws() {
+        assert_join_semilattice_laws(&[
+            StorageJoinValue::EMPTY,
+            StorageJoinValue::A,
+            StorageJoinValue::B,
+            StorageJoinValue::C,
+            StorageJoinValue::A.join(StorageJoinValue::B),
+            StorageJoinValue::ALL,
+        ]);
+    }
+
+    /// Stage 3 — topology-aware SEC. Every reachable partition/merge state
+    /// stays below the global lub, and every merged state reaches that lub under
+    /// fair repeated send/deliver. This is the storage convergence proof; the
+    /// copy/ack/delete model below is only local cleanup safety.
+    #[test]
+    fn storage_join_topology_model_converges_after_partition_merge() {
+        for state in reachable_storage_join_states() {
+            assert!(
+                state.preserves_lub_bound(),
+                "storage join exceeded global lub: {state:?}"
+            );
+            if state.phase == StorageJoinPhase::Merged {
+                let closed = state.drive_to_quiescent_lub();
+                assert!(
+                    closed.is_quiescent_lub(),
+                    "merged state did not close to global lub: start={state:?}, closed={closed:?}"
+                );
+            }
+        }
+    }
+
+    /// Stage 4 — storage S2'. Exhaustively explores the finite state graph for
+    /// one placement hand-off and checks the cleanup safety predicate:
     /// deleting the local placement key is allowed only when the successor has
     /// durably stored the same value.
     #[test]

--- a/crates/core/src/tests/default/dht_stateright.rs
+++ b/crates/core/src/tests/default/dht_stateright.rs
@@ -560,8 +560,11 @@ fn discovery_model(all: Vec<Did>, rounds: u8) -> ActorModel<DiscoveryNode, Cfg, 
 //   whenever the topology allows that edge.
 //   Merge changes phase from Partitioned to Merged, enabling every edge.
 //
-// Invariant:
-//   forall node. replica[node] <= A join B join C.
+// Carrier safety:
+//   `storage_entry_join_satisfies_semilattice_laws` proves the real Entry
+//   carriers are join-semilattices over this finite domain. This topology
+//   model therefore does not duplicate the carrier <= LUB invariant; its
+//   distinct obligation is the liveness/closure step below.
 //
 // Liveness expectation under fair anti-entropy:
 //   from any reachable Merged state, repeated Transfer steps reach the single
@@ -639,13 +642,6 @@ impl StorageJoinValue {
 
     fn bottom_like(&self) -> Self {
         storage_value_from_bits(self.carrier, 0)
-    }
-
-    fn is_subset_of(&self, other: &Self) -> bool {
-        if self.carrier != other.carrier {
-            return false;
-        }
-        storage_join_entry(self.entry.clone(), other.entry.clone()) == other.entry
     }
 }
 
@@ -979,12 +975,6 @@ impl StorageJoinState {
             }
         }
         next
-    }
-
-    fn is_below_global_lub(&self, global_lub: &StorageJoinValue) -> bool {
-        self.replicas
-            .iter()
-            .all(|value| value.is_subset_of(global_lub))
     }
 
     fn is_quiescent_lub(&self, global_lub: &StorageJoinValue) -> bool {
@@ -1344,22 +1334,18 @@ mod tests {
         }
     }
 
-    /// Stage 3 — topology-aware SEC. Every reachable partition/merge state
-    /// stays below the global lub, and every merged state reaches that lub under
-    /// fair repeated send/deliver. The finite carriers cover bounded top-N data,
-    /// overwrite reset floors, and relay tombstones. The copy/ack/delete model
-    /// below is only local cleanup safety.
+    /// Stage 3 — topology-aware SEC. Carrier safety is proved by
+    /// `storage_entry_join_satisfies_semilattice_laws`; this model checks the
+    /// topology-specific liveness obligation that every merged state reaches the
+    /// global lub under fair repeated send/deliver. The finite carriers cover
+    /// bounded top-N data, overwrite reset floors, and relay tombstones. The
+    /// copy/ack/delete model below is only local cleanup safety.
     #[test]
     fn storage_join_topology_model_converges_after_partition_merge() {
         for scenario in storage_join_scenarios() {
             let global_lub = scenario.global_lub();
             for partition in STORAGE_PARTITION_MASKS {
                 for state in reachable_storage_join_states(partition, scenario.initial.clone()) {
-                    assert!(
-                        state.is_below_global_lub(&global_lub),
-                        "storage join exceeded global lub for {}: {state:?}",
-                        scenario.name
-                    );
                     if state.phase == StorageJoinPhase::Merged {
                         let closed = state.drive_to_quiescent_lub(&global_lub);
                         assert!(

--- a/crates/core/src/tests/default/test_stabilization.rs
+++ b/crates/core/src/tests/default/test_stabilization.rs
@@ -52,11 +52,7 @@ async fn stabilize_republishes_local_entries_to_missing_affine_owners() -> Resul
         .build(),
     );
     let node = Node::new(swarm);
-    let entry = Entry {
-        did: key.address().into(),
-        data: vec![],
-        kind: EntryKind::Data,
-    };
+    let entry = Entry::new(key.address().into(), vec![], EntryKind::Data);
     let placement_keys = entry.did.rotate_affine(2)?;
     node.dht()
         .storage


### PR DESCRIPTION
Closes #627.

## Summary
- make replicated DHT entries explicit CRDT carriers with `JoinSemilattice` laws, including relay-message tombstones as a production `EntryOperation`
- expand the production pure Chord topology transition to cover join, remove, successor update, notify, stabilize, finger fix, and indexed finger-apply reports
- keep `PeerRing` as the interpreter shell over pure topology state and lower DHT actions through the existing effect coproduct, including `FindSuccessorForFix { did, index }`
- replace the storage convergence proof in `dht_stateright` with a finite partition/merge join-semilattice SEC model, while retaining copy/ack/delete only as cleanup safety
- update storage sync/repair documentation so #611/#612/#614 are consequences of join delivery plus bounded conditional cleanup, not separate convergence mechanisms

## Coverage for #627
- [x] `JoinSemilattice` laws and named DHT entry CRDTs; operate, sync persistence, repair, and ack persistence route through entry join
- [x] SEC witnessed by generic law tests and by a `dht_stateright` partition-then-merge topology model
- [x] Chord transitions exposed as a pure `step(State, Event) -> (State, Actions)` production core; convergence tests use `dht::topology` rather than a parallel oracle
- [x] Identifier arithmetic stays on `algebra.rs`/`Did`; DHT side effects lower through the existing effect coproduct without a parallel action encoding
- [x] #611/#612/#614 documented as lattice consequences or cleanup boundaries

## Validation
- `cargo +nightly fmt --all -- --check`
- `cargo check -p rings-core --tests`
- `cargo test -p rings-core dht::entry --lib`
- `cargo test -p rings-core dht_stateright --lib`
- `cargo test -p rings-core dht::topology --lib`
- `cargo test -p rings-core --lib`