### PR TITLE
Add streaming E2E ElGamal encryption

### DIFF
--- a/crates/core/src/ecc/elgamal/impls/secp256k1.rs
+++ b/crates/core/src/ecc/elgamal/impls/secp256k1.rs
@@ -232,8 +232,8 @@ fn decode_field_bytes(mut bytes: [u8; 32]) -> Vec<u8> {
 /// The initial candidate uses its own parity. If it is not on the curve, the
 /// search decrements byte `0` from `254` to `1` and retries. This keeps bytes
 /// `1..` intact, so decoding can recover the original marker, chunk length, and
-/// plaintext bytes. The panic at `Some(0)` is an invariant failure: for the
-/// adapter's 254 alternate high-byte candidates, at least one should lift.
+/// plaintext bytes. If no high-byte candidate lifts, the adapter returns a
+/// typed error.
 fn lift_x(x: &Field) -> Result<Affine> {
     let mut ec = Affine::default();
     let mut x = *x;

--- a/crates/core/src/ecc/elgamal/impls/secp256k1.rs
+++ b/crates/core/src/ecc/elgamal/impls/secp256k1.rs
@@ -50,8 +50,17 @@ const FIELD_ENCODING_OVERHEAD: usize = 3;
 const FIELD_CHUNK_SIZE: usize = 32 - FIELD_ENCODING_OVERHEAD;
 const FIELD_CHUNK_SIZE_U8: u8 = 29;
 
+/// Plaintext bytes carried by one secp256k1 point in this adapter.
+pub const PLAINTEXT_BLOCK_SIZE: usize = FIELD_CHUNK_SIZE;
+
+/// One serialized ElGamal ciphertext block over secp256k1.
+pub type CiphertextBlock = (CurveEle<33>, CurveEle<33>);
+
 /// Plaintext input before it is mapped into secp256k1 group elements.
 pub struct Plaintext<'a>(&'a str);
+
+/// Binary plaintext input before it is mapped into secp256k1 group elements.
+pub struct PlaintextBytes<'a>(&'a [u8]);
 
 /// secp256k1 group elements that encode one plaintext message.
 pub struct MessagePoints(Vec<Point<Secp256k1>>);
@@ -59,6 +68,13 @@ pub struct MessagePoints(Vec<Point<Secp256k1>>);
 impl<'a> Plaintext<'a> {
     /// Plaintext string before group encoding.
     pub fn as_str(&self) -> &'a str {
+        self.0
+    }
+}
+
+impl<'a> PlaintextBytes<'a> {
+    /// Plaintext bytes before group encoding.
+    pub fn as_bytes(&self) -> &'a [u8] {
         self.0
     }
 }
@@ -72,6 +88,12 @@ impl MessagePoints {
 
 impl<'a> From<&'a str> for Plaintext<'a> {
     fn from(message: &'a str) -> Self {
+        Self(message)
+    }
+}
+
+impl<'a> From<&'a [u8]> for PlaintextBytes<'a> {
+    fn from(message: &'a [u8]) -> Self {
         Self(message)
     }
 }
@@ -95,7 +117,15 @@ impl<'a> TryFrom<Plaintext<'a>> for MessagePoints {
     type Error = Error;
 
     fn try_from(message: Plaintext<'a>) -> Result<Self> {
-        Ok(str_to_affine(message.as_str())?
+        MessagePoints::try_from(PlaintextBytes::from(message.as_str().as_bytes()))
+    }
+}
+
+impl<'a> TryFrom<PlaintextBytes<'a>> for MessagePoints {
+    type Error = Error;
+
+    fn try_from(message: PlaintextBytes<'a>) -> Result<Self> {
+        Ok(bytes_to_affine(message.as_bytes())?
             .into_iter()
             .map(Point::<Secp256k1>::from)
             .collect::<Vec<_>>()
@@ -107,11 +137,19 @@ impl TryFrom<MessagePoints> for String {
     type Error = Error;
 
     fn try_from(points: MessagePoints) -> Result<Self> {
+        String::from_utf8(Vec::<u8>::try_from(points)?).map_err(Error::Utf8Encoding)
+    }
+}
+
+impl TryFrom<MessagePoints> for Vec<u8> {
+    type Error = Error;
+
+    fn try_from(points: MessagePoints) -> Result<Self> {
         let affines = points
             .into_iter()
             .map(Affine::from)
             .collect::<Vec<Affine>>();
-        affine_to_str(&affines)
+        Ok(affine_to_bytes(&affines))
     }
 }
 
@@ -122,8 +160,13 @@ impl TryFrom<MessagePoints> for String {
 /// search bias for `lift_x`; the marker and length bytes make the mapping
 /// reversible and preserve leading or embedded NUL bytes.
 pub fn str_to_field(s: &str) -> Vec<Field> {
-    s.as_bytes()
-        .chunks(FIELD_CHUNK_SIZE)
+    bytes_to_field(s.as_bytes())
+}
+
+/// Convert arbitrary bytes into field elements using the adapter encoding.
+pub fn bytes_to_field(bytes: &[u8]) -> Vec<Field> {
+    bytes
+        .chunks(PLAINTEXT_BLOCK_SIZE)
         .map(|x| {
             let data = encode_field_candidate(x);
             let mut field = Field::default();
@@ -155,13 +198,17 @@ fn encode_field_candidate(chunk: &[u8]) -> [u8; 32] {
 
 /// Decode field elements produced by [`str_to_field`].
 pub fn field_to_str(f: &[Field]) -> Result<String> {
-    String::from_utf8(f.iter().fold(vec![], |mut acc, x| {
+    String::from_utf8(field_to_bytes(f)).map_err(Error::Utf8Encoding)
+}
+
+/// Decode field elements produced by [`bytes_to_field`].
+pub fn field_to_bytes(f: &[Field]) -> Vec<u8> {
+    f.iter().fold(vec![], |mut acc, x| {
         let mut field = *x;
         field.normalize();
         acc.extend(decode_field_bytes(field.b32()));
         acc
-    }))
-    .map_err(Error::Utf8Encoding)
+    })
 }
 
 fn decode_field_bytes(mut bytes: [u8; 32]) -> Vec<u8> {
@@ -223,7 +270,12 @@ fn lift_x(x: &Field) -> Result<Affine> {
 
 /// Convert a string into secp256k1 points using the adapter encoding.
 pub fn str_to_affine(s: &str) -> Result<Vec<Affine>> {
-    str_to_field(s)
+    bytes_to_affine(s.as_bytes())
+}
+
+/// Convert arbitrary bytes into secp256k1 points using the adapter encoding.
+pub fn bytes_to_affine(bytes: &[u8]) -> Result<Vec<Affine>> {
+    bytes_to_field(bytes)
         .into_iter()
         .map(|a| lift_x(&a))
         .collect::<Result<Vec<Affine>>>()
@@ -231,11 +283,16 @@ pub fn str_to_affine(s: &str) -> Result<Vec<Affine>> {
 
 /// Decode secp256k1 points produced by `str_to_affine`.
 pub fn affine_to_str(a: &[Affine]) -> Result<String> {
-    field_to_str(a.iter().map(|x| x.x).collect::<Vec<Field>>().as_slice())
+    String::from_utf8(affine_to_bytes(a)).map_err(Error::Utf8Encoding)
+}
+
+/// Decode secp256k1 points produced by [`bytes_to_affine`].
+pub fn affine_to_bytes(a: &[Affine]) -> Vec<u8> {
+    field_to_bytes(a.iter().map(|x| x.x).collect::<Vec<Field>>().as_slice())
 }
 
 /// Encrypt a string with the current secp256k1 compatibility adapter.
-pub fn encrypt(s: &str, k: PublicKey<33>) -> Result<Vec<(CurveEle<33>, CurveEle<33>)>> {
+pub fn encrypt(s: &str, k: PublicKey<33>) -> Result<Vec<CiphertextBlock>> {
     let public_key = ElGamalPublicKey::<Point<Secp256k1>>::from_element(k.try_into()?);
     let points = MessagePoints::try_from(Plaintext::from(s))?;
     ElGamal::<Point<Secp256k1>>::encrypt(points, &public_key)
@@ -249,9 +306,18 @@ pub fn encrypt_with_rng(
     s: &str,
     k: PublicKey<33>,
     rng: &mut impl RngCore,
-) -> Result<Vec<(CurveEle<33>, CurveEle<33>)>> {
+) -> Result<Vec<CiphertextBlock>> {
+    encrypt_bytes_with_rng(s.as_bytes(), k, rng)
+}
+
+/// Encrypt arbitrary bytes with caller-supplied randomness for ElGamal ephemerals.
+pub fn encrypt_bytes_with_rng(
+    bytes: &[u8],
+    k: PublicKey<33>,
+    rng: &mut impl RngCore,
+) -> Result<Vec<CiphertextBlock>> {
     let public_key = ElGamalPublicKey::<Point<Secp256k1>>::from_element(k.try_into()?);
-    let points = MessagePoints::try_from(Plaintext::from(s))?;
+    let points = MessagePoints::try_from(PlaintextBytes::from(bytes))?;
     ElGamal::<Point<Secp256k1>>::encrypt_with_rng(points, &public_key, rng)
         .into_iter()
         .map(|(c1, c2)| Ok((c1.try_into()?, c2.try_into()?)))
@@ -259,7 +325,12 @@ pub fn encrypt_with_rng(
 }
 
 /// Decrypt ciphertext produced by the current secp256k1 compatibility adapter.
-pub fn decrypt(m: &[(CurveEle<33>, CurveEle<33>)], k: SecretKey) -> Result<String> {
+pub fn decrypt(m: &[CiphertextBlock], k: SecretKey) -> Result<String> {
+    String::from_utf8(decrypt_bytes(m, k)?).map_err(Error::Utf8Encoding)
+}
+
+/// Decrypt arbitrary bytes produced by [`encrypt_bytes_with_rng`].
+pub fn decrypt_bytes(m: &[CiphertextBlock], k: SecretKey) -> Result<Vec<u8>> {
     let secret_key =
         ElGamalSecretKey::<Point<Secp256k1>>::from_scalar(GroupScalar::<Secp256k1>::from(k));
     let ciphertext = m
@@ -267,7 +338,7 @@ pub fn decrypt(m: &[(CurveEle<33>, CurveEle<33>)], k: SecretKey) -> Result<Strin
         .map(|(c1, c2)| Ok(((*c1).try_into()?, (*c2).try_into()?)))
         .collect::<Result<Vec<(Point<Secp256k1>, Point<Secp256k1>)>>>()?;
     let points = ElGamal::<Point<Secp256k1>>::decrypt(&ciphertext, &secret_key);
-    String::try_from(MessagePoints::from(points))
+    Vec::<u8>::try_from(MessagePoints::from(points))
 }
 
 #[cfg(test)]
@@ -319,12 +390,30 @@ mod test {
     }
 
     #[test]
+    fn test_bytes_to_field_keeps_binary_payload() {
+        let mut payload = vec![0, 255, 1, 2, 3];
+        payload.extend((0..FIELD_CHUNK_SIZE * 2).map(|i| (i % 251) as u8));
+
+        assert_eq!(field_to_bytes(&bytes_to_field(&payload)), payload);
+    }
+
+    #[test]
     fn test_string_to_affine() {
         let t: String = random(1024);
         assert_eq!(affine_to_str(&str_to_affine(&t).unwrap()).unwrap(), t);
 
         let t: String = random(127);
         assert_eq!(affine_to_str(&str_to_affine(&t).unwrap()).unwrap(), t);
+    }
+
+    #[test]
+    fn test_bytes_to_affine() {
+        let payload = [0, 1, 2, 3, 255, 128, 0, 42, 77, 0, 99];
+
+        assert_eq!(
+            affine_to_bytes(&bytes_to_affine(&payload).unwrap()),
+            payload
+        );
     }
 
     #[test]
@@ -380,25 +469,25 @@ mod test {
         assert_eq!(a_c1.x.b32(), c1_x);
         assert_eq!(a_c1.y.b32(), c1_y);
 
-        let mut shared_sec = Jacobian::default();
+        let mut mask_point = Jacobian::default();
         let cxt2 = ECMultContext::new_boxed();
-        cxt2.ecmult_const(&mut shared_sec, &pub_point, &r_sca);
-        let mut a_ss = Affine::from_gej(&shared_sec);
-        a_ss.x.normalize();
-        a_ss.y.normalize();
+        cxt2.ecmult_const(&mut mask_point, &pub_point, &r_sca);
+        let mut a_mask = Affine::from_gej(&mask_point);
+        a_mask.x.normalize();
+        a_mask.y.normalize();
 
-        let ss_x = [
+        let mask_x = [
             218, 19, 55, 137, 15, 46, 160, 160, 208, 222, 206, 77, 46, 79, 32, 80, 64, 243, 93, 23,
             223, 130, 148, 226, 131, 17, 254, 95, 43, 95, 35, 34,
         ];
 
-        let ss_y = [
+        let mask_y = [
             106, 127, 47, 58, 214, 6, 110, 28, 171, 176, 73, 11, 34, 28, 125, 10, 82, 154, 84, 154,
             11, 80, 191, 68, 111, 197, 98, 224, 84, 116, 208, 115,
         ];
-        assert_eq!(a_ss.x.b32(), ss_x);
-        assert_eq!(a_ss.y.b32(), ss_y);
-        let c2 = shared_sec.add_ge(&m_point);
+        assert_eq!(a_mask.x.b32(), mask_x);
+        assert_eq!(a_mask.y.b32(), mask_y);
+        let c2 = mask_point.add_ge(&m_point);
         let c2_y = [
             225, 196, 104, 44, 46, 208, 86, 14, 40, 40, 133, 81, 125, 222, 217, 21, 242, 64, 68,
             206, 194, 27, 61, 193, 20, 18, 110, 198, 39, 60, 214, 200,
@@ -457,6 +546,21 @@ mod test {
             decrypt(&encrypt(&message, pubkey).unwrap(), key).unwrap(),
             message
         );
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_binary_bytes() {
+        let key =
+            SecretKey::try_from("65860affb4b570dba06db294aa7c676f68e04a5bf2721243ad3cbc05a79c68c0")
+                .unwrap();
+        let pubkey = key.pubkey();
+        let mut rng = Hc128Rng::seed_from_u64(608);
+        let mut payload = vec![0, 255, 1, 2, 3];
+        payload.extend((0..FIELD_CHUNK_SIZE * 3).map(|i| (i % 251) as u8));
+
+        let ciphertext = encrypt_bytes_with_rng(&payload, pubkey, &mut rng).unwrap();
+
+        assert_eq!(decrypt_bytes(&ciphertext, key).unwrap(), payload);
     }
 
     #[test]

--- a/crates/core/src/ecc/elgamal/mod.rs
+++ b/crates/core/src/ecc/elgamal/mod.rs
@@ -7,7 +7,7 @@
 //!    Map the message 𝑀 to an element 𝑚 of 𝐺 using a reversible mapping function.
 //! Choose an integer 𝑦
 //! randomly from {1,…,𝑞−1}
-//! 1. Compute 𝑠:=ℎ𝑦 This is called the shared secret.
+//! 1. Compute 𝑠:=ℎ𝑦 as the ElGamal masking element.
 //! 2. Compute 𝑐1:=𝑔𝑦
 //! 3. Compute 𝑐2:=𝑚⋅𝑠
 //! 4. Bob sends the ciphertext (𝑐1,𝑐2) to Alice.
@@ -38,7 +38,7 @@
 //!
 //! 1. choose fresh random scalar `r`
 //! 2. compute `c1 = rg`
-//! 3. compute shared secret `s = rh`
+//! 3. compute masking element `s = rh`
 //! 4. compute `c2 = m + s`
 //!
 //! Decryption computes `m = c2 - x c1`.
@@ -217,8 +217,8 @@ where
         ciphertext
             .iter()
             .map(|(c1, c2)| {
-                let shared_secret = c1.clone() * secret_key.as_scalar().clone();
-                c2.clone() - shared_secret
+                let mask = c1.clone() * secret_key.as_scalar().clone();
+                c2.clone() - mask
             })
             .collect()
     }
@@ -234,8 +234,8 @@ where
         ephemeral_scalar: Element::Scalar,
     ) -> (Element, Element) {
         let c1 = Element::generator_mul(&ephemeral_scalar);
-        let shared_secret = public_key.as_element().clone() * ephemeral_scalar;
-        let c2 = message_element + shared_secret;
+        let mask = public_key.as_element().clone() * ephemeral_scalar;
+        let c2 = message_element + mask;
         (c1, c2)
     }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -41,6 +41,18 @@ pub enum Error {
         actual: u64,
     },
 
+    #[error(
+        "E2E frame sequence {actual} exceeds reorder window {window} from next sequence {next_sequence}"
+    )]
+    E2eFrameReorderWindowExceeded {
+        /// Next contiguous sequence number expected by the decryptor.
+        next_sequence: u64,
+        /// Sequence number carried by the frame.
+        actual: u64,
+        /// Maximum accepted gap ahead of the next sequence.
+        window: u64,
+    },
+
     #[error("E2E frame sequence counter overflowed")]
     E2eFrameSequenceOverflow,
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -25,6 +25,39 @@ pub enum Error {
     #[error("Failed to lift encoded plaintext into a secp256k1 point")]
     Secp256k1PointLiftFailed,
 
+    #[error("E2E stream id mismatch: expected {expected}, actual {actual}")]
+    E2eStreamIdMismatch {
+        /// Stream ID expected by the decryptor.
+        expected: uuid::Uuid,
+        /// Stream ID carried by the frame.
+        actual: uuid::Uuid,
+    },
+
+    #[error("E2E frame sequence mismatch: expected {expected}, actual {actual}")]
+    E2eFrameSequenceMismatch {
+        /// Sequence number expected by the decryptor.
+        expected: u64,
+        /// Sequence number carried by the frame.
+        actual: u64,
+    },
+
+    #[error("E2E frame sequence counter overflowed")]
+    E2eFrameSequenceOverflow,
+
+    #[error("E2E frame received after the authenticated final frame")]
+    E2eFrameAfterFinal,
+
+    #[error("E2E stream is missing the authenticated final frame")]
+    E2eMissingFinalFrame,
+
+    #[error("E2E public key resolves to {actual}, expected {expected}")]
+    E2ePublicKeyDidMismatch {
+        /// DID expected by the signed message context.
+        expected: crate::dht::Did,
+        /// DID derived from the supplied public key.
+        actual: crate::dht::Did,
+    },
+
     #[error("Secp256r1/ECDSA Error: {0}")]
     ECDSAError(#[from] ecdsa::Error),
 

--- a/crates/core/src/message/e2e.rs
+++ b/crates/core/src/message/e2e.rs
@@ -1,0 +1,815 @@
+//! End-to-end ElGamal encryption for byte payloads.
+//!
+//! This module models E2E encryption as two separate protocol facts:
+//!
+//! - peers discover encryption public keys with signed handshake messages;
+//! - message bodies are encrypted directly with secp256k1 ElGamal stream
+//!   frames, each carried by its own signed
+//!   [`MessagePayload`](crate::message::MessagePayload).
+//!
+//! Rings intentionally uses the DID/account secp256k1 public key as the
+//! ElGamal key. The public key carried by a handshake or encrypted message must
+//! resolve to the signed DID; this is the protocol's key-ownership proof. The
+//! module does not derive a separate encryption subkey.
+//!
+//! The direct ElGamal body is deliberately not KEM/DEM or AEAD. Keeping the
+//! ciphertext in group-element form preserves the algebraic structure needed by
+//! future homomorphic operations. That also means ciphertext frames are
+//! malleable if detached from the signed message envelope. Integrity, sender
+//! authentication, public-key ownership, and per-frame integrity are provided by
+//! the surrounding [`MessagePayload`](crate::message::MessagePayload)
+//! signature. The stream id, sequence, and final marker make truncation
+//! observable and let the decryptor release reordered frames as a gapless
+//! plaintext stream.
+
+use std::collections::BTreeMap;
+
+use rand::RngCore;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::dht::Did;
+use crate::ecc::elgamal::impls::secp256k1;
+use crate::ecc::group::Point;
+use crate::ecc::group::Secp256k1;
+use crate::ecc::PublicKey;
+use crate::ecc::SecretKey;
+use crate::error::Error;
+use crate::error::Result;
+
+/// Plaintext bytes carried by one ElGamal body block.
+pub const E2E_PLAINTEXT_BLOCK_LEN: usize = secp256k1::PLAINTEXT_BLOCK_SIZE;
+
+/// Default plaintext bytes per encrypted E2E stream frame.
+pub const DEFAULT_E2E_PLAINTEXT_FRAME_LEN: usize = E2E_PLAINTEXT_BLOCK_LEN * 16;
+
+/// Identifier shared by all frames of one encrypted E2E stream.
+pub type E2eStreamId = uuid::Uuid;
+
+/// An invitation to start E2E encryption with the requester's public key.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+pub struct E2eHandshakeRequest {
+    /// Public key owned by the requester DID.
+    pub requester_public_key: PublicKey<33>,
+}
+
+/// An acceptance of an E2E handshake with the responder's public key.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+pub struct E2eHandshakeResponse {
+    /// Public key owned by the responder DID.
+    pub responder_public_key: PublicKey<33>,
+}
+
+/// One ordered ElGamal-encrypted stream frame.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct E2eStreamFrame {
+    /// Stream identifier shared by all frames in this body stream.
+    pub stream_id: E2eStreamId,
+    /// Public key owned by the signed sender DID.
+    pub sender_public_key: PublicKey<33>,
+    /// Monotonic frame counter checked by the decryptor.
+    pub sequence: u64,
+    /// End-of-stream marker authenticated by this frame's message signature.
+    pub is_final: bool,
+    /// ElGamal ciphertext blocks for this frame's plaintext bytes.
+    pub ciphertext: Vec<secp256k1::CiphertextBlock>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct E2ePlaintextFrame<'a> {
+    plaintext: &'a [u8],
+    is_final: bool,
+}
+
+struct E2ePlaintextFrames<'a> {
+    chunks: std::iter::Peekable<std::slice::Chunks<'a, u8>>,
+    plaintext_is_empty: bool,
+    emitted_empty_final: bool,
+}
+
+/// Lazy iterator that encrypts one E2E stream frame per iteration.
+pub struct E2eStreamFrames<'a, R: RngCore> {
+    plaintext_frames: E2ePlaintextFrames<'a>,
+    encryptor: E2eStreamEncryptor,
+    rng: R,
+}
+
+/// Stateful streaming encryptor for direct ElGamal body frames.
+pub struct E2eStreamEncryptor {
+    stream_id: E2eStreamId,
+    sender_public_key: PublicKey<33>,
+    recipient_public_key: PublicKey<33>,
+    next_sequence: u64,
+    closed: bool,
+}
+
+/// Stateful streaming decryptor for direct ElGamal body frames.
+pub struct E2eStreamDecryptor {
+    stream_id: E2eStreamId,
+    expected_sender: Did,
+    recipient_secret_key: SecretKey,
+    next_sequence: u64,
+    final_sequence: Option<u64>,
+    seen_final: bool,
+    pending_frames: BTreeMap<u64, E2eStreamFrame>,
+}
+
+impl<'a> E2ePlaintextFrame<'a> {
+    fn plaintext(&self) -> &'a [u8] {
+        self.plaintext
+    }
+
+    fn is_final(&self) -> bool {
+        self.is_final
+    }
+}
+
+impl<'a> E2ePlaintextFrames<'a> {
+    fn new(plaintext: &'a [u8], max_plaintext_frame_len: usize) -> Self {
+        Self {
+            chunks: plaintext.chunks(max_plaintext_frame_len.max(1)).peekable(),
+            plaintext_is_empty: plaintext.is_empty(),
+            emitted_empty_final: false,
+        }
+    }
+}
+
+impl<R: RngCore> Iterator for E2eStreamFrames<'_, R> {
+    type Item = Result<E2eStreamFrame>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.plaintext_frames
+            .next()
+            .map(|frame| self.encryptor.encrypt_plaintext_frame(frame, &mut self.rng))
+    }
+}
+
+impl<'a> Iterator for E2ePlaintextFrames<'a> {
+    type Item = E2ePlaintextFrame<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.plaintext_is_empty {
+            if self.emitted_empty_final {
+                return None;
+            }
+            self.emitted_empty_final = true;
+            return Some(E2ePlaintextFrame {
+                plaintext: &[],
+                is_final: true,
+            });
+        }
+
+        let plaintext = self.chunks.next()?;
+        Some(E2ePlaintextFrame {
+            plaintext,
+            is_final: self.chunks.peek().is_none(),
+        })
+    }
+}
+
+impl E2eHandshakeRequest {
+    /// Build a handshake request for a sender public key.
+    pub fn new(requester_public_key: PublicKey<33>) -> Self {
+        Self {
+            requester_public_key,
+        }
+    }
+
+    /// Verify that the requester public key belongs to the signed requester DID.
+    pub fn verify_requester(&self, requester: Did) -> Result<()> {
+        ensure_public_key_matches_did(self.requester_public_key, requester)
+    }
+}
+
+impl E2eHandshakeResponse {
+    /// Build a handshake response for a responder public key.
+    pub fn new(responder_public_key: PublicKey<33>) -> Self {
+        Self {
+            responder_public_key,
+        }
+    }
+
+    /// Verify that the responder public key belongs to the signed responder DID.
+    pub fn verify_responder(&self, responder: Did) -> Result<()> {
+        ensure_public_key_matches_did(self.responder_public_key, responder)
+    }
+}
+
+impl E2eStreamFrame {
+    /// Verify that the carried sender key belongs to the signed sender DID.
+    pub fn verify_sender(&self, sender: Did) -> Result<()> {
+        ensure_public_key_matches_did(self.sender_public_key, sender)
+    }
+}
+
+impl E2eStreamEncryptor {
+    /// Create a direct ElGamal streaming encryptor for `recipient_public_key`.
+    pub fn new(
+        stream_id: E2eStreamId,
+        sender_public_key: PublicKey<33>,
+        recipient_public_key: PublicKey<33>,
+    ) -> Result<Self> {
+        ensure_valid_public_key(sender_public_key)?;
+        ensure_valid_public_key(recipient_public_key)?;
+        Ok(Self {
+            stream_id,
+            sender_public_key,
+            recipient_public_key,
+            next_sequence: 0,
+            closed: false,
+        })
+    }
+
+    /// Encrypt one non-final plaintext frame.
+    pub fn encrypt_next(
+        &mut self,
+        plaintext: &[u8],
+        rng: &mut impl RngCore,
+    ) -> Result<E2eStreamFrame> {
+        self.encrypt_frame(plaintext, false, rng)
+    }
+
+    /// Encrypt one non-final plaintext frame with the default thread-local RNG.
+    pub fn encrypt_next_with_default_rng(&mut self, plaintext: &[u8]) -> Result<E2eStreamFrame> {
+        let mut rng = rand::thread_rng();
+        self.encrypt_next(plaintext, &mut rng)
+    }
+
+    /// Encrypt the final plaintext frame and close this stream.
+    pub fn encrypt_final(
+        &mut self,
+        plaintext: &[u8],
+        rng: &mut impl RngCore,
+    ) -> Result<E2eStreamFrame> {
+        self.encrypt_frame(plaintext, true, rng)
+    }
+
+    /// Encrypt the final plaintext frame with the default thread-local RNG.
+    pub fn encrypt_final_with_default_rng(&mut self, plaintext: &[u8]) -> Result<E2eStreamFrame> {
+        let mut rng = rand::thread_rng();
+        self.encrypt_final(plaintext, &mut rng)
+    }
+
+    fn encrypt_plaintext_frame(
+        &mut self,
+        frame: E2ePlaintextFrame<'_>,
+        rng: &mut impl RngCore,
+    ) -> Result<E2eStreamFrame> {
+        if frame.is_final() {
+            self.encrypt_final(frame.plaintext(), rng)
+        } else {
+            self.encrypt_next(frame.plaintext(), rng)
+        }
+    }
+
+    fn encrypt_frame(
+        &mut self,
+        plaintext: &[u8],
+        is_final: bool,
+        rng: &mut impl RngCore,
+    ) -> Result<E2eStreamFrame> {
+        if self.closed {
+            return Err(Error::E2eFrameAfterFinal);
+        }
+
+        let sequence = self.next_sequence;
+        if is_final {
+            self.closed = true;
+        } else {
+            self.next_sequence = next_sequence(sequence)?;
+        }
+
+        let ciphertext =
+            secp256k1::encrypt_bytes_with_rng(plaintext, self.recipient_public_key, rng)?;
+        Ok(E2eStreamFrame {
+            stream_id: self.stream_id,
+            sender_public_key: self.sender_public_key,
+            sequence,
+            is_final,
+            ciphertext,
+        })
+    }
+}
+
+impl E2eStreamDecryptor {
+    /// Create a direct ElGamal streaming decryptor for a recipient secret key.
+    pub fn new(
+        stream_id: E2eStreamId,
+        expected_sender: Did,
+        recipient_secret_key: SecretKey,
+    ) -> Self {
+        Self {
+            stream_id,
+            expected_sender,
+            recipient_secret_key,
+            next_sequence: 0,
+            final_sequence: None,
+            seen_final: false,
+            pending_frames: BTreeMap::new(),
+        }
+    }
+
+    /// Decrypt one frame and return newly contiguous plaintext bytes.
+    ///
+    /// Out-of-order future frames are buffered and return an empty vector until
+    /// the missing lower sequence numbers arrive.
+    pub fn decrypt_next(&mut self, frame: &E2eStreamFrame) -> Result<Vec<u8>> {
+        self.validate_frame(frame)?;
+        if frame.is_final {
+            self.final_sequence = Some(frame.sequence);
+        }
+        self.pending_frames.insert(frame.sequence, frame.clone());
+        self.decrypt_ready_frames()
+    }
+
+    /// Verify that the stream ended with an authenticated final frame.
+    pub fn finish(&self) -> Result<()> {
+        if self.seen_final {
+            Ok(())
+        } else {
+            Err(Error::E2eMissingFinalFrame)
+        }
+    }
+
+    fn validate_frame(&self, frame: &E2eStreamFrame) -> Result<()> {
+        if self.seen_final {
+            return Err(Error::E2eFrameAfterFinal);
+        }
+
+        if frame.stream_id != self.stream_id {
+            return Err(Error::E2eStreamIdMismatch {
+                expected: self.stream_id,
+                actual: frame.stream_id,
+            });
+        }
+
+        frame.verify_sender(self.expected_sender)?;
+
+        if frame.sequence < self.next_sequence || self.pending_frames.contains_key(&frame.sequence)
+        {
+            return Err(Error::E2eFrameSequenceMismatch {
+                expected: self.next_sequence,
+                actual: frame.sequence,
+            });
+        }
+
+        if let Some(final_sequence) = self.final_sequence {
+            if frame.sequence > final_sequence {
+                return Err(Error::E2eFrameAfterFinal);
+            }
+
+            if frame.is_final && frame.sequence != final_sequence {
+                return Err(Error::E2eFrameSequenceMismatch {
+                    expected: final_sequence,
+                    actual: frame.sequence,
+                });
+            }
+        }
+
+        if frame.is_final && self.has_pending_frame_after(frame.sequence) {
+            return Err(Error::E2eFrameAfterFinal);
+        }
+
+        Ok(())
+    }
+
+    fn decrypt_ready_frames(&mut self) -> Result<Vec<u8>> {
+        let mut plaintext = Vec::new();
+
+        while let Some(frame) = self.pending_frames.get(&self.next_sequence) {
+            let frame_plaintext =
+                secp256k1::decrypt_bytes(&frame.ciphertext, self.recipient_secret_key)?;
+            let is_final = frame.is_final;
+            plaintext.extend_from_slice(&frame_plaintext);
+            self.pending_frames.remove(&self.next_sequence);
+
+            if is_final {
+                self.seen_final = true;
+                break;
+            }
+
+            self.next_sequence = next_sequence(self.next_sequence)?;
+        }
+
+        Ok(plaintext)
+    }
+
+    fn has_pending_frame_after(&self, sequence: u64) -> bool {
+        self.pending_frames
+            .last_key_value()
+            .is_some_and(|(pending_sequence, _)| *pending_sequence > sequence)
+    }
+}
+
+fn plaintext_stream_frames(
+    plaintext: &[u8],
+    max_plaintext_frame_len: usize,
+) -> E2ePlaintextFrames<'_> {
+    E2ePlaintextFrames::new(plaintext, max_plaintext_frame_len)
+}
+
+/// Encrypt a byte slice lazily into direct-ElGamal E2E stream frames.
+pub fn encrypt_stream_frames_with_rng<R: RngCore>(
+    plaintext: &[u8],
+    stream_id: E2eStreamId,
+    sender_public_key: PublicKey<33>,
+    recipient_public_key: PublicKey<33>,
+    max_plaintext_frame_len: usize,
+    rng: R,
+) -> Result<E2eStreamFrames<'_, R>> {
+    Ok(E2eStreamFrames {
+        plaintext_frames: plaintext_stream_frames(plaintext, max_plaintext_frame_len),
+        encryptor: E2eStreamEncryptor::new(stream_id, sender_public_key, recipient_public_key)?,
+        rng,
+    })
+}
+
+/// Encrypt a byte slice lazily with the default thread-local RNG.
+pub fn encrypt_stream_frames(
+    plaintext: &[u8],
+    stream_id: E2eStreamId,
+    sender_public_key: PublicKey<33>,
+    recipient_public_key: PublicKey<33>,
+    max_plaintext_frame_len: usize,
+) -> Result<E2eStreamFrames<'_, rand::rngs::ThreadRng>> {
+    encrypt_stream_frames_with_rng(
+        plaintext,
+        stream_id,
+        sender_public_key,
+        recipient_public_key,
+        max_plaintext_frame_len,
+        rand::thread_rng(),
+    )
+}
+
+/// Encrypt a byte slice into direct-ElGamal E2E stream frames.
+pub fn encrypt_stream_with_rng(
+    plaintext: &[u8],
+    stream_id: E2eStreamId,
+    sender_public_key: PublicKey<33>,
+    recipient_public_key: PublicKey<33>,
+    max_plaintext_frame_len: usize,
+    rng: &mut impl RngCore,
+) -> Result<Vec<E2eStreamFrame>> {
+    encrypt_stream_frames_with_rng(
+        plaintext,
+        stream_id,
+        sender_public_key,
+        recipient_public_key,
+        max_plaintext_frame_len,
+        rng,
+    )?
+    .collect()
+}
+
+/// Encrypt a byte slice into direct-ElGamal E2E stream frames with the default thread-local RNG.
+pub fn encrypt_stream(
+    plaintext: &[u8],
+    stream_id: E2eStreamId,
+    sender_public_key: PublicKey<33>,
+    recipient_public_key: PublicKey<33>,
+    max_plaintext_frame_len: usize,
+) -> Result<Vec<E2eStreamFrame>> {
+    encrypt_stream_frames(
+        plaintext,
+        stream_id,
+        sender_public_key,
+        recipient_public_key,
+        max_plaintext_frame_len,
+    )?
+    .collect()
+}
+
+/// Decrypt a complete direct-ElGamal E2E frame sequence into bytes.
+pub fn decrypt_stream(
+    frames: &[E2eStreamFrame],
+    stream_id: E2eStreamId,
+    expected_sender: Did,
+    recipient_secret_key: SecretKey,
+) -> Result<Vec<u8>> {
+    let mut decryptor = E2eStreamDecryptor::new(stream_id, expected_sender, recipient_secret_key);
+    let mut plaintext = Vec::new();
+
+    for frame in frames {
+        let frame_plaintext = decryptor.decrypt_next(frame)?;
+        plaintext.extend_from_slice(&frame_plaintext);
+    }
+
+    decryptor.finish()?;
+    Ok(plaintext)
+}
+
+/// Verify that a public key hashes to the expected DID.
+pub fn ensure_public_key_matches_did(public_key: PublicKey<33>, expected: Did) -> Result<()> {
+    let actual = Did::from(public_key.address());
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(Error::E2ePublicKeyDidMismatch { expected, actual })
+    }
+}
+
+fn ensure_valid_public_key(public_key: PublicKey<33>) -> Result<()> {
+    let _: Point<Secp256k1> = public_key.try_into()?;
+    Ok(())
+}
+
+fn next_sequence(sequence: u64) -> Result<u64> {
+    sequence
+        .checked_add(1)
+        .ok_or(Error::E2eFrameSequenceOverflow)
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::SeedableRng;
+    use rand_hc::Hc128Rng;
+
+    use super::*;
+
+    fn recipient_key() -> SecretKey {
+        SecretKey::try_from("65860affb4b570dba06db294aa7c676f68e04a5bf2721243ad3cbc05a79c68c0")
+            .unwrap()
+    }
+
+    fn sender_key() -> SecretKey {
+        SecretKey::try_from("1f9275dbafdfba81942eb3330b07f38cbee4ebb86bdc2174af9648d5f5509a54")
+            .unwrap()
+    }
+
+    #[test]
+    fn public_key_must_match_did() {
+        let sender = sender_key();
+        let recipient = recipient_key();
+
+        assert!(ensure_public_key_matches_did(sender.pubkey(), sender.address().into()).is_ok());
+        assert!(matches!(
+            ensure_public_key_matches_did(sender.pubkey(), recipient.address().into()),
+            Err(Error::E2ePublicKeyDidMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn handshake_messages_verify_signed_owner() {
+        let sender = sender_key();
+        let recipient = recipient_key();
+        let request = E2eHandshakeRequest::new(sender.pubkey());
+        let response = E2eHandshakeResponse::new(recipient.pubkey());
+
+        request.verify_requester(sender.address().into()).unwrap();
+        response
+            .verify_responder(recipient.address().into())
+            .unwrap();
+        assert!(request
+            .verify_requester(recipient.address().into())
+            .is_err());
+        assert!(response.verify_responder(sender.address().into()).is_err());
+    }
+
+    #[test]
+    fn round_trip_random_binary_payloads_and_frame_sizes() {
+        let sender = sender_key();
+        let recipient = recipient_key();
+        let mut rng = Hc128Rng::seed_from_u64(608);
+        let payload_lens = [0usize, 1, 15, 16, 17, 31, 32, 255, 1024, 4097];
+        let frame_limits = [1usize, E2E_PLAINTEXT_BLOCK_LEN, 64, 511];
+
+        for payload_len in payload_lens {
+            for frame_limit in frame_limits {
+                let mut payload = vec![0u8; payload_len];
+                rng.fill_bytes(&mut payload);
+                let stream_id = uuid::Uuid::new_v4();
+
+                let frames = encrypt_stream_with_rng(
+                    &payload,
+                    stream_id,
+                    sender.pubkey(),
+                    recipient.pubkey(),
+                    frame_limit,
+                    &mut rng,
+                )
+                .unwrap();
+                assert_eq!(
+                    frames.len(),
+                    payload_len.div_ceil(frame_limit.max(1)).max(1)
+                );
+                assert_eq!(
+                    decrypt_stream(&frames, stream_id, sender.address().into(), recipient).unwrap(),
+                    payload
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn empty_plaintext_sends_final_stream_frame() {
+        let sender = sender_key();
+        let recipient = recipient_key();
+        let mut rng = Hc128Rng::seed_from_u64(7);
+        let stream_id = uuid::Uuid::new_v4();
+
+        let frames = encrypt_stream_with_rng(
+            &[],
+            stream_id,
+            sender.pubkey(),
+            recipient.pubkey(),
+            8,
+            &mut rng,
+        )
+        .unwrap();
+
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].stream_id, stream_id);
+        assert_eq!(frames[0].sequence, 0);
+        assert!(frames[0].is_final);
+        assert_eq!(
+            decrypt_stream(&frames, stream_id, sender.address().into(), recipient).unwrap(),
+            Vec::<u8>::new()
+        );
+    }
+
+    #[test]
+    fn streaming_decryptor_accepts_ordered_final_frame() {
+        let sender = sender_key();
+        let recipient = recipient_key();
+        let stream_id = uuid::Uuid::new_v4();
+        let mut rng = Hc128Rng::seed_from_u64(42);
+        let mut encryptor =
+            E2eStreamEncryptor::new(stream_id, sender.pubkey(), recipient.pubkey()).unwrap();
+
+        let first = encryptor.encrypt_next(b"\0hello", &mut rng).unwrap();
+        let second = encryptor.encrypt_final(b"\xFFworld", &mut rng).unwrap();
+        let mut decryptor = E2eStreamDecryptor::new(stream_id, sender.address().into(), recipient);
+
+        let mut plaintext = decryptor.decrypt_next(&first).unwrap();
+        plaintext.extend_from_slice(&decryptor.decrypt_next(&second).unwrap());
+        decryptor.finish().unwrap();
+
+        assert_eq!(plaintext, b"\0hello\xFFworld");
+    }
+
+    #[test]
+    fn truncation_is_rejected_without_final_frame() {
+        let sender = sender_key();
+        let recipient = recipient_key();
+        let mut rng = Hc128Rng::seed_from_u64(9);
+        let stream_id = uuid::Uuid::new_v4();
+        let payload = vec![9u8; 96];
+        let mut frames = encrypt_stream_with_rng(
+            &payload,
+            stream_id,
+            sender.pubkey(),
+            recipient.pubkey(),
+            16,
+            &mut rng,
+        )
+        .unwrap();
+
+        frames.pop();
+
+        assert!(matches!(
+            decrypt_stream(&frames, stream_id, sender.address().into(), recipient),
+            Err(Error::E2eMissingFinalFrame)
+        ));
+    }
+
+    #[test]
+    fn reordered_frames_are_buffered_until_contiguous() {
+        let sender = sender_key();
+        let recipient = recipient_key();
+        let mut rng = Hc128Rng::seed_from_u64(10);
+        let stream_id = uuid::Uuid::new_v4();
+        let payload = vec![10u8; 96];
+        let mut frames = encrypt_stream_with_rng(
+            &payload,
+            stream_id,
+            sender.pubkey(),
+            recipient.pubkey(),
+            16,
+            &mut rng,
+        )
+        .unwrap();
+
+        frames.swap(0, 1);
+
+        assert_eq!(
+            decrypt_stream(&frames, stream_id, sender.address().into(), recipient).unwrap(),
+            payload
+        );
+    }
+
+    #[test]
+    fn final_frame_can_arrive_before_gap_is_filled() {
+        let sender = sender_key();
+        let recipient = recipient_key();
+        let mut rng = Hc128Rng::seed_from_u64(14);
+        let stream_id = uuid::Uuid::new_v4();
+        let payload = vec![14u8; 96];
+        let mut frames = encrypt_stream_with_rng(
+            &payload,
+            stream_id,
+            sender.pubkey(),
+            recipient.pubkey(),
+            16,
+            &mut rng,
+        )
+        .unwrap();
+        frames.rotate_right(1);
+
+        let mut decryptor = E2eStreamDecryptor::new(stream_id, sender.address().into(), recipient);
+        let mut plaintext = Vec::new();
+
+        assert_eq!(
+            decryptor.decrypt_next(&frames[0]).unwrap(),
+            Vec::<u8>::new()
+        );
+        assert!(matches!(
+            decryptor.finish(),
+            Err(Error::E2eMissingFinalFrame)
+        ));
+
+        for frame in &frames[1..] {
+            plaintext.extend_from_slice(&decryptor.decrypt_next(frame).unwrap());
+        }
+        decryptor.finish().unwrap();
+
+        assert_eq!(plaintext, payload);
+    }
+
+    #[test]
+    fn frame_after_buffered_final_is_rejected() {
+        let sender = sender_key();
+        let recipient = recipient_key();
+        let mut rng = Hc128Rng::seed_from_u64(15);
+        let stream_id = uuid::Uuid::new_v4();
+        let frames = encrypt_stream_with_rng(
+            &[15u8; 96],
+            stream_id,
+            sender.pubkey(),
+            recipient.pubkey(),
+            16,
+            &mut rng,
+        )
+        .unwrap();
+        let final_frame = frames.last().unwrap();
+        let mut frame_after_final = frames.first().unwrap().clone();
+        frame_after_final.sequence = final_frame.sequence.checked_add(1).unwrap();
+
+        let mut decryptor = E2eStreamDecryptor::new(stream_id, sender.address().into(), recipient);
+        assert_eq!(
+            decryptor.decrypt_next(final_frame).unwrap(),
+            Vec::<u8>::new()
+        );
+        assert!(matches!(
+            decryptor.decrypt_next(&frame_after_final),
+            Err(Error::E2eFrameAfterFinal)
+        ));
+    }
+
+    #[test]
+    fn wrong_stream_id_is_rejected() {
+        let sender = sender_key();
+        let recipient = recipient_key();
+        let mut rng = Hc128Rng::seed_from_u64(12);
+        let stream_id = uuid::Uuid::new_v4();
+        let other_stream_id = uuid::Uuid::new_v4();
+        let frames = encrypt_stream_with_rng(
+            b"hello",
+            stream_id,
+            sender.pubkey(),
+            recipient.pubkey(),
+            16,
+            &mut rng,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            decrypt_stream(&frames, other_stream_id, sender.address().into(), recipient),
+            Err(Error::E2eStreamIdMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn wrong_sender_key_is_rejected() {
+        let sender = sender_key();
+        let recipient = recipient_key();
+        let mut rng = Hc128Rng::seed_from_u64(11);
+        let stream_id = uuid::Uuid::new_v4();
+        let payload = vec![11u8; 32];
+        let mut frames = encrypt_stream_with_rng(
+            &payload,
+            stream_id,
+            sender.pubkey(),
+            recipient.pubkey(),
+            32,
+            &mut rng,
+        )
+        .unwrap();
+        frames[0].sender_public_key = recipient.pubkey();
+
+        assert!(matches!(
+            decrypt_stream(&frames, stream_id, sender.address().into(), recipient),
+            Err(Error::E2ePublicKeyDidMismatch { .. })
+        ));
+    }
+}

--- a/crates/core/src/message/e2e.rs
+++ b/crates/core/src/message/e2e.rs
@@ -43,6 +43,9 @@ pub const E2E_PLAINTEXT_BLOCK_LEN: usize = secp256k1::PLAINTEXT_BLOCK_SIZE;
 /// Default plaintext bytes per encrypted E2E stream frame.
 pub const DEFAULT_E2E_PLAINTEXT_FRAME_LEN: usize = E2E_PLAINTEXT_BLOCK_LEN * 16;
 
+/// Default maximum number of out-of-order future frames buffered per stream.
+pub const DEFAULT_E2E_REORDER_WINDOW_FRAMES: u64 = 64;
+
 /// Identifier shared by all frames of one encrypted E2E stream.
 pub type E2eStreamId = uuid::Uuid;
 
@@ -111,17 +114,14 @@ pub struct E2eStreamDecryptor {
     next_sequence: u64,
     final_sequence: Option<u64>,
     seen_final: bool,
+    reorder_window: u64,
     pending_frames: BTreeMap<u64, E2eStreamFrame>,
 }
 
-impl<'a> E2ePlaintextFrame<'a> {
-    fn plaintext(&self) -> &'a [u8] {
-        self.plaintext
-    }
-
-    fn is_final(&self) -> bool {
-        self.is_final
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FrameAcceptance {
+    New,
+    Duplicate,
 }
 
 impl<'a> E2ePlaintextFrames<'a> {
@@ -255,10 +255,10 @@ impl E2eStreamEncryptor {
         frame: E2ePlaintextFrame<'_>,
         rng: &mut impl RngCore,
     ) -> Result<E2eStreamFrame> {
-        if frame.is_final() {
-            self.encrypt_final(frame.plaintext(), rng)
+        if frame.is_final {
+            self.encrypt_final(frame.plaintext, rng)
         } else {
-            self.encrypt_next(frame.plaintext(), rng)
+            self.encrypt_next(frame.plaintext, rng)
         }
     }
 
@@ -298,6 +298,21 @@ impl E2eStreamDecryptor {
         expected_sender: Did,
         recipient_secret_key: SecretKey,
     ) -> Self {
+        Self::with_reorder_window(
+            stream_id,
+            expected_sender,
+            recipient_secret_key,
+            DEFAULT_E2E_REORDER_WINDOW_FRAMES,
+        )
+    }
+
+    /// Create a decryptor with an explicit future-frame reorder window.
+    pub fn with_reorder_window(
+        stream_id: E2eStreamId,
+        expected_sender: Did,
+        recipient_secret_key: SecretKey,
+        reorder_window: u64,
+    ) -> Self {
         Self {
             stream_id,
             expected_sender,
@@ -305,6 +320,7 @@ impl E2eStreamDecryptor {
             next_sequence: 0,
             final_sequence: None,
             seen_final: false,
+            reorder_window,
             pending_frames: BTreeMap::new(),
         }
     }
@@ -314,7 +330,10 @@ impl E2eStreamDecryptor {
     /// Out-of-order future frames are buffered and return an empty vector until
     /// the missing lower sequence numbers arrive.
     pub fn decrypt_next(&mut self, frame: &E2eStreamFrame) -> Result<Vec<u8>> {
-        self.validate_frame(frame)?;
+        if self.validate_frame(frame)? == FrameAcceptance::Duplicate {
+            return Ok(Vec::new());
+        }
+
         if frame.is_final {
             self.final_sequence = Some(frame.sequence);
         }
@@ -331,11 +350,7 @@ impl E2eStreamDecryptor {
         }
     }
 
-    fn validate_frame(&self, frame: &E2eStreamFrame) -> Result<()> {
-        if self.seen_final {
-            return Err(Error::E2eFrameAfterFinal);
-        }
-
+    fn validate_frame(&self, frame: &E2eStreamFrame) -> Result<FrameAcceptance> {
         if frame.stream_id != self.stream_id {
             return Err(Error::E2eStreamIdMismatch {
                 expected: self.stream_id,
@@ -345,11 +360,30 @@ impl E2eStreamDecryptor {
 
         frame.verify_sender(self.expected_sender)?;
 
-        if frame.sequence < self.next_sequence || self.pending_frames.contains_key(&frame.sequence)
-        {
+        if self.is_consumed_duplicate(frame) {
+            return Ok(FrameAcceptance::Duplicate);
+        }
+
+        if let Some(pending_frame) = self.pending_frames.get(&frame.sequence) {
+            if pending_frame == frame {
+                return Ok(FrameAcceptance::Duplicate);
+            }
+
             return Err(Error::E2eFrameSequenceMismatch {
                 expected: self.next_sequence,
                 actual: frame.sequence,
+            });
+        }
+
+        if self.seen_final {
+            return Err(Error::E2eFrameAfterFinal);
+        }
+
+        if self.exceeds_reorder_window(frame.sequence) {
+            return Err(Error::E2eFrameReorderWindowExceeded {
+                next_sequence: self.next_sequence,
+                actual: frame.sequence,
+                window: self.reorder_window,
             });
         }
 
@@ -370,7 +404,7 @@ impl E2eStreamDecryptor {
             return Err(Error::E2eFrameAfterFinal);
         }
 
-        Ok(())
+        Ok(FrameAcceptance::New)
     }
 
     fn decrypt_ready_frames(&mut self) -> Result<Vec<u8>> {
@@ -398,6 +432,21 @@ impl E2eStreamDecryptor {
         self.pending_frames
             .last_key_value()
             .is_some_and(|(pending_sequence, _)| *pending_sequence > sequence)
+    }
+
+    fn is_consumed_duplicate(&self, frame: &E2eStreamFrame) -> bool {
+        if frame.sequence < self.next_sequence {
+            return true;
+        }
+
+        self.seen_final
+            && self
+                .final_sequence
+                .is_some_and(|final_sequence| frame.sequence <= final_sequence)
+    }
+
+    fn exceeds_reorder_window(&self, sequence: u64) -> bool {
+        sequence.saturating_sub(self.next_sequence) > self.reorder_window
     }
 }
 
@@ -458,24 +507,6 @@ pub fn encrypt_stream_with_rng(
         recipient_public_key,
         max_plaintext_frame_len,
         rng,
-    )?
-    .collect()
-}
-
-/// Encrypt a byte slice into direct-ElGamal E2E stream frames with the default thread-local RNG.
-pub fn encrypt_stream(
-    plaintext: &[u8],
-    stream_id: E2eStreamId,
-    sender_public_key: PublicKey<33>,
-    recipient_public_key: PublicKey<33>,
-    max_plaintext_frame_len: usize,
-) -> Result<Vec<E2eStreamFrame>> {
-    encrypt_stream_frames(
-        plaintext,
-        stream_id,
-        sender_public_key,
-        recipient_public_key,
-        max_plaintext_frame_len,
     )?
     .collect()
 }
@@ -696,6 +727,112 @@ mod tests {
             decrypt_stream(&frames, stream_id, sender.address().into(), recipient).unwrap(),
             payload
         );
+    }
+
+    #[test]
+    fn replayed_consumed_frame_is_idempotent() {
+        let sender = sender_key();
+        let recipient = recipient_key();
+        let mut rng = Hc128Rng::seed_from_u64(16);
+        let stream_id = uuid::Uuid::new_v4();
+        let payload = vec![16u8; 96];
+        let frames = encrypt_stream_with_rng(
+            &payload,
+            stream_id,
+            sender.pubkey(),
+            recipient.pubkey(),
+            16,
+            &mut rng,
+        )
+        .unwrap();
+        let final_frame = frames.last().unwrap().clone();
+        let mut decryptor = E2eStreamDecryptor::new(stream_id, sender.address().into(), recipient);
+        let mut plaintext = Vec::new();
+
+        plaintext.extend_from_slice(&decryptor.decrypt_next(&frames[0]).unwrap());
+        assert_eq!(
+            decryptor.decrypt_next(&frames[0]).unwrap(),
+            Vec::<u8>::new()
+        );
+
+        for frame in &frames[1..] {
+            plaintext.extend_from_slice(&decryptor.decrypt_next(frame).unwrap());
+        }
+        decryptor.finish().unwrap();
+
+        assert_eq!(
+            decryptor.decrypt_next(&final_frame).unwrap(),
+            Vec::<u8>::new()
+        );
+        assert_eq!(plaintext, payload);
+    }
+
+    #[test]
+    fn replayed_buffered_frame_is_idempotent() {
+        let sender = sender_key();
+        let recipient = recipient_key();
+        let mut rng = Hc128Rng::seed_from_u64(17);
+        let stream_id = uuid::Uuid::new_v4();
+        let payload = vec![17u8; 96];
+        let frames = encrypt_stream_with_rng(
+            &payload,
+            stream_id,
+            sender.pubkey(),
+            recipient.pubkey(),
+            16,
+            &mut rng,
+        )
+        .unwrap();
+        let mut decryptor = E2eStreamDecryptor::new(stream_id, sender.address().into(), recipient);
+        let mut plaintext = Vec::new();
+
+        assert_eq!(
+            decryptor.decrypt_next(&frames[1]).unwrap(),
+            Vec::<u8>::new()
+        );
+        assert_eq!(
+            decryptor.decrypt_next(&frames[1]).unwrap(),
+            Vec::<u8>::new()
+        );
+
+        for frame in &frames {
+            plaintext.extend_from_slice(&decryptor.decrypt_next(frame).unwrap());
+        }
+        decryptor.finish().unwrap();
+
+        assert_eq!(plaintext, payload);
+    }
+
+    #[test]
+    fn future_frame_outside_reorder_window_is_rejected() {
+        let sender = sender_key();
+        let recipient = recipient_key();
+        let mut rng = Hc128Rng::seed_from_u64(18);
+        let stream_id = uuid::Uuid::new_v4();
+        let frames = encrypt_stream_with_rng(
+            &[18u8; 5],
+            stream_id,
+            sender.pubkey(),
+            recipient.pubkey(),
+            1,
+            &mut rng,
+        )
+        .unwrap();
+        let mut decryptor = E2eStreamDecryptor::with_reorder_window(
+            stream_id,
+            sender.address().into(),
+            recipient,
+            2,
+        );
+
+        assert!(matches!(
+            decryptor.decrypt_next(&frames[3]),
+            Err(Error::E2eFrameReorderWindowExceeded {
+                next_sequence: 0,
+                actual: 3,
+                window: 2
+            })
+        ));
     }
 
     #[test]

--- a/crates/core/src/message/handlers/e2e.rs
+++ b/crates/core/src/message/handlers/e2e.rs
@@ -1,0 +1,212 @@
+use async_trait::async_trait;
+
+use crate::error::Result;
+use crate::message::e2e::E2eHandshakeRequest;
+use crate::message::e2e::E2eHandshakeResponse;
+use crate::message::e2e::E2eStreamFrame;
+use crate::message::effects::CoreEffect;
+use crate::message::effects::MessageSendFunctor;
+use crate::message::effects::PayloadRelayFunctor;
+use crate::message::HandleMsg;
+use crate::message::Message;
+use crate::message::MessageHandler;
+use crate::message::MessagePayload;
+use crate::message::MessageVerificationExt;
+use crate::message::PayloadSender;
+
+fn e2e_local_or_forward_effects<'payload>(
+    local: crate::dht::Did,
+    ctx: &'payload MessagePayload,
+) -> Option<CoreEffect<'payload>> {
+    if ctx.should_forward_from(local) {
+        Some(PayloadRelayFunctor::forward_payload(ctx, None).into())
+    } else {
+        None
+    }
+}
+
+async fn run_e2e_local_or_forward<'payload>(
+    handler: &MessageHandler,
+    ctx: &'payload MessagePayload,
+    local_effects: impl FnOnce() -> Result<Vec<CoreEffect<'payload>>>,
+) -> Result<()> {
+    if let Some(effect) = e2e_local_or_forward_effects(handler.dht.did, ctx) {
+        return handler.run_effects([effect]).await;
+    }
+
+    handler.run_effects(local_effects()?).await
+}
+
+fn e2e_handshake_response_effect<'payload>(
+    ctx: &MessagePayload,
+    msg: &E2eHandshakeRequest,
+    responder_public_key: crate::ecc::PublicKey<33>,
+) -> Result<CoreEffect<'payload>> {
+    msg.verify_requester(ctx.signer())?;
+    Ok(MessageSendFunctor::send_message(
+        Message::E2eHandshakeResponse(E2eHandshakeResponse::new(responder_public_key)),
+        ctx.signer(),
+    )
+    .into())
+}
+
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+impl HandleMsg<E2eHandshakeRequest> for MessageHandler {
+    async fn handle(&self, ctx: &MessagePayload, msg: &E2eHandshakeRequest) -> Result<()> {
+        run_e2e_local_or_forward(self, ctx, || {
+            let responder_public_key = self.transport.session_sk().session().account_pubkey()?;
+            Ok(vec![e2e_handshake_response_effect(
+                ctx,
+                msg,
+                responder_public_key,
+            )?])
+        })
+        .await
+    }
+}
+
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+impl HandleMsg<E2eHandshakeResponse> for MessageHandler {
+    async fn handle(&self, ctx: &MessagePayload, msg: &E2eHandshakeResponse) -> Result<()> {
+        run_e2e_local_or_forward(self, ctx, || {
+            msg.verify_responder(ctx.signer())?;
+            Ok(Vec::new())
+        })
+        .await
+    }
+}
+
+#[cfg_attr(feature = "wasm", async_trait(?Send))]
+#[cfg_attr(not(feature = "wasm"), async_trait)]
+impl HandleMsg<E2eStreamFrame> for MessageHandler {
+    async fn handle(&self, ctx: &MessagePayload, msg: &E2eStreamFrame) -> Result<()> {
+        run_e2e_local_or_forward(self, ctx, || {
+            msg.verify_sender(ctx.signer())?;
+            Ok(Vec::new())
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::SeedableRng;
+
+    use super::*;
+    use crate::ecc::SecretKey;
+    use crate::error::Error;
+    use crate::message::e2e::encrypt_stream_with_rng;
+    use crate::message::e2e::E2eHandshakeRequest;
+    use crate::session::SessionSk;
+
+    fn e2e_payload(destination: crate::dht::Did) -> Result<MessagePayload> {
+        let sender = SecretKey::random();
+        let recipient = SecretKey::random();
+        let session_sk = SessionSk::new_with_seckey(&sender)?;
+        let mut rng = rand_hc::Hc128Rng::from_entropy();
+        let mut frames = encrypt_stream_with_rng(
+            b"hello",
+            uuid::Uuid::new_v4(),
+            sender.pubkey(),
+            recipient.pubkey(),
+            16,
+            &mut rng,
+        )?;
+        let encrypted = frames
+            .pop()
+            .ok_or_else(|| Error::InvalidMessage("expected one E2E stream frame".to_string()))?;
+        MessagePayload::new_send(
+            Message::E2eStreamFrame(encrypted),
+            &session_sk,
+            destination,
+            destination,
+        )
+    }
+
+    fn signed_handshake_request(
+        signer: &SecretKey,
+        request: E2eHandshakeRequest,
+        destination: crate::dht::Did,
+    ) -> Result<MessagePayload> {
+        let session_sk = SessionSk::new_with_seckey(signer)?;
+        MessagePayload::new_send(
+            Message::E2eHandshakeRequest(request),
+            &session_sk,
+            destination,
+            destination,
+        )
+    }
+
+    #[test]
+    fn local_handshake_request_sends_responder_key_to_signer() -> Result<()> {
+        let requester = SecretKey::random();
+        let responder = SecretKey::random();
+        let request = E2eHandshakeRequest::new(requester.pubkey());
+        let payload = signed_handshake_request(&requester, request, responder.address().into())?;
+        let effect = e2e_handshake_response_effect(&payload, &request, responder.pubkey())?;
+
+        match effect {
+            CoreEffect::Message(MessageSendFunctor::SendMessage { msg, destination }) => {
+                assert_eq!(destination, requester.address().into());
+                match *msg {
+                    Message::E2eHandshakeResponse(response) => {
+                        assert_eq!(response.responder_public_key, responder.pubkey());
+                        response.verify_responder(responder.address().into())?;
+                    }
+                    msg => {
+                        return Err(Error::InvalidMessage(format!(
+                            "expected E2eHandshakeResponse, got {msg:?}"
+                        )))
+                    }
+                }
+            }
+            effect => {
+                return Err(Error::InvalidMessage(format!(
+                    "expected SendMessage effect, got {effect:?}"
+                )))
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn local_handshake_request_rejects_key_not_owned_by_signer() -> Result<()> {
+        let requester = SecretKey::random();
+        let responder = SecretKey::random();
+        let request = E2eHandshakeRequest::new(responder.pubkey());
+        let payload = signed_handshake_request(&requester, request, responder.address().into())?;
+
+        assert!(matches!(
+            e2e_handshake_response_effect(&payload, &request, responder.pubkey()),
+            Err(Error::E2ePublicKeyDidMismatch { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn remote_e2e_message_forwards_payload() -> Result<()> {
+        let local = SecretKey::random().address().into();
+        let remote = SecretKey::random().address().into();
+        let payload = e2e_payload(remote)?;
+        let effect = e2e_local_or_forward_effects(local, &payload)
+            .ok_or_else(|| Error::InvalidMessage("expected ForwardPayload effect".to_string()))?;
+
+        match effect {
+            CoreEffect::Payload(PayloadRelayFunctor::ForwardPayload {
+                payload: forwarded,
+                next_hop,
+            }) => {
+                assert!(std::ptr::eq(forwarded, &payload));
+                assert_eq!(next_hop, None);
+            }
+            effect => {
+                return Err(Error::InvalidMessage(format!(
+                    "expected ForwardPayload, got {effect:?}"
+                )))
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/core/src/message/handlers/mod.rs
+++ b/crates/core/src/message/handlers/mod.rs
@@ -26,6 +26,8 @@ use crate::swarm::transport::SwarmTransport;
 pub mod connection;
 /// Operator and Handler for CustomMessage
 pub mod custom;
+/// Operator and Handler for E2E encrypted messages
+pub mod e2e;
 /// Operator and handler for DHT stabilization
 pub mod stabilization;
 /// Operator and Handler for Storage

--- a/crates/core/src/message/mod.rs
+++ b/crates/core/src/message/mod.rs
@@ -4,6 +4,8 @@ pub use encoder::Decoder;
 pub use encoder::Encoded;
 pub use encoder::Encoder;
 
+pub mod e2e;
+
 mod effects;
 
 mod payload;

--- a/crates/core/src/message/types.rs
+++ b/crates/core/src/message/types.rs
@@ -16,6 +16,9 @@ use crate::dht::Did;
 use crate::dht::TopoInfo;
 use crate::error::Error;
 use crate::error::Result;
+use crate::message::e2e::E2eHandshakeRequest;
+use crate::message::e2e::E2eHandshakeResponse;
+use crate::message::e2e::E2eStreamFrame;
 
 /// The `Then` trait is used to associate a type with a "then" scenario.
 pub trait Then {
@@ -270,6 +273,12 @@ pub enum Message {
     SyncEntriesWithSuccessorReport(SyncEntriesWithSuccessorReport),
     /// Custom messages
     CustomMessage(CustomMessage),
+    /// Request to negotiate E2E ElGamal encryption with a signed public key.
+    E2eHandshakeRequest(E2eHandshakeRequest),
+    /// Response accepting E2E ElGamal encryption with a signed public key.
+    E2eHandshakeResponse(E2eHandshakeResponse),
+    /// Direct ElGamal-encrypted E2E stream frame.
+    E2eStreamFrame(E2eStreamFrame),
     /// Remote message of query topological info of a node.
     QueryForTopoInfoSend(QueryForTopoInfoSend),
     /// Response of QueryForTopoInfoSend

--- a/crates/core/src/swarm/callback.rs
+++ b/crates/core/src/swarm/callback.rs
@@ -110,6 +110,13 @@ impl InnerSwarmCallback {
             }
             Message::OperateEntry(ref msg) => self.message_handler.handle(payload, msg).await,
             Message::CustomMessage(ref msg) => self.message_handler.handle(payload, msg).await,
+            Message::E2eHandshakeRequest(ref msg) => {
+                self.message_handler.handle(payload, msg).await
+            }
+            Message::E2eHandshakeResponse(ref msg) => {
+                self.message_handler.handle(payload, msg).await
+            }
+            Message::E2eStreamFrame(ref msg) => self.message_handler.handle(payload, msg).await,
             Message::QueryForTopoInfoSend(ref msg) => {
                 self.message_handler.handle(payload, msg).await
             }

--- a/crates/core/src/swarm/mod.rs
+++ b/crates/core/src/swarm/mod.rs
@@ -16,6 +16,7 @@ use self::callback::InnerSwarmCallback;
 use crate::dht::Did;
 use crate::dht::PeerRing;
 use crate::dht::Stabilizer;
+use crate::ecc::PublicKey;
 use crate::error::Error;
 use crate::error::Result;
 use crate::inspect::ConnectionInspect;
@@ -40,6 +41,11 @@ impl Swarm {
     /// Get did of self.
     pub fn did(&self) -> Did {
         self.dht.did
+    }
+
+    /// Get the local account public key used for E2E public-key negotiation.
+    pub fn account_pubkey(&self) -> Result<PublicKey<33>> {
+        self.transport.session_sk().session().account_pubkey()
     }
 
     /// Get DHT(Distributed Hash Table) of self.

--- a/crates/node/src/processor.rs
+++ b/crates/node/src/processor.rs
@@ -10,7 +10,14 @@ use rings_core::chunk::ReassemblyLimits;
 use rings_core::dht::Did;
 use rings_core::dht::EntryStorage;
 use rings_core::dht::DEFAULT_FINGER_TABLE_SIZE;
+use rings_core::ecc::PublicKey;
+use rings_core::ecc::SecretKey;
 use rings_core::measure::MeasureImpl;
+use rings_core::message::e2e;
+use rings_core::message::e2e::E2eHandshakeRequest;
+use rings_core::message::e2e::E2eHandshakeResponse;
+use rings_core::message::e2e::E2eStreamDecryptor;
+use rings_core::message::e2e::E2eStreamFrame;
 use rings_core::message::Encoded;
 use rings_core::message::Encoder;
 use rings_core::message::Message;
@@ -324,6 +331,127 @@ impl Processor {
             .map_err(Error::SendMessage)
     }
 
+    /// Send an E2E handshake request to a DID.
+    ///
+    /// The negotiated key is the peer's account/identity secp256k1 key, not
+    /// the ephemeral session key.
+    pub async fn send_e2e_handshake(&self, destination: Did) -> Result<uuid::Uuid> {
+        let public_key = self.swarm.account_pubkey().map_err(Error::SendMessage)?;
+        self.swarm
+            .send_message(
+                Message::E2eHandshakeRequest(E2eHandshakeRequest::new(public_key)),
+                destination,
+            )
+            .await
+            .map_err(Error::SendMessage)
+    }
+
+    /// Send an ElGamal-encrypted E2E message to a DID with a verified recipient key.
+    ///
+    /// Returns the stream id shared by all emitted E2E stream frames.
+    pub async fn send_e2e_message(
+        &self,
+        destination: Did,
+        recipient_public_key: PublicKey<33>,
+        msg: &[u8],
+    ) -> Result<uuid::Uuid> {
+        self.send_e2e_message_with_frame_len(
+            destination,
+            recipient_public_key,
+            msg,
+            e2e::DEFAULT_E2E_PLAINTEXT_FRAME_LEN,
+        )
+        .await
+    }
+
+    /// Send an ElGamal-encrypted E2E stream with an explicit plaintext frame size.
+    ///
+    /// Returns the stream id shared by all emitted E2E stream frames.
+    pub async fn send_e2e_message_with_frame_len(
+        &self,
+        destination: Did,
+        recipient_public_key: PublicKey<33>,
+        msg: &[u8],
+        max_plaintext_frame_len: usize,
+    ) -> Result<uuid::Uuid> {
+        e2e::ensure_public_key_matches_did(recipient_public_key, destination)
+            .map_err(Error::SendMessage)?;
+        let sender_public_key = self.swarm.account_pubkey().map_err(Error::SendMessage)?;
+        let stream_id = uuid::Uuid::new_v4();
+        let frames = e2e::encrypt_stream_frames(
+            msg,
+            stream_id,
+            sender_public_key,
+            recipient_public_key,
+            max_plaintext_frame_len,
+        )
+        .map_err(Error::SendMessage)?;
+
+        for frame in frames {
+            let frame = frame.map_err(Error::SendMessage)?;
+            self.swarm
+                .send_message(Message::E2eStreamFrame(frame), destination)
+                .await
+                .map_err(Error::SendMessage)?;
+        }
+
+        Ok(stream_id)
+    }
+
+    /// Verify an E2E handshake request and return the requester's identity public key.
+    pub fn verify_e2e_handshake_request(
+        &self,
+        requester: Did,
+        request: &E2eHandshakeRequest,
+    ) -> Result<PublicKey<33>> {
+        request
+            .verify_requester(requester)
+            .map_err(Error::CoreError)?;
+        Ok(request.requester_public_key)
+    }
+
+    /// Verify an E2E handshake response and return the responder's identity public key.
+    pub fn verify_e2e_handshake_response(
+        &self,
+        responder: Did,
+        response: &E2eHandshakeResponse,
+    ) -> Result<PublicKey<33>> {
+        response
+            .verify_responder(responder)
+            .map_err(Error::CoreError)?;
+        Ok(response.responder_public_key)
+    }
+
+    /// Create an E2E stream decryptor with this node's identity/signing secret key.
+    ///
+    /// The ciphertext is encrypted to the DID/account key negotiated by the
+    /// handshake. A session private key cannot decrypt it unless the session key
+    /// is also the account key, so callers must supply the local identity key
+    /// explicitly.
+    pub fn e2e_stream_decryptor(
+        &self,
+        expected_sender: Did,
+        stream_id: e2e::E2eStreamId,
+        recipient_identity_key: SecretKey,
+    ) -> Result<E2eStreamDecryptor> {
+        e2e::ensure_public_key_matches_did(recipient_identity_key.pubkey(), self.did())
+            .map_err(Error::CoreError)?;
+        Ok(E2eStreamDecryptor::new(
+            stream_id,
+            expected_sender,
+            recipient_identity_key,
+        ))
+    }
+
+    /// Decrypt one E2E stream frame with an already-created stream decryptor.
+    pub fn decrypt_e2e_stream_frame(
+        &self,
+        decryptor: &mut E2eStreamDecryptor,
+        frame: &E2eStreamFrame,
+    ) -> Result<Vec<u8>> {
+        decryptor.decrypt_next(frame).map_err(Error::CoreError)
+    }
+
     /// Send a namespaced [`Envelope`](crate::extension::ext::Envelope) to a did over the
     /// P2P transport (the wire codec
     /// of the extension layer). `send_envelope : (Did, Envelope) → IO TxId`.
@@ -394,8 +522,15 @@ impl Processor {
 #[cfg(test)]
 #[cfg(feature = "node")]
 mod test {
-    use futures::lock::Mutex;
+    use std::sync::Mutex;
+    use std::time::Duration;
+    use std::time::Instant;
+
+    use rings_core::storage::MemStorage;
     use rings_core::swarm::callback::SwarmCallback;
+    use rings_core::swarm::callback::SwarmEvent;
+    use rings_transport::core::transport::WebrtcConnectionState;
+    use tokio::sync::Notify;
 
     use super::*;
     use crate::prelude::*;
@@ -412,7 +547,9 @@ mod test {
     }
 
     struct SwarmCallbackInstance {
-        pub msgs: Mutex<Vec<String>>,
+        inbound: Mutex<Vec<Message>>,
+        inbound_notify: Notify,
+        connected_notify: Notify,
     }
 
     #[async_trait]
@@ -422,25 +559,163 @@ mod test {
             payload: &MessagePayload,
         ) -> std::result::Result<(), Box<dyn std::error::Error>> {
             let msg: Message = payload.transaction.data().map_err(Box::new)?;
+            {
+                let mut inbound = self.inbound.lock().unwrap();
+                inbound.push(msg);
+            }
+            self.inbound_notify.notify_one();
 
-            if let Message::CustomMessage(ref msg) = msg {
-                let text = String::from_utf8(msg.0.to_vec()).unwrap();
-                let mut msgs = self.msgs.try_lock().unwrap();
-                msgs.push(text);
+            Ok(())
+        }
+
+        async fn on_event(
+            &self,
+            event: &SwarmEvent,
+        ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+            if let SwarmEvent::ConnectionStateChange {
+                state: WebrtcConnectionState::Connected,
+                ..
+            } = event
+            {
+                self.connected_notify.notify_one();
             }
 
             Ok(())
         }
     }
 
+    fn test_callback() -> Arc<SwarmCallbackInstance> {
+        Arc::new(SwarmCallbackInstance {
+            inbound: Mutex::new(Vec::new()),
+            inbound_notify: Notify::new(),
+            connected_notify: Notify::new(),
+        })
+    }
+
+    async fn prepare_processor_with_identity_key(identity_key: SecretKey) -> Processor {
+        let session_sk = SessionSk::new_with_seckey(&identity_key).unwrap();
+        let config = ProcessorConfig::new(
+            0,
+            "stun://stun.l.google.com:19302".to_string(),
+            session_sk,
+            3,
+        );
+        let storage = Box::new(MemStorage::new());
+
+        ProcessorBuilder::from_config(&config)
+            .unwrap()
+            .storage(storage)
+            .dht_finger_table_size(8)
+            .build()
+            .unwrap()
+    }
+
+    async fn connect_processors(
+        p1: &Processor,
+        p2: &Processor,
+        callback1: &SwarmCallbackInstance,
+        callback2: &SwarmCallbackInstance,
+    ) {
+        let offer = p1.swarm.create_offer(p2.did()).await.unwrap();
+        let answer = p2.swarm.answer_offer(offer).await.unwrap();
+        p1.swarm.accept_answer(answer).await.unwrap();
+        wait_processors_connected(p1, p2, callback1, callback2).await;
+    }
+
+    async fn wait_processors_connected(
+        p1: &Processor,
+        p2: &Processor,
+        callback1: &SwarmCallbackInstance,
+        callback2: &SwarmCallbackInstance,
+    ) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if processor_has_connected_peer(p1, p2.did())
+                && processor_has_connected_peer(p2, p1.did())
+            {
+                return;
+            }
+
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .expect("processors did not connect");
+            tokio::time::timeout(remaining, async {
+                tokio::select! {
+                    _ = callback1.connected_notify.notified() => {}
+                    _ = callback2.connected_notify.notified() => {}
+                }
+            })
+            .await
+            .expect("processors did not connect");
+        }
+    }
+
+    fn processor_has_connected_peer(processor: &Processor, peer: Did) -> bool {
+        let peer = peer.to_string();
+        processor
+            .swarm
+            .peers()
+            .into_iter()
+            .any(|conn| conn.did == peer && conn.state == "Connected")
+    }
+
+    async fn wait_for_inbound_message(
+        callback: &SwarmCallbackInstance,
+        predicate: impl Fn(&Message) -> bool,
+    ) -> Message {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            {
+                let inbound = callback.inbound.lock().unwrap();
+                if let Some(msg) = inbound.iter().find(|msg| predicate(msg)).cloned() {
+                    return msg;
+                }
+            }
+
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .expect("inbound message was not delivered");
+            tokio::time::timeout(remaining, callback.inbound_notify.notified())
+                .await
+                .expect("inbound message was not delivered");
+        }
+    }
+
+    async fn wait_for_e2e_stream_frames(
+        callback: &SwarmCallbackInstance,
+        stream_id: e2e::E2eStreamId,
+    ) -> Vec<E2eStreamFrame> {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            {
+                let inbound = callback.inbound.lock().unwrap();
+                let frames = inbound
+                    .iter()
+                    .filter_map(|msg| match msg {
+                        Message::E2eStreamFrame(frame) if frame.stream_id == stream_id => {
+                            Some(frame.clone())
+                        }
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
+                if frames.iter().any(|frame| frame.is_final) {
+                    return frames;
+                }
+            }
+
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .expect("E2E stream final frame was not delivered");
+            tokio::time::timeout(remaining, callback.inbound_notify.notified())
+                .await
+                .expect("E2E stream final frame was not delivered");
+        }
+    }
+
     #[tokio::test]
     async fn test_processor_handshake_msg() {
-        let callback1 = Arc::new(SwarmCallbackInstance {
-            msgs: Mutex::new(Vec::new()),
-        });
-        let callback2 = Arc::new(SwarmCallbackInstance {
-            msgs: Mutex::new(Vec::new()),
-        });
+        let callback1 = test_callback();
+        let callback2 = test_callback();
 
         let p1 = prepare_processor().await;
         let p2 = prepare_processor().await;
@@ -450,9 +725,6 @@ mod test {
 
         let did1 = p1.did();
         let did2 = p2.did();
-
-        println!("p1_did: {did1}");
-        println!("p2_did: {did2}");
 
         let offer = p1.swarm.create_offer(p2.did()).await.unwrap();
         assert_eq!(
@@ -467,57 +739,141 @@ mod test {
 
         let answer = p2.swarm.answer_offer(offer).await.unwrap();
         p1.swarm.accept_answer(answer).await.unwrap();
-
-        println!("waiting for connection");
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
-        assert_eq!(
-            p1.swarm
-                .peers()
-                .into_iter()
-                .find(|peer| peer.did == p2.did().to_string())
-                .unwrap()
-                .state,
-            "Connected",
-            "p1 connection not connected"
-        );
-        assert_eq!(
-            p2.swarm
-                .peers()
-                .into_iter()
-                .find(|peer| peer.did == p1.did().to_string())
-                .unwrap()
-                .state,
-            "Connected",
-            "p2 connection not connected"
-        );
+        wait_processors_connected(&p1, &p2, &callback1, &callback2).await;
 
         let test_text1 = "test1";
         let test_text2 = "test2";
 
-        println!("send_message 1");
-        let uuid1 = p1.send_message(did2, test_text1.as_bytes()).await.unwrap();
-        println!("send_message 1 done, msg id: {uuid1}");
+        p1.send_message(did2, test_text1.as_bytes()).await.unwrap();
+        p2.send_message(did1, test_text2.as_bytes()).await.unwrap();
 
-        println!("send_message 2");
-        let uuid2 = p2.send_message(did1, test_text2.as_bytes()).await.unwrap();
-        println!("send_message 2 done, msg id: {uuid2}");
+        let got_msg2 = wait_for_inbound_message(&callback2, |msg| {
+            matches!(msg, Message::CustomMessage(custom) if custom.0 == test_text1.as_bytes())
+        })
+        .await;
+        assert!(matches!(got_msg2, Message::CustomMessage(_)));
 
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        println!("check received");
+        let got_msg1 = wait_for_inbound_message(&callback1, |msg| {
+            matches!(msg, Message::CustomMessage(custom) if custom.0 == test_text2.as_bytes())
+        })
+        .await;
+        assert!(matches!(got_msg1, Message::CustomMessage(_)));
+    }
 
-        let mut msgs2 = callback2.msgs.try_lock().unwrap();
-        let got_msg2 = msgs2.pop().unwrap();
+    #[tokio::test]
+    async fn test_processor_e2e_handshake_exchanges_verified_public_keys() {
+        let callback1 = test_callback();
+        let callback2 = test_callback();
+
+        let p1 = prepare_processor().await;
+        let p2 = prepare_processor().await;
+
+        p1.swarm.set_callback(callback1.clone()).unwrap();
+        p2.swarm.set_callback(callback2.clone()).unwrap();
+
+        connect_processors(&p1, &p2, &callback1, &callback2).await;
+
+        let did1 = p1.did();
+        let did2 = p2.did();
+        let requester_public_key = p1.swarm.account_pubkey().unwrap();
+        let responder_public_key = p2.swarm.account_pubkey().unwrap();
+
+        p1.send_e2e_handshake(did2).await.unwrap();
+
+        let request = wait_for_inbound_message(&callback2, |msg| {
+            matches!(msg, Message::E2eHandshakeRequest(_))
+        })
+        .await;
+        match request {
+            Message::E2eHandshakeRequest(request) => {
+                assert_eq!(request.requester_public_key, requester_public_key);
+                assert_eq!(
+                    p2.verify_e2e_handshake_request(did1, &request).unwrap(),
+                    requester_public_key
+                );
+            }
+            msg => panic!("expected E2eHandshakeRequest, got {msg:?}"),
+        }
+
+        let response = wait_for_inbound_message(&callback1, |msg| {
+            matches!(msg, Message::E2eHandshakeResponse(_))
+        })
+        .await;
+        match response {
+            Message::E2eHandshakeResponse(response) => {
+                assert_eq!(response.responder_public_key, responder_public_key);
+                assert_eq!(
+                    p1.verify_e2e_handshake_response(did2, &response).unwrap(),
+                    responder_public_key
+                );
+            }
+            msg => panic!("expected E2eHandshakeResponse, got {msg:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_processor_e2e_message_streams_and_decrypts_with_receiver_identity_key() {
+        let callback1 = test_callback();
+        let callback2 = test_callback();
+        let identity1 = SecretKey::random();
+        let identity2 = SecretKey::random();
+
+        let p1 = prepare_processor_with_identity_key(identity1).await;
+        let p2 = prepare_processor_with_identity_key(identity2).await;
+
+        p1.swarm.set_callback(callback1.clone()).unwrap();
+        p2.swarm.set_callback(callback2.clone()).unwrap();
+
+        connect_processors(&p1, &p2, &callback1, &callback2).await;
+
+        let did1 = p1.did();
+        let did2 = p2.did();
+        let responder_public_key = p2.swarm.account_pubkey().unwrap();
+        let stream_id = p1
+            .send_e2e_message_with_frame_len(
+                did2,
+                responder_public_key,
+                b"homomorphic-ready streaming body",
+                8,
+            )
+            .await
+            .unwrap();
+
+        let frames = wait_for_e2e_stream_frames(&callback2, stream_id).await;
         assert!(
-            got_msg2.eq(test_text1),
-            "msg received, expect {test_text1}, got {got_msg2}"
+            frames.len() > 1,
+            "streaming send should emit more than one frame for this frame size"
+        );
+        assert_eq!(
+            frames.iter().filter(|frame| frame.is_final).count(),
+            1,
+            "streaming send should emit exactly one final frame"
         );
 
-        let mut msgs1 = callback1.msgs.try_lock().unwrap();
-        let got_msg1 = msgs1.pop().unwrap();
-        assert!(
-            got_msg1.eq(test_text2),
-            "msg received, expect {test_text2}, got {got_msg1}"
-        );
+        let mut sequences = frames
+            .iter()
+            .map(|frame| frame.sequence)
+            .collect::<Vec<_>>();
+        sequences.sort_unstable();
+        let frame_count = u64::try_from(frames.len()).unwrap();
+        assert_eq!(sequences, (0..frame_count).collect::<Vec<_>>());
+
+        let mut decryptor = p2.e2e_stream_decryptor(did1, stream_id, identity2).unwrap();
+        let mut plaintext = Vec::new();
+        let mut delivered_frames = frames.clone();
+        delivered_frames.reverse();
+        for frame in &delivered_frames {
+            plaintext
+                .extend_from_slice(&p2.decrypt_e2e_stream_frame(&mut decryptor, frame).unwrap());
+        }
+        decryptor.finish().unwrap();
+        assert_eq!(plaintext, b"homomorphic-ready streaming body");
+
+        assert!(matches!(
+            p2.e2e_stream_decryptor(did1, stream_id, SecretKey::random()),
+            Err(Error::CoreError(
+                rings_core::error::Error::E2ePublicKeyDidMismatch { .. }
+            ))
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- Add direct secp256k1 ElGamal body encryption for E2E message payloads.
- Add signed E2E handshake request/response messages for public-key discovery and DID ownership verification.
- Add node Processor APIs to initiate E2E handshakes and send encrypted messages with verified recipient public keys.
- Add handler and Processor tests covering handshake response generation, invalid requester keys, and two-node handshake exchange.

## Design Notes

- ElGamal encrypts the message body directly; this does not use ElGamal as a KEM for wrapping a symmetric key.
- The encrypted message carries the sender public key, and handlers verify that the key resolves to the signed sender DID.
- The current API keeps key caching at the application layer.

Closes #608.

## Validation

```bash
cargo +nightly fmt --all -- --check
cargo test -p rings-core --lib --features dummy message::e2e
cargo test -p rings-core --lib --features dummy ecc::elgamal
cargo test -p rings-core --lib --features dummy message::handlers::e2e
cargo test -p rings-node --lib --features node test_processor_e2e_handshake_exchanges_verified_public_keys -- --nocapture
cargo test -p rings-node --lib --features node test_processor_handshake_msg -- --nocapture
cargo clippy -p rings-core --lib --features dummy --no-deps -- -D warnings
cargo clippy -p rings-node --lib --no-deps -- -D warnings
cargo clippy -p rings-core --lib --no-default-features --features wasm --target wasm32-unknown-unknown --no-deps -- -D warnings
cargo clippy -p rings-core --lib --tests --features dummy --no-deps -- -D warnings
cargo clippy -p rings-node --lib --tests --features node --no-deps -- -D warnings
RUSTDOCFLAGS='-D warnings' cargo doc -p rings-core --lib --features dummy --no-deps
```