### PR TITLE
Add browser connectivity examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Runnable examples live in [`examples/`](./examples):
 | Example | What it shows |
 |---|---|
 | [`native`](./examples/native) | A minimal native node registering a custom namespaced protocol |
-| [`browser`](./examples/browser) | The same protocol model in the browser (WASM) — same Rust code, no JS handler |
+| [`browser`](./examples/browser) | Browser-to-browser and browser-to-native connectivity over a seed node, without manual SDP exchange |
 | [`relay`](./examples/relay) | TCP & UDP tunnels to a peer's service over the overlay (`tcp.rs` / `udp.rs`) |
 | [`snark`](./examples/snark) | Fold-scheme zkSNARK proving / verification |
 | [`proof-demo`](./examples/proof-demo) | A browser zk-proof app (Yew / Trunk) |

--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -1,33 +1,109 @@
-# Rings browser (wasm) example — dweb core
+# Rings browser connectivity example
 
-The UI-free core a browser (e.g. Yew) Rings app calls. It shows that **the browser uses
-the same model as native**: protocols are pure Rust `Protocol`s. Here the built-in Rust
-`Echo` protocol is registered on a *browser* `Provider` — no JavaScript handler, the
-same code a daemon runs. (For a JS-defined protocol, use
-`provider.on(namespace, initialState, handler)` instead.)
+This example covers the issue #539 flows:
 
-Three primitives (`src/lib.rs`), which a frontend's components call:
+- browser to browser without manually copying SDP;
+- browser to native with bidirectional namespaced messages.
 
-- `connect_via_seed(provider, url)` — join an overlay via a seed node's HTTP endpoint;
-- `register_echo(provider)` — register the protocol(s) this app speaks;
-- `send_echo(provider, did, payload)` — send a namespaced message to a peer.
+The page in `index.html` uses the browser WASM provider directly. Each browser node joins the
+overlay through a seed node HTTP endpoint, then dials a peer by DID with `connectWithDid`.
+Messages are sent with `sendBackendMessage` under the `example` namespace.
 
-The whole crate is `#![cfg(target_arch = "wasm32")]`, so on native it is an empty lib
-(the workspace stays green) and only builds for real on wasm.
+`src/lib.rs` also keeps the smaller Rust/WASM helper functions used by application code that
+wants to register the built-in Rust `Echo` protocol from a browser provider.
 
 ## Build
 
+From the repository root:
+
 ```sh
-wasm-pack build examples/browser
+npm install
+npm run wasm_pack
 ```
+
+The page imports `crates/node/pkg/rings_node.js`, so serve the repository root, not just this
+directory:
+
+```sh
+python3 -m http.server 8080
+```
+
+Open:
+
+```text
+http://127.0.0.1:8080/examples/browser/
+```
+
+## Seed node
+
+Both browser and native examples use the default Rings network id `1`. Start one native daemon as
+the shared seed:
+
+```sh
+cargo run -p rings-node --bin rings -- init \
+  --location /tmp/rings-seed/config.yaml \
+  --session-sk /tmp/rings-seed/session_sk
+
+cargo run -p rings-node --bin rings -- run \
+  --config /tmp/rings-seed/config.yaml \
+  --external-api-addr 127.0.0.1:50001 \
+  --internal-api-port 50000 \
+  --storage-path /tmp/rings-seed/storage
+```
+
+Use `http://127.0.0.1:50001` as the browser page's seed HTTP endpoint.
+
+## Browser to browser
+
+1. Start the seed node above.
+2. Serve this repo on two different origins so each browser node gets separate IndexedDB storage:
+
+   ```sh
+   python3 -m http.server 8080
+   python3 -m http.server 8081
+   ```
+
+3. Open both pages:
+
+   ```text
+   http://127.0.0.1:8080/examples/browser/
+   http://127.0.0.1:8081/examples/browser/
+   ```
+
+4. On both pages, click `Start provider`, then `Connect seed`.
+5. Copy browser B's DID into browser A's `Remote peer DID`.
+6. On browser A, click `Connect DID`, then `Send example message`.
+
+No SDP is copied by the user. The seed gives the peers an initial overlay path; `connectWithDid`
+performs the peer connection by DID.
+
+## Browser to native
+
+1. Start the seed node.
+2. Open the browser page, click `Start provider`, then `Connect seed`.
+3. Copy the browser DID.
+4. Start the native example and pass the seed URL plus the browser DID:
+
+   ```sh
+   cargo run -p rings-native-example -- http://127.0.0.1:50001 BROWSER_DID
+   ```
+
+The native example prints its DID, connects through the same seed, sends an `example` message to
+the browser, and then waits for replies. To send back from the browser, paste the native DID into
+`Remote peer DID` and click `Send example message`.
 
 ## Test
 
+The browser page is an integration example. The deterministic protocol unit runs in node:
+
 ```sh
-wasm-pack test --headless --chrome examples/browser
+wasm-pack test --release --node examples/browser
 ```
 
-`tests/echo.rs` checks the pure `Echo::step` the example installs (deterministic, no
-overlay). The full two-node browser round-trip (connect + namespaced protocol + send)
-is covered by the node crate's `crates/node/src/tests/wasm/browser.rs` suite, which has
-the in-browser connection harness.
+The full two-provider browser connection harness lives in
+`crates/node/src/tests/wasm/browser.rs` and is covered by the node WASM CI path:
+
+```sh
+cargo test -p rings-node --release --target=wasm32-unknown-unknown \
+  --features browser_default --no-default-features
+```

--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -9,6 +9,10 @@ The page in `index.html` uses the browser WASM provider directly. Each browser n
 overlay through a seed node HTTP endpoint, then dials a peer by DID with `connectWithDid`.
 Messages are sent with `sendBackendMessage` under the `example` namespace.
 
+The page imports `ethers@6.13.5` from jsDelivr to create an EIP-191 signing wallet in the
+browser. Running the page therefore needs internet access unless that dependency is vendored or
+served locally.
+
 `src/lib.rs` also keeps the smaller Rust/WASM helper functions used by application code that
 wants to register the built-in Rust `Echo` protocol from a browser provider.
 
@@ -72,7 +76,8 @@ Use `http://127.0.0.1:50001` as the browser page's seed HTTP endpoint.
 
 4. On both pages, click `Start provider`, then `Connect seed`.
 5. Copy browser B's DID into browser A's `Remote peer DID`.
-6. On browser A, click `Connect DID`, then `Send example message`.
+6. Wait a few seconds, or click `List peers` until each page shows the seed as connected.
+7. On browser A, click `Connect DID`, then `Send example message`.
 
 No SDP is copied by the user. The seed gives the peers an initial overlay path; `connectWithDid`
 performs the peer connection by DID.
@@ -82,7 +87,8 @@ performs the peer connection by DID.
 1. Start the seed node.
 2. Open the browser page, click `Start provider`, then `Connect seed`.
 3. Copy the browser DID.
-4. Start the native example and pass the seed URL plus the browser DID:
+4. Wait a few seconds, or click `List peers` until the page shows the seed as connected.
+5. Start the native example and pass the seed URL plus the browser DID:
 
    ```sh
    cargo run -p rings-native-example -- http://127.0.0.1:50001 BROWSER_DID
@@ -94,7 +100,8 @@ the browser, and then waits for replies. To send back from the browser, paste th
 
 ## Test
 
-The browser page is an integration example. The deterministic protocol unit runs in node:
+The browser page is an integration example. The deterministic protocol unit for the Rust `Echo`
+helper runs in node:
 
 ```sh
 wasm-pack test --release --node examples/browser
@@ -107,3 +114,7 @@ The full two-provider browser connection harness lives in
 cargo test -p rings-node --release --target=wasm32-unknown-unknown \
   --features browser_default --no-default-features
 ```
+
+That harness covers direct offer/answer connection setup, `listPeers`, `sendBackendMessage`, and
+`provider.on` message handling. It does not start a native seed daemon, so the seed HTTP join plus
+`connectWithDid` flow documented above remains a manual integration path.

--- a/examples/browser/app.mjs
+++ b/examples/browser/app.mjs
@@ -1,0 +1,188 @@
+import init, { debug, Provider } from "../../crates/node/pkg/rings_node.js";
+import { Wallet } from "https://cdn.jsdelivr.net/npm/ethers@6.13.5/+esm";
+
+const EXAMPLE_NAMESPACE = "example";
+
+const refs = {
+  networkId: document.getElementById("network-id"),
+  stabilizeInterval: document.getElementById("stabilize-interval"),
+  iceServers: document.getElementById("ice-servers"),
+  startProvider: document.getElementById("start-provider"),
+  copyDid: document.getElementById("copy-did"),
+  localDid: document.getElementById("local-did"),
+  seedUrl: document.getElementById("seed-url"),
+  remoteDid: document.getElementById("remote-did"),
+  connectSeed: document.getElementById("connect-seed"),
+  connectDid: document.getElementById("connect-did"),
+  listPeers: document.getElementById("list-peers"),
+  message: document.getElementById("message"),
+  sendMessage: document.getElementById("send-message"),
+  log: document.getElementById("log"),
+};
+
+const state = {
+  provider: null,
+  wallet: null,
+  listen: null,
+};
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function log(message, detail) {
+  const time = new Date().toLocaleTimeString();
+  const suffix = detail === undefined ? "" : `\n${stringify(detail)}`;
+  refs.log.textContent += `[${time}] ${message}${suffix}\n`;
+  refs.log.scrollTop = refs.log.scrollHeight;
+}
+
+function stringify(value) {
+  if (value instanceof Error) {
+    return value.stack || value.message;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function hexToBytes(hex) {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (!/^[0-9a-fA-F]*$/.test(clean) || clean.length % 2 !== 0) {
+    throw new Error("signature is not even-length hex");
+  }
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let offset = 0; offset < clean.length; offset += 2) {
+    bytes[offset / 2] = Number.parseInt(clean.slice(offset, offset + 2), 16);
+  }
+  return bytes;
+}
+
+function bytesToBase64(bytes) {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+function requireProvider() {
+  if (!state.provider) {
+    throw new Error("start the provider first");
+  }
+  return state.provider;
+}
+
+function setStarted(started) {
+  refs.startProvider.disabled = started;
+  refs.copyDid.disabled = !started;
+  refs.connectSeed.disabled = !started;
+  refs.connectDid.disabled = !started;
+  refs.listPeers.disabled = !started;
+  refs.sendMessage.disabled = !started;
+}
+
+async function startProvider() {
+  await init();
+  debug(true);
+
+  const wallet = Wallet.createRandom();
+  const signer = async (proof) => hexToBytes(await wallet.signMessage(proof));
+  const provider = await new Provider(
+    Number(refs.networkId.value),
+    refs.iceServers.value,
+    BigInt(refs.stabilizeInterval.value),
+    wallet.address,
+    "eip191",
+    signer,
+  );
+
+  provider.on(EXAMPLE_NAMESPACE, { received: 0 }, (ctx, event) => {
+    const text = decoder.decode(event.payload);
+    log(`received ${EXAMPLE_NAMESPACE} message from ${event.from}`, text);
+    return {
+      state: { received: Number(ctx.state?.received || 0) + 1 },
+      effects: [],
+    };
+  });
+
+  state.provider = provider;
+  state.wallet = wallet;
+  state.listen = provider.listen();
+  state.listen.catch((error) => log("listen task stopped", error));
+
+  refs.localDid.textContent = provider.address();
+  setStarted(true);
+  log("provider started", { did: provider.address(), account: wallet.address });
+}
+
+async function connectSeed() {
+  const provider = requireProvider();
+  const url = refs.seedUrl.value.trim();
+  const response = await provider.request("connectPeerViaHttp", { url });
+  log("connected to seed", response);
+  await refreshPeers();
+}
+
+async function connectDid() {
+  const provider = requireProvider();
+  const did = refs.remoteDid.value.trim();
+  const response = await provider.request("connectWithDid", { did });
+  log("connectWithDid returned", response);
+  await refreshPeers();
+}
+
+async function refreshPeers() {
+  const provider = requireProvider();
+  const response = await provider.request("listPeers", {});
+  log("peers", response);
+}
+
+async function sendMessage() {
+  const provider = requireProvider();
+  const destinationDid = refs.remoteDid.value.trim();
+  const payload = encoder.encode(refs.message.value);
+  const response = await provider.request("sendBackendMessage", {
+    destination_did: destinationDid,
+    namespace: EXAMPLE_NAMESPACE,
+    data: bytesToBase64(payload),
+  });
+  log("message sent", response);
+}
+
+async function copyDid() {
+  const did = refs.localDid.textContent;
+  await navigator.clipboard.writeText(did);
+  log("copied local DID");
+}
+
+function bind(id, action) {
+  refs[id].addEventListener("click", async () => {
+    refs[id].disabled = true;
+    try {
+      await action();
+    } catch (error) {
+      log("error", error);
+    } finally {
+      if (id === "startProvider") {
+        refs[id].disabled = Boolean(state.provider);
+      } else {
+        refs[id].disabled = !state.provider;
+      }
+    }
+  });
+}
+
+bind("startProvider", startProvider);
+bind("connectSeed", connectSeed);
+bind("connectDid", connectDid);
+bind("listPeers", refreshPeers);
+bind("sendMessage", sendMessage);
+bind("copyDid", copyDid);
+
+setStarted(false);
+log("build crates/node first, then serve the repository root over HTTP");

--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Rings browser connectivity example</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+        background: #f5f7f8;
+        color: #1f2933;
+      }
+
+      body {
+        margin: 0;
+      }
+
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 24px;
+      }
+
+      h1 {
+        margin: 0 0 6px;
+        font-size: 1.75rem;
+      }
+
+      h2 {
+        margin: 0 0 12px;
+        font-size: 1rem;
+      }
+
+      p {
+        margin: 0 0 16px;
+        color: #52606d;
+      }
+
+      section {
+        margin-top: 20px;
+        padding: 16px;
+        border: 1px solid #d9e2ec;
+        border-radius: 8px;
+        background: #ffffff;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      label {
+        display: grid;
+        gap: 6px;
+        font-size: 0.82rem;
+        font-weight: 650;
+      }
+
+      input,
+      textarea {
+        box-sizing: border-box;
+        width: 100%;
+        border: 1px solid #bcccdc;
+        border-radius: 6px;
+        padding: 9px 10px;
+        font: inherit;
+        background: #ffffff;
+        color: inherit;
+      }
+
+      textarea {
+        min-height: 92px;
+        resize: vertical;
+      }
+
+      button {
+        border: 0;
+        border-radius: 6px;
+        padding: 9px 12px;
+        font: inherit;
+        font-weight: 700;
+        color: #ffffff;
+        background: #1f6feb;
+        cursor: pointer;
+      }
+
+      button.secondary {
+        color: #1f2933;
+        background: #e4e7eb;
+      }
+
+      button:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
+
+      .row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        align-items: center;
+      }
+
+      .value {
+        overflow-wrap: anywhere;
+        border-radius: 6px;
+        padding: 8px 10px;
+        background: #f0f4f8;
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      }
+
+      #log {
+        min-height: 240px;
+        max-height: 420px;
+        overflow: auto;
+        white-space: pre-wrap;
+        border-radius: 6px;
+        padding: 12px;
+        background: #111827;
+        color: #d1d5db;
+        font-family:
+          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-size: 0.85rem;
+      }
+
+      @media (max-width: 720px) {
+        main {
+          padding: 16px;
+        }
+
+        .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Rings browser connectivity example</h1>
+      <p>
+        Browser peers join through a seed node HTTP endpoint, connect by DID,
+        then exchange namespaced messages on the <code>example</code> protocol.
+      </p>
+
+      <section>
+        <h2>Local provider</h2>
+        <div class="grid">
+          <label>
+            Network ID
+            <input id="network-id" type="number" min="0" value="1" />
+          </label>
+          <label>
+            Stabilize interval seconds
+            <input id="stabilize-interval" type="number" min="1" value="3" />
+          </label>
+          <label style="grid-column: 1 / -1">
+            ICE servers
+            <input id="ice-servers" value="stun://stun.l.google.com:19302" />
+          </label>
+        </div>
+        <div class="row" style="margin-top: 12px">
+          <button id="start-provider">Start provider</button>
+          <button id="copy-did" class="secondary" disabled>Copy DID</button>
+        </div>
+        <p style="margin-top: 12px">DID</p>
+        <div id="local-did" class="value">not started</div>
+      </section>
+
+      <section>
+        <h2>Connect</h2>
+        <div class="grid">
+          <label>
+            Seed HTTP endpoint
+            <input id="seed-url" value="http://127.0.0.1:50001" />
+          </label>
+          <label>
+            Remote peer DID
+            <input id="remote-did" placeholder="0x..." />
+          </label>
+        </div>
+        <div class="row" style="margin-top: 12px">
+          <button id="connect-seed" disabled>Connect seed</button>
+          <button id="connect-did" disabled>Connect DID</button>
+          <button id="list-peers" class="secondary" disabled>List peers</button>
+        </div>
+      </section>
+
+      <section>
+        <h2>Message</h2>
+        <label>
+          Message payload
+          <textarea id="message">hello from browser</textarea>
+        </label>
+        <div class="row" style="margin-top: 12px">
+          <button id="send-message" disabled>Send example message</button>
+        </div>
+      </section>
+
+      <section>
+        <h2>Log</h2>
+        <pre id="log"></pre>
+      </section>
+    </main>
+
+    <script type="module" src="./app.mjs"></script>
+  </body>
+</html>

--- a/examples/browser/tests/echo.rs
+++ b/examples/browser/tests/echo.rs
@@ -1,10 +1,10 @@
 #![cfg(target_arch = "wasm32")]
-//! Browser integration test (wasm-bindgen-test) for the protocol the example registers.
+//! Browser integration test (wasm-bindgen-test) for the Rust `Echo` helper protocol.
 //!
-//! It exercises the pure `Echo::step` the example installs — deterministic, no overlay
-//! needed — so it runs reliably under `wasm-pack test`. The full two-node browser
-//! round-trip (connect + namespaced protocol + send) is covered by the node crate's
-//! `tests/wasm/browser.rs` suite, which has the in-browser connection harness.
+//! The browser page in `index.html` registers a JS `example` protocol through
+//! `provider.on(...)`. This test intentionally covers the separate Rust helper path in
+//! `src/lib.rs`, where applications can register the built-in `Echo` protocol from WASM.
+//! It exercises the pure `Echo::step` transition with no overlay, so it stays deterministic.
 
 use rings_core::dht::Did;
 use rings_core::ecc::SecretKey;

--- a/examples/native/README.md
+++ b/examples/native/README.md
@@ -30,5 +30,5 @@ cargo run -p rings-native-example -- http://127.0.0.1:50001 BROWSER_DID
 ```
 
 The native example uses the same default network id as the daemon (`1`), sends one
-`example`-namespace message to the browser, and waits briefly so the browser can send an
+`example`-namespace message to the browser, and waits 30 seconds so the browser can send an
 `example` message back to the native DID printed at startup.

--- a/examples/native/README.md
+++ b/examples/native/README.md
@@ -1,0 +1,34 @@
+# Rings native example
+
+This native example registers the `example` namespace, connects to a seed node over HTTP, and sends
+a message to a destination DID. It is intended to interoperate with
+[`examples/browser`](../browser).
+
+## Run with the browser example
+
+Start a seed daemon first:
+
+```sh
+cargo run -p rings-node --bin rings -- init \
+  --location /tmp/rings-seed/config.yaml \
+  --session-sk /tmp/rings-seed/session_sk
+
+cargo run -p rings-node --bin rings -- run \
+  --config /tmp/rings-seed/config.yaml \
+  --external-api-addr 127.0.0.1:50001 \
+  --internal-api-port 50000 \
+  --storage-path /tmp/rings-seed/storage
+```
+
+Open the browser example, start its provider, connect it to `http://127.0.0.1:50001`, then copy
+the browser DID.
+
+Run the native example:
+
+```sh
+cargo run -p rings-native-example -- http://127.0.0.1:50001 BROWSER_DID
+```
+
+The native example uses the same default network id as the daemon (`1`), sends one
+`example`-namespace message to the browser, and waits briefly so the browser can send an
+`example` message back to the native DID printed at startup.

--- a/examples/native/src/main.rs
+++ b/examples/native/src/main.rs
@@ -15,6 +15,7 @@ use rings_node::extension::ext::Transition;
 use rings_node::extension::ext::Wire;
 use rings_node::logging::init_logging;
 use rings_node::logging::LogLevel;
+use rings_node::native::config::DEFAULT_NETWORK_ID;
 use rings_node::processor::ProcessorBuilder;
 use rings_node::processor::ProcessorConfig;
 use rings_node::provider::Provider;
@@ -23,6 +24,7 @@ use rings_rpc::protos::rings_node::*;
 
 /// Namespace this example speaks over.
 const EXAMPLE_NAMESPACE: &str = "example";
+const REPLY_WINDOW_SECONDS: u64 = 30;
 
 /// A decoded example message (who sent it + the text).
 struct Received {
@@ -108,8 +110,13 @@ async fn main() {
     let sk = skb.build().unwrap();
 
     // Build processor
-    let config = ProcessorConfig::new(0, "stun://stun.l.google.com:19302".to_string(), sk, 3);
-    println!("===> Use network_id: 0");
+    let config = ProcessorConfig::new(
+        DEFAULT_NETWORK_ID,
+        "stun://stun.l.google.com:19302".to_string(),
+        sk,
+        3,
+    );
+    println!("===> Use network_id: {DEFAULT_NETWORK_ID}");
 
     let storage = Box::new(MemStorage::new());
     let processor = Arc::new(
@@ -196,6 +203,6 @@ async fn main() {
         .unwrap();
     println!("<=== SendBackendMessage: {resp:?}");
 
-    // Wait for message sent.
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    println!("<=== waiting {REPLY_WINDOW_SECONDS}s for example replies...");
+    tokio::time::sleep(Duration::from_secs(REPLY_WINDOW_SECONDS)).await;
 }


### PR DESCRIPTION
## Summary
- Add a runnable browser example page for browser-to-browser and browser-to-native connectivity without manual SDP exchange.
- Document the seed-node flow, the shared `example` namespace, and the browser/native commands under `examples/`.
- Align `examples/native` with the daemon default network id and keep it alive briefly so browser replies can be observed.

Closes #539.

## Validation
- `node --check examples/browser/app.mjs`
- `typos README.md examples/browser examples/native`
- `CARGO_HOME=/private/tmp/rings-examples-539-cargo-home CARGO_TARGET_DIR=/private/tmp/rings-examples-539-target cargo +nightly fmt --all -- --check`
- `CARGO_HOME=/private/tmp/rings-examples-539-cargo-home CARGO_TARGET_DIR=/private/tmp/rings-examples-539-target cargo check -p rings-native-example`
- `CARGO_HOME=/private/tmp/rings-examples-539-cargo-home CARGO_TARGET_DIR=/private/tmp/rings-examples-539-target wasm-pack build crates/node --release --scope ringsnetwork -t web --no-default-features --features browser_default --features console_error_panic_hook`
- `CARGO_HOME=/private/tmp/rings-examples-539-cargo-home CARGO_TARGET_DIR=/private/tmp/rings-examples-539-target cargo check -p rings-browser-example --target wasm32-unknown-unknown`
- `CARGO_HOME=/private/tmp/rings-examples-539-cargo-home CARGO_TARGET_DIR=/private/tmp/rings-examples-539-target wasm-pack test --release --node examples/browser`
