### PR TITLE
Expose native WebRTC UDP port range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4185,7 +4185,7 @@ dependencies = [
 
 [[package]]
 name = "rings-browser-example"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "js-sys",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "rings-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "rings-derive"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "rings-native-example"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -4291,7 +4291,7 @@ dependencies = [
 
 [[package]]
 name = "rings-node"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -4351,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "rings-relay-example"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "rings-core",
  "rings-node",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "rings-rpc"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "rings-snark"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bellpepper-core",
  "byteorder",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "rings-snark-example"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "rings-core",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "rings-transport"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "examples/browser", "examples/native", "examples/relay", "examples/snark"]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "GPL-3.0"
 authors = ["RND <dev@ringsnetwork.io>"]
@@ -13,12 +13,12 @@ repository = "https://github.com/RingsNetwork/rings-node"
 async-trait = "0.1.77"
 js-sys = "0.3.64"
 jsonrpc-core = "18.0.0"
-rings-core = { path = "crates/core", version = "0.10.0", default-features = false }
-rings-derive = { path = "crates/derive", version = "0.10.0", default-features = false }
-rings-node = { path = "crates/node", version = "0.10.0" }
-rings-rpc = { path = "crates/rpc", version = "0.10.0", default-features = false }
-rings-snark = { path = "crates/snark", version = "0.10.0", default-features = false }
-rings-transport = { path = "crates/transport", version = "0.10.0" }
+rings-core = { path = "crates/core", version = "0.11.0", default-features = false }
+rings-derive = { path = "crates/derive", version = "0.11.0", default-features = false }
+rings-node = { path = "crates/node", version = "0.11.0" }
+rings-rpc = { path = "crates/rpc", version = "0.11.0", default-features = false }
+rings-snark = { path = "crates/snark", version = "0.11.0", default-features = false }
+rings-transport = { path = "crates/transport", version = "0.11.0" }
 serde-wasm-bindgen = "0.6.5"
 wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.37"

--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ path**. Each layer maps directly to a crate/module:
 
 - **Transport** establishes direct, peer-to-peer WebRTC datachannels — browser-to-browser
   included — using STUN/ICE/SDP for NAT traversal, so traffic never transits a central server.
+  Native nodes deployed behind cloud firewalls can bound ICE UDP gathering with
+  `external_ip`, `webrtc_udp_port_min`, and `webrtc_udp_port_max`; for example,
+  `49160..=49200` maps to an AWS security-group rule for `UDP 49160-49200`.
+  Browser nodes still use the browser ICE stack, whose local UDP ports are not
+  controlled by Rings.
 - **Overlay** organizes peers into a Chord DHT and routes messages by DID; distinct overlays are
   isolated by `network_id`.
 - **Extension runtime** is a *functional core / imperative shell*: a protocol's state transition

--- a/crates/core/src/swarm/builder.rs
+++ b/crates/core/src/swarm/builder.rs
@@ -5,6 +5,8 @@
 use std::sync::Arc;
 use std::sync::RwLock;
 
+use rings_transport::webrtc_config::WebrtcUdpPortRange;
+
 use crate::chunk::ReassemblyLimits;
 use crate::dht::EntryStorage;
 use crate::dht::PeerRing;
@@ -15,6 +17,7 @@ use crate::swarm::callback::SharedSwarmCallback;
 use crate::swarm::callback::SwarmCallback;
 use crate::swarm::transport::SwarmTransport;
 use crate::swarm::transport::SwarmTransportSettings;
+use crate::swarm::transport::SwarmWebrtcConfig;
 use crate::swarm::Swarm;
 
 struct DefaultCallback;
@@ -25,6 +28,7 @@ pub struct SwarmBuilder {
     network_id: u32,
     ice_servers: String,
     external_address: Option<String>,
+    webrtc_udp_port_range: Option<WebrtcUdpPortRange>,
     dht_succ_max: u8,
     dht_finger_table_size: usize,
     dht_storage_redundancy: u16,
@@ -48,6 +52,7 @@ impl SwarmBuilder {
             network_id,
             ice_servers: ice_servers.to_string(),
             external_address: None,
+            webrtc_udp_port_range: None,
             dht_succ_max: 3,
             dht_finger_table_size: DEFAULT_FINGER_TABLE_SIZE,
             dht_storage_redundancy: 1,
@@ -94,6 +99,15 @@ impl SwarmBuilder {
         self
     }
 
+    /// Sets the native WebRTC UDP port range used during ICE gathering.
+    ///
+    /// Invariant: a present range has already proven `1 <= min <= max`.
+    /// Browser transports ignore this native deployment setting.
+    pub fn webrtc_udp_port_range(mut self, range: WebrtcUdpPortRange) -> Self {
+        self.webrtc_udp_port_range = Some(range);
+        self
+    }
+
     /// Setup timeout for session.
     pub fn session_ttl(mut self, ttl: usize) -> Self {
         self.session_ttl = Some(ttl);
@@ -130,8 +144,11 @@ impl SwarmBuilder {
 
         let transport = Arc::new(SwarmTransport::new(
             self.network_id,
-            &self.ice_servers,
-            self.external_address,
+            SwarmWebrtcConfig::new(
+                self.ice_servers,
+                self.external_address,
+                self.webrtc_udp_port_range,
+            ),
             self.session_sk,
             dht.clone(),
             self.measure,

--- a/crates/core/src/swarm/transport.rs
+++ b/crates/core/src/swarm/transport.rs
@@ -25,6 +25,7 @@ use rings_transport::core::transport::TransportInterface;
 use rings_transport::core::transport::TransportMessage;
 use rings_transport::core::transport::WebrtcConnectionState;
 use rings_transport::delivery::DeliveryFuture;
+use rings_transport::webrtc_config::WebrtcUdpPortRange;
 
 use crate::chunk::Chunk;
 use crate::chunk::ChunkList;
@@ -84,6 +85,32 @@ impl SwarmTransportSettings {
         Self {
             storage_redundancy,
             reassembly_limits,
+        }
+    }
+}
+
+/// WebRTC transport configuration used when constructing [`SwarmTransport`].
+pub(crate) struct SwarmWebrtcConfig {
+    ice_servers: String,
+    external_address: Option<String>,
+    udp_port_range: Option<WebrtcUdpPortRange>,
+}
+
+impl SwarmWebrtcConfig {
+    /// Build WebRTC transport configuration.
+    ///
+    /// Invariant: a present `udp_port_range` already proves `1 <= min <= max`.
+    /// Native transports use it to constrain ICE UDP gathering; browser
+    /// transports ignore it because local ICE ports are owned by the browser.
+    pub(crate) fn new(
+        ice_servers: String,
+        external_address: Option<String>,
+        udp_port_range: Option<WebrtcUdpPortRange>,
+    ) -> Self {
+        Self {
+            ice_servers,
+            external_address,
+            udp_port_range,
         }
     }
 }
@@ -250,8 +277,7 @@ fn spawn_chunked_send(
 impl SwarmTransport {
     pub(crate) fn new(
         network_id: u32,
-        ice_servers: &str,
-        external_address: Option<String>,
+        webrtc: SwarmWebrtcConfig,
         session_sk: SessionSk,
         dht: Arc<PeerRing>,
         measure: Option<MeasureImpl>,
@@ -259,7 +285,11 @@ impl SwarmTransport {
     ) -> Self {
         Self {
             network_id,
-            transport: Transport::new(ice_servers, external_address),
+            transport: Transport::new(
+                &webrtc.ice_servers,
+                webrtc.external_address,
+                webrtc.udp_port_range,
+            ),
             session_sk,
             dht,
             storage_redundancy: settings.storage_redundancy,

--- a/crates/core/src/tests/wasm/test_wasm_transport.rs
+++ b/crates/core/src/tests/wasm/test_wasm_transport.rs
@@ -27,7 +27,7 @@ async fn get_fake_permission() {
 }
 
 async fn prepare_transport() -> Transport {
-    let trans = Transport::new("stun://stun.l.google.com:19302", None);
+    let trans = Transport::new("stun://stun.l.google.com:19302", None, None);
     trans
         .new_connection("test", Box::new(DefaultCallback))
         .await

--- a/crates/node/bin/rings.rs
+++ b/crates/node/bin/rings.rs
@@ -179,6 +179,20 @@ struct RunCommand {
 
     #[arg(
         long,
+        help = "Minimum UDP port used by native WebRTC ICE gathering. Must be paired with --webrtc-udp-port-max.",
+        env
+    )]
+    pub webrtc_udp_port_min: Option<u16>,
+
+    #[arg(
+        long,
+        help = "Maximum UDP port used by native WebRTC ICE gathering. Must be paired with --webrtc-udp-port-min.",
+        env
+    )]
+    pub webrtc_udp_port_max: Option<u16>,
+
+    #[arg(
+        long,
         help = "Storage files location. If not provided, use storage.path in config file or ~/.local/share/rings",
         env
     )]
@@ -408,6 +422,12 @@ async fn daemon_run(args: RunCommand) -> anyhow::Result<()> {
     if let Some(external_ip) = args.external_ip {
         c.external_ip = Some(external_ip);
     }
+    if args.webrtc_udp_port_min.is_some() {
+        c.webrtc_udp_port_min = args.webrtc_udp_port_min;
+    }
+    if args.webrtc_udp_port_max.is_some() {
+        c.webrtc_udp_port_max = args.webrtc_udp_port_max;
+    }
     if let Some(stabilize_interval) = args.stabilize_interval {
         c.stabilize_interval = stabilize_interval;
     }
@@ -422,14 +442,14 @@ async fn daemon_run(args: RunCommand) -> anyhow::Result<()> {
 
     let (data_storage, measure_storage) = if let Some(storage_path) = args.storage_path {
         let storage_path = Path::new(&storage_path);
-        let data_path = storage_path.join("data");
-        let measure_path = storage_path.join("measure");
+        let data_path = storage_path.join("data").to_string_lossy().to_string();
+        let measure_path = storage_path.join("measure").to_string_lossy().to_string();
         let capacity = args
             .storage_capacity
             .unwrap_or(config::DEFAULT_STORAGE_CAPACITY);
         (
-            config::StorageConfig::new(data_path.to_str().unwrap(), capacity),
-            config::StorageConfig::new(measure_path.to_str().unwrap(), capacity),
+            config::StorageConfig::new(&data_path, capacity),
+            config::StorageConfig::new(&measure_path, capacity),
         )
     } else {
         (c.data_storage, c.measure_storage)
@@ -463,7 +483,7 @@ async fn daemon_run(args: RunCommand) -> anyhow::Result<()> {
     // The Backend decodes inbound custom messages as namespaced envelopes and routes
     // them to the protocol registry.
     let backend = Arc::new(Backend::new(provider));
-    processor.swarm.set_callback(backend).unwrap();
+    processor.swarm.set_callback(backend)?;
 
     let processor_clone1 = processor.clone();
     let processor_clone2 = processor.clone();

--- a/crates/node/build.rs
+++ b/crates/node/build.rs
@@ -7,7 +7,9 @@ fn gen_version() {
         .args(["rev-parse", "--short", "HEAD"])
         .output()
     {
-        let git_short_hash = String::from_utf8(output.stdout).unwrap();
+        let Ok(git_short_hash) = String::from_utf8(output.stdout) else {
+            return;
+        };
         println!("cargo:rustc-env=GIT_SHORT_HASH={git_short_hash}");
     }
 }

--- a/crates/node/src/error.rs
+++ b/crates/node/src/error.rs
@@ -89,6 +89,11 @@ pub enum Error {
     Swarm(rings_core::error::Error) = 808,
     #[error("Invalid logging level: {0}")]
     InvalidLoggingLevel(String) = 809,
+    #[error("Invalid WebRTC UDP port range: {0}")]
+    InvalidWebrtcUdpPortRange(#[from] rings_transport::webrtc_config::WebrtcUdpPortRangeError) =
+        810,
+    #[error("Both webrtc_udp_port_min and webrtc_udp_port_max must be set together: min={min:?}, max={max:?}")]
+    IncompleteWebrtcUdpPortRange { min: Option<u16>, max: Option<u16> } = 811,
     #[error("Create File Error: {0}")]
     CreateFileError(String) = 900,
     #[error("Open File Error: {0}")]
@@ -99,6 +104,8 @@ pub enum Error {
     HomeDirError = 903,
     #[error("Cannot find parent directory")]
     ParentDirError = 904,
+    #[error("Path is not valid UTF-8: {0}")]
+    PathUtf8Error(String) = 905,
     #[error("Serde json error: {0}")]
     SerdeJsonError(#[from] serde_json::Error) = 1000,
     #[error("Serde yaml error: {0}")]

--- a/crates/node/src/extension/ext/registry.rs
+++ b/crates/node/src/extension/ext/registry.rs
@@ -335,7 +335,10 @@ impl Extensions {
         let mut handlers = self.core.handlers.write().map_err(|_| Error::Lock)?;
         // Check-all (existing table + intra-batch duplicates) before mutating anything.
         for (index, (namespace, _)) in prepared.iter().enumerate() {
-            let duplicate_in_batch = prepared[..index].iter().any(|(seen, _)| seen == namespace);
+            let duplicate_in_batch = prepared
+                .iter()
+                .take(index)
+                .any(|(seen, _)| seen == namespace);
             if duplicate_in_batch || handlers.contains_key(namespace) {
                 return Err(Error::ExtensionError(format!(
                     "namespace {namespace:?} is already registered"

--- a/crates/node/src/native/cli.rs
+++ b/crates/node/src/native/cli.rs
@@ -211,11 +211,13 @@ impl Client {
                             })
                             .await;
 
-                        if let Err(e) = result {
-                            tracing::error!("Failed to fetch messages of topic: {}, {}", topic, e);
-                            continue;
-                        }
-                        let messages = result.unwrap().data;
+                        let messages = match result {
+                            Ok(result) => result.data,
+                            Err(e) => {
+                                tracing::error!("Failed to fetch messages of topic: {}, {}", topic, e);
+                                continue;
+                            }
+                        };
                         for msg in messages.iter().cloned() {
                             yield msg
                         }
@@ -234,7 +236,7 @@ impl Client {
             .await
             .map_err(|e| anyhow::anyhow!("{}", e))?
             .swarm
-            .unwrap();
+            .ok_or_else(|| anyhow::anyhow!("node_info response did not include swarm info"))?;
 
         let display =
             serde_json::to_string_pretty(&swarm_info).map_err(|e| anyhow::anyhow!("{}", e))?;

--- a/crates/node/src/native/config.rs
+++ b/crates/node/src/native/config.rs
@@ -37,11 +37,11 @@ pub const DEFAULT_STORAGE_CAPACITY: u32 = 200000000;
 pub fn get_storage_location<P>(prefix: P, path: P) -> String
 where P: AsRef<std::path::Path> {
     let home_dir = env::var_os("HOME").map(PathBuf::from);
-    let expect = match home_dir {
+    let storage_path = match home_dir {
         Some(dir) => dir.join(prefix).join(path),
         None => std::path::Path::new("data").join(prefix).join(path),
     };
-    expect.to_str().unwrap().to_string()
+    storage_path.to_string_lossy().to_string()
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -59,6 +59,10 @@ pub struct Config {
     pub stabilize_interval: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_ip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub webrtc_udp_port_min: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub webrtc_udp_port_max: Option<u16>,
     pub data_storage: StorageConfig,
     pub measure_storage: StorageConfig,
 }
@@ -70,14 +74,15 @@ impl TryFrom<Config> for ProcessorConfigSerialized {
         let session_sk: String = if let Some(sk) = config.ecdsa_key {
             tracing::warn!("Field `ecdsa_key` is deprecated, use `session_sk` instead.");
             SessionSk::new_with_seckey(&sk)
-                .expect("create session sk failed")
-                .dump()
-                .expect("dump session sk failed")
+                .and_then(|session_sk| session_sk.dump())
+                .map_err(|e| Error::VerifyError(e.to_string()))?
         } else if let Some(ssk) = config.session_manager {
             tracing::warn!("Field `session_manager` is deprecated, use `session_sk` instead.");
             ssk
         } else {
-            let ssk_file = config.session_sk.expect("session_sk is not set.");
+            let Some(ssk_file) = config.session_sk else {
+                return Err(Error::InvalidData);
+            };
             let ssk_file_expand_home = expand_home(&ssk_file)?;
             fs::read_to_string(ssk_file_expand_home).unwrap_or_else(|e| {
                 tracing::warn!("Read session_sk file failed: {e:?}. Handling it as raw session_sk string. This mode is deprecated. please use a file path.");
@@ -94,6 +99,15 @@ impl TryFrom<Config> for ProcessorConfigSerialized {
 
         cs = if let Some(ext_ip) = config.external_ip {
             cs.external_address(ext_ip)
+        } else {
+            cs
+        };
+        let udp_range = crate::processor::parse_webrtc_udp_port_range(
+            config.webrtc_udp_port_min,
+            config.webrtc_udp_port_max,
+        )?;
+        cs = if let Some(range) = udp_range {
+            cs.webrtc_udp_port_range(range)
         } else {
             cs
         };
@@ -124,6 +138,8 @@ impl Config {
             ice_servers: DEFAULT_ICE_SERVERS.to_string(),
             stabilize_interval: DEFAULT_STABILIZE_INTERVAL,
             external_ip: None,
+            webrtc_udp_port_min: None,
+            webrtc_udp_port_max: None,
             data_storage: DEFAULT_DATA_STORAGE_CONFIG.clone(),
             measure_storage: DEFAULT_MEASURE_STORAGE_CONFIG.clone(),
         }
@@ -137,7 +153,9 @@ impl Config {
             fs::File::create(path.as_path()).map_err(|e| Error::CreateFileError(e.to_string()))?;
         let f_writer = io::BufWriter::new(f);
         serde_yaml::to_writer(f_writer, self).map_err(|_| Error::EncodeError)?;
-        Ok(path.to_str().unwrap().to_owned())
+        path.to_str()
+            .map(str::to_owned)
+            .ok_or_else(|| Error::PathUtf8Error(path.display().to_string()))
     }
 
     pub fn read_fs<P>(path: P) -> Result<Config>
@@ -169,6 +187,18 @@ impl StorageConfig {
 mod tests {
     use super::*;
 
+    fn dumped_session_sk() -> String {
+        let key = SecretKey::random();
+        let session = match SessionSk::new_with_seckey(&key) {
+            Ok(session) => session,
+            Err(error) => panic!("session key construction failed: {error}"),
+        };
+        match session.dump() {
+            Ok(dump) => dump,
+            Err(error) => panic!("session key dump failed: {error}"),
+        }
+    }
+
     #[test]
     fn test_deserialization_with_missed_field() {
         let yaml = r#"
@@ -180,6 +210,8 @@ endpoint_url: http://127.0.0.1:50000
 ice_servers: stun://stun.l.google.com:19302
 stabilize_interval: 3
 external_ip: null
+webrtc_udp_port_min: null
+webrtc_udp_port_max: null
 data_storage:
   path: /Users/foo/.rings/data
   capacity: 200000000
@@ -189,5 +221,35 @@ measure_storage:
 "#;
         let cfg: Config = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(cfg.network_id, 1);
+    }
+
+    #[test]
+    fn config_with_valid_webrtc_udp_range_builds_processor_config() {
+        let mut config = Config::new(dumped_session_sk());
+        config.webrtc_udp_port_min = Some(49160);
+        config.webrtc_udp_port_max = Some(49200);
+
+        let processor_config = ProcessorConfig::try_from(config);
+
+        assert!(matches!(
+            processor_config.and_then(|config| config.webrtc_udp_port_range()),
+            Ok(Some(range)) if range.min() == 49160 && range.max() == 49200
+        ));
+    }
+
+    #[test]
+    fn config_with_partial_webrtc_udp_range_is_rejected() {
+        let mut config = Config::new(dumped_session_sk());
+        config.webrtc_udp_port_min = Some(49160);
+
+        let processor_config = ProcessorConfig::try_from(config);
+
+        assert!(matches!(
+            processor_config,
+            Err(Error::IncompleteWebrtcUdpPortRange {
+                min: Some(49160),
+                max: None
+            })
+        ));
     }
 }

--- a/crates/node/src/native/endpoint/mod.rs
+++ b/crates/node/src/native/endpoint/mod.rs
@@ -82,7 +82,7 @@ pub async fn run_internal_api(port: u16, processor: Arc<Processor>) -> anyhow::R
 
 /// Run a web server to handle jsonrpc request from external
 pub async fn run_external_api(addr: String, processor: Arc<Processor>) -> anyhow::Result<()> {
-    let binding_addr = addr.parse().unwrap();
+    let binding_addr: SocketAddr = addr.parse()?;
 
     let jsonrpc_handler = MetaIoHandler::with_middleware(ExternalRpcMiddleware);
     let jsonrpc_state = Arc::new(JsonRpcState {

--- a/crates/node/src/processor.rs
+++ b/crates/node/src/processor.rs
@@ -26,6 +26,7 @@ use rings_core::storage::MemStorage;
 use rings_core::swarm::Swarm;
 use rings_core::swarm::SwarmBuilder;
 use rings_rpc::protos::rings_node::*;
+use rings_transport::webrtc_config::WebrtcUdpPortRange;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -51,6 +52,10 @@ pub struct ProcessorConfig {
     ice_servers: String,
     /// External address for webrtc
     external_address: Option<String>,
+    /// Inclusive lower native WebRTC UDP port bound.
+    webrtc_udp_port_min: Option<u16>,
+    /// Inclusive upper native WebRTC UDP port bound.
+    webrtc_udp_port_max: Option<u16>,
     /// [SessionSk].
     session_sk: SessionSk,
     /// Stabilization interval.
@@ -70,6 +75,8 @@ impl ProcessorConfig {
             network_id,
             ice_servers,
             external_address: None,
+            webrtc_udp_port_min: None,
+            webrtc_udp_port_max: None,
             session_sk,
             stabilize_interval: Duration::from_secs(stabilize_interval),
         }
@@ -78,6 +85,13 @@ impl ProcessorConfig {
     /// Return associated [SessionSk].
     pub fn session_sk(&self) -> SessionSk {
         self.session_sk.clone()
+    }
+}
+
+impl ProcessorConfig {
+    /// Returns the validated native WebRTC UDP port range, when configured.
+    pub fn webrtc_udp_port_range(&self) -> Result<Option<WebrtcUdpPortRange>> {
+        parse_webrtc_udp_port_range(self.webrtc_udp_port_min, self.webrtc_udp_port_max)
     }
 }
 
@@ -101,6 +115,10 @@ pub struct ProcessorConfigSerialized {
     ice_servers: String,
     /// An optional string representing the external address for WebRTC
     external_address: Option<String>,
+    /// Inclusive lower native WebRTC UDP port bound.
+    webrtc_udp_port_min: Option<u16>,
+    /// Inclusive upper native WebRTC UDP port bound.
+    webrtc_udp_port_max: Option<u16>,
     /// A string representing the dumped `SessionSk`.
     session_sk: String,
     /// An unsigned integer representing the stabilization interval in seconds.
@@ -119,6 +137,8 @@ impl ProcessorConfigSerialized {
             network_id,
             ice_servers,
             external_address: None,
+            webrtc_udp_port_min: None,
+            webrtc_udp_port_max: None,
             session_sk,
             stabilize_interval,
         }
@@ -130,6 +150,26 @@ impl ProcessorConfigSerialized {
         self.external_address = Some(external_address);
         self
     }
+
+    /// Sets the native WebRTC UDP port range bounds.
+    pub fn webrtc_udp_port_range(mut self, range: WebrtcUdpPortRange) -> Self {
+        self.webrtc_udp_port_min = Some(range.min());
+        self.webrtc_udp_port_max = Some(range.max());
+        self
+    }
+}
+
+pub(crate) fn parse_webrtc_udp_port_range(
+    min: Option<u16>,
+    max: Option<u16>,
+) -> Result<Option<WebrtcUdpPortRange>> {
+    match (min, max) {
+        (None, None) => Ok(None),
+        (Some(min), Some(max)) => WebrtcUdpPortRange::new(min, max)
+            .map(Some)
+            .map_err(Error::from),
+        (min, max) => Err(Error::IncompleteWebrtcUdpPortRange { min, max }),
+    }
 }
 
 impl TryFrom<ProcessorConfig> for ProcessorConfigSerialized {
@@ -139,6 +179,8 @@ impl TryFrom<ProcessorConfig> for ProcessorConfigSerialized {
             network_id: ins.network_id,
             ice_servers: ins.ice_servers.clone(),
             external_address: ins.external_address.clone(),
+            webrtc_udp_port_min: ins.webrtc_udp_port_min,
+            webrtc_udp_port_max: ins.webrtc_udp_port_max,
             session_sk: ins.session_sk.dump()?,
             stabilize_interval: ins.stabilize_interval.as_secs(),
         })
@@ -148,10 +190,14 @@ impl TryFrom<ProcessorConfig> for ProcessorConfigSerialized {
 impl TryFrom<ProcessorConfigSerialized> for ProcessorConfig {
     type Error = Error;
     fn try_from(ins: ProcessorConfigSerialized) -> Result<Self> {
+        let webrtc_udp_port_range =
+            parse_webrtc_udp_port_range(ins.webrtc_udp_port_min, ins.webrtc_udp_port_max)?;
         Ok(Self {
             network_id: ins.network_id,
             ice_servers: ins.ice_servers.clone(),
             external_address: ins.external_address.clone(),
+            webrtc_udp_port_min: webrtc_udp_port_range.map(WebrtcUdpPortRange::min),
+            webrtc_udp_port_max: webrtc_udp_port_range.map(WebrtcUdpPortRange::max),
             session_sk: SessionSk::from_str(&ins.session_sk)?,
             stabilize_interval: Duration::from_secs(ins.stabilize_interval),
         })
@@ -191,6 +237,7 @@ pub struct ProcessorBuilder {
     network_id: u32,
     ice_servers: String,
     external_address: Option<String>,
+    webrtc_udp_port_range: Option<WebrtcUdpPortRange>,
     session_sk: SessionSk,
     storage: Option<EntryStorage>,
     measure: Option<MeasureImpl>,
@@ -221,6 +268,7 @@ impl ProcessorBuilder {
             network_id: config.network_id,
             ice_servers: config.ice_servers.clone(),
             external_address: config.external_address.clone(),
+            webrtc_udp_port_range: config.webrtc_udp_port_range()?,
             session_sk: config.session_sk.clone(),
             storage: None,
             measure: None,
@@ -271,6 +319,9 @@ impl ProcessorBuilder {
 
         if let Some(external_address) = self.external_address {
             swarm_builder = swarm_builder.external_address(external_address);
+        }
+        if let Some(range) = self.webrtc_udp_port_range {
+            swarm_builder = swarm_builder.webrtc_udp_port_range(range);
         }
 
         if let Some(measure) = self.measure {
@@ -531,6 +582,66 @@ mod test {
     use super::*;
     use crate::prelude::*;
     use crate::tests::native::prepare_processor;
+
+    #[test]
+    fn webrtc_udp_port_range_absent_by_default() {
+        let range = parse_webrtc_udp_port_range(None, None);
+
+        assert!(matches!(range, core::result::Result::Ok(None)));
+    }
+
+    #[test]
+    fn webrtc_udp_port_range_accepts_valid_bounds() {
+        let range = parse_webrtc_udp_port_range(Some(49160), Some(49200));
+
+        assert!(matches!(
+            range,
+            Ok(Some(range)) if range.min() == 49160 && range.max() == 49200
+        ));
+    }
+
+    #[test]
+    fn webrtc_udp_port_range_rejects_partial_bounds() {
+        let range = parse_webrtc_udp_port_range(Some(49160), None);
+
+        assert!(matches!(
+            range,
+            Err(Error::IncompleteWebrtcUdpPortRange {
+                min: Some(49160),
+                max: None
+            })
+        ));
+    }
+
+    #[test]
+    fn webrtc_udp_port_range_rejects_zero_bound() {
+        let range = parse_webrtc_udp_port_range(Some(0), Some(49200));
+
+        assert!(matches!(
+            range,
+            Err(Error::InvalidWebrtcUdpPortRange(
+                rings_transport::webrtc_config::WebrtcUdpPortRangeError::ZeroBound {
+                    min: 0,
+                    max: 49200
+                }
+            ))
+        ));
+    }
+
+    #[test]
+    fn webrtc_udp_port_range_rejects_inverted_bounds() {
+        let range = parse_webrtc_udp_port_range(Some(49200), Some(49160));
+
+        assert!(matches!(
+            range,
+            Err(Error::InvalidWebrtcUdpPortRange(
+                rings_transport::webrtc_config::WebrtcUdpPortRangeError::Inverted {
+                    min: 49200,
+                    max: 49160
+                }
+            ))
+        ));
+    }
 
     #[tokio::test]
     async fn test_processor_create_offer() {

--- a/crates/transport/src/connections/dummy/mod.rs
+++ b/crates/transport/src/connections/dummy/mod.rs
@@ -29,6 +29,7 @@ use crate::ice_server::parse_ice_servers_or_warn;
 use crate::notifier::Notifier;
 use crate::pool::Pool;
 use crate::sync_utils::lock_recover;
+use crate::webrtc_config::WebrtcUdpPortRange;
 
 /// Max delay in ms on sending message
 const DUMMY_DELAY_MAX: u64 = 100;
@@ -257,7 +258,11 @@ impl DummyConnection {
 
 impl DummyTransport {
     /// Create a new [DummyTransport] instance.
-    pub fn new(ice_servers: &str, _external_address: Option<String>) -> Self {
+    pub fn new(
+        ice_servers: &str,
+        _external_address: Option<String>,
+        _udp_port_range: Option<WebrtcUdpPortRange>,
+    ) -> Self {
         let _ = parse_ice_servers_or_warn(ice_servers, "dummy");
 
         Self { pool: Pool::new() }

--- a/crates/transport/src/connections/native_webrtc/mod.rs
+++ b/crates/transport/src/connections/native_webrtc/mod.rs
@@ -12,6 +12,8 @@ use webrtc::data_channel::data_channel_message::DataChannelMessage;
 use webrtc::data_channel::data_channel_state::RTCDataChannelState;
 use webrtc::data_channel::RTCDataChannel;
 use webrtc::ice::mdns::MulticastDnsMode;
+use webrtc::ice::udp_network::EphemeralUDP;
+use webrtc::ice::udp_network::UDPNetwork;
 use webrtc::ice_transport::ice_candidate_type::RTCIceCandidateType;
 use webrtc::ice_transport::ice_server::RTCIceServer;
 use webrtc::peer_connection::configuration::RTCConfiguration;
@@ -40,6 +42,7 @@ use crate::ice_server::IceCredentialType;
 use crate::ice_server::IceServer;
 use crate::notifier::Notifier;
 use crate::pool::Pool;
+use crate::webrtc_config::WebrtcUdpPortRange;
 
 const WEBRTC_WAIT_FOR_DATA_CHANNEL_OPEN_TIMEOUT: u8 = 8; // seconds
 const WEBRTC_GATHER_TIMEOUT: u8 = 60; // seconds
@@ -138,6 +141,7 @@ pub struct WebrtcConnection {
 pub struct WebrtcTransport {
     ice_servers: Vec<IceServer>,
     external_address: Option<String>,
+    udp_port_range: Option<WebrtcUdpPortRange>,
     pool: Pool<WebrtcConnection>,
 }
 
@@ -183,15 +187,40 @@ impl WebrtcConnection {
 
 impl WebrtcTransport {
     /// Create a new [WebrtcTransport] instance.
-    pub fn new(ice_servers: &str, external_address: Option<String>) -> Self {
+    pub fn new(
+        ice_servers: &str,
+        external_address: Option<String>,
+        udp_port_range: Option<WebrtcUdpPortRange>,
+    ) -> Self {
         let ice_servers = parse_ice_servers_or_warn(ice_servers, "native-webrtc");
 
         Self {
             ice_servers,
             external_address,
+            udp_port_range,
             pool: Pool::new(),
         }
     }
+}
+
+fn ephemeral_udp_for_range(range: WebrtcUdpPortRange) -> Result<EphemeralUDP> {
+    EphemeralUDP::new(range.min(), range.max()).map_err(|e| {
+        Error::WebrtcUdpPortRange(format!(
+            "min={}, max={}, reason={e}",
+            range.min(),
+            range.max()
+        ))
+    })
+}
+
+fn set_udp_network_range(
+    setting: &mut webrtc::api::setting_engine::SettingEngine,
+    range: Option<WebrtcUdpPortRange>,
+) -> Result<()> {
+    if let Some(range) = range {
+        setting.set_udp_network(UDPNetwork::Ephemeral(ephemeral_udp_for_range(range)?));
+    }
+    Ok(())
 }
 
 #[async_trait]
@@ -329,6 +358,7 @@ impl TransportInterface for WebrtcTransport {
         };
 
         let mut setting = webrtc::api::setting_engine::SettingEngine::default();
+        set_udp_network_range(&mut setting, self.udp_port_range)?;
         if let Some(ref addr) = self.external_address {
             tracing::debug!("setting external ip {:?}", addr);
             setting.set_nat_1to1_ips(vec![addr.to_string()], RTCIceCandidateType::Host);
@@ -498,5 +528,37 @@ impl From<RTCPeerConnectionState> for WebrtcConnectionState {
             RTCPeerConnectionState::Failed => Self::Failed,
             RTCPeerConnectionState::Closed => Self::Closed,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_test_range() -> WebrtcUdpPortRange {
+        match WebrtcUdpPortRange::new(49160, 49200) {
+            Ok(range) => range,
+            Err(error) => panic!("valid range rejected: {error}"),
+        }
+    }
+
+    #[test]
+    fn native_udp_range_builds_ephemeral_udp_with_same_bounds() {
+        let udp = ephemeral_udp_for_range(valid_test_range());
+        let udp = match udp {
+            Ok(udp) => udp,
+            Err(error) => panic!("valid range rejected by ICE stack: {error}"),
+        };
+
+        assert_eq!(udp.port_min(), 49160);
+        assert_eq!(udp.port_max(), 49200);
+    }
+
+    #[test]
+    fn native_transport_keeps_configured_udp_range() {
+        let range = valid_test_range();
+        let transport = WebrtcTransport::new("", None, Some(range));
+
+        assert_eq!(transport.udp_port_range, Some(range));
     }
 }

--- a/crates/transport/src/connections/web_sys_webrtc/mod.rs
+++ b/crates/transport/src/connections/web_sys_webrtc/mod.rs
@@ -46,6 +46,7 @@ use crate::ice_server::IceCredentialType;
 use crate::ice_server::IceServer;
 use crate::notifier::Notifier;
 use crate::pool::Pool;
+use crate::webrtc_config::WebrtcUdpPortRange;
 
 const WEBRTC_WAIT_FOR_DATA_CHANNEL_OPEN_TIMEOUT: u8 = 8; // seconds
 const WEBRTC_GATHER_TIMEOUT: u8 = 60; // seconds
@@ -190,7 +191,11 @@ impl WebSysWebrtcConnection {
 
 impl WebSysWebrtcTransport {
     /// Create a new [WebSysWebrtcTransport] instance.
-    pub fn new(ice_servers: &str, _external_address: Option<String>) -> Self {
+    pub fn new(
+        ice_servers: &str,
+        _external_address: Option<String>,
+        _udp_port_range: Option<WebrtcUdpPortRange>,
+    ) -> Self {
         let ice_servers = parse_ice_servers_or_warn(ice_servers, "web-sys-webrtc");
 
         Self {

--- a/crates/transport/src/error.rs
+++ b/crates/transport/src/error.rs
@@ -42,6 +42,9 @@ pub enum Error {
     #[error("WebRTC local SDP generation error: {0}")]
     WebrtcLocalSdpGenerationError(String),
 
+    #[error("WebRTC UDP port range was rejected by the ICE stack: {0}")]
+    WebrtcUdpPortRange(String),
+
     #[error("Connection {0} already exists")]
     ConnectionAlreadyExists(String),
 

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -27,5 +27,6 @@ pub mod error;
 pub mod ice_server;
 pub mod notifier;
 pub mod pool;
+pub mod webrtc_config;
 
 mod sync_utils;

--- a/crates/transport/src/webrtc_config.rs
+++ b/crates/transport/src/webrtc_config.rs
@@ -1,0 +1,117 @@
+//! WebRTC transport configuration values.
+
+use std::fmt;
+
+/// A validated inclusive UDP port range for native WebRTC ICE gathering.
+///
+/// `None` at the caller boundary means "use the OS/default WebRTC ephemeral
+/// range". A present [`WebrtcUdpPortRange`] always carries two non-zero bounds
+/// with `min <= max`.
+///
+/// Invariant: `1 <= min <= max <= u16::MAX`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WebrtcUdpPortRange {
+    min: u16,
+    max: u16,
+}
+
+impl WebrtcUdpPortRange {
+    /// Builds a validated inclusive UDP port range.
+    pub fn new(min: u16, max: u16) -> Result<Self, WebrtcUdpPortRangeError> {
+        if min == 0 || max == 0 {
+            return Err(WebrtcUdpPortRangeError::ZeroBound { min, max });
+        }
+        if min > max {
+            return Err(WebrtcUdpPortRangeError::Inverted { min, max });
+        }
+
+        Ok(Self { min, max })
+    }
+
+    /// The inclusive lower UDP port bound.
+    pub fn min(self) -> u16 {
+        self.min
+    }
+
+    /// The inclusive upper UDP port bound.
+    pub fn max(self) -> u16 {
+        self.max
+    }
+}
+
+/// Error returned when a UDP port range cannot witness the range invariant.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WebrtcUdpPortRangeError {
+    /// At least one bound is zero. Zero is reserved for the absent/default case.
+    ZeroBound {
+        /// Rejected lower bound.
+        min: u16,
+        /// Rejected upper bound.
+        max: u16,
+    },
+    /// The lower bound is greater than the upper bound.
+    Inverted {
+        /// Rejected lower bound.
+        min: u16,
+        /// Rejected upper bound.
+        max: u16,
+    },
+}
+
+impl fmt::Display for WebrtcUdpPortRangeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ZeroBound { min, max } => write!(
+                f,
+                "WebRTC UDP port range bounds must be non-zero: min={min}, max={max}"
+            ),
+            Self::Inverted { min, max } => write!(
+                f,
+                "WebRTC UDP port range min must be <= max: min={min}, max={max}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for WebrtcUdpPortRangeError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn udp_port_range_preserves_valid_bounds() {
+        let range = WebrtcUdpPortRange::new(49160, 49200);
+
+        assert_eq!(
+            range,
+            Ok(WebrtcUdpPortRange {
+                min: 49160,
+                max: 49200
+            })
+        );
+    }
+
+    #[test]
+    fn udp_port_range_rejects_zero_bound() {
+        let range = WebrtcUdpPortRange::new(0, 49200);
+
+        assert_eq!(
+            range,
+            Err(WebrtcUdpPortRangeError::ZeroBound { min: 0, max: 49200 })
+        );
+    }
+
+    #[test]
+    fn udp_port_range_rejects_inverted_bounds() {
+        let range = WebrtcUdpPortRange::new(49200, 49160);
+
+        assert_eq!(
+            range,
+            Err(WebrtcUdpPortRangeError::Inverted {
+                min: 49200,
+                max: 49160
+            })
+        );
+    }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "RND <dev@ringsnetwork.io>"
   ],
   "description": "Rings is a structured peer-to-peer network implementation using WebRTC, Chord algorithm, and full WebAssembly (WASM) support.\n",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "GPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

This PR implements #634 by exposing a native WebRTC UDP port range for deployable ICE configuration and bumps the project version to `0.11.0` because the configuration surface is a breaking change.

## Changes

- Adds a validated `WebrtcUdpPortRange` type with explicit zero-bound and inverted-range errors.
- Carries `webrtc_udp_port_min` / `webrtc_udp_port_max` through native config, serialized processor config, processor construction, swarm construction, and native WebRTC transport setup.
- Applies the range in native WebRTC via `SettingEngine::set_udp_network(UDPNetwork::Ephemeral(...))`.
- Keeps browser and dummy transports ABI-compatible by accepting and ignoring the native-only setting.
- Adds CLI flags `--webrtc-udp-port-min` and `--webrtc-udp-port-max`.
- Documents the AWS security-group mapping for bounded native ICE UDP ports.
- Bumps Rust workspace and npm package versions to `0.11.0`.
- Removes several production panic paths exposed by strict Rustacean self-review in build/config/CLI/native endpoint paths.

## Breaking Change

Native node configuration now has an explicit validated WebRTC UDP port range surface. Invalid partial, zero, or inverted bounds are rejected at config/processor construction instead of reaching the transport layer.

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test -p rings-transport webrtc_config --features native-webrtc`
- `cargo test -p rings-transport native_ --features native-webrtc`
- `cargo test -p rings-node webrtc_udp_port_range`
- `cargo test -p rings-node webrtc_udp_range`
- `cargo check -p rings-node --target wasm32-unknown-unknown --no-default-features --features browser`
- `cargo check -p rings-transport --target wasm32-unknown-unknown --no-default-features --features web-sys-webrtc`
- `cargo clippy -p rings-node --lib --no-default-features --features node -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::indexing_slicing`
- `cargo clippy -p rings-node --bin rings --no-default-features --features node -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::indexing_slicing`
- `cargo clippy -p rings-transport --lib --features native-webrtc -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::indexing_slicing`