### PR TITLE
Prioritize DHT connections by peer quality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4185,7 +4185,7 @@ dependencies = [
 
 [[package]]
 name = "rings-browser-example"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "js-sys",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "rings-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "rings-derive"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "rings-native-example"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -4291,7 +4291,7 @@ dependencies = [
 
 [[package]]
 name = "rings-node"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -4351,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "rings-relay-example"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "rings-core",
  "rings-node",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "rings-rpc"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "rings-snark"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bellpepper-core",
  "byteorder",
@@ -4406,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "rings-snark-example"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "rings-snark",
  "tokio",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "rings-transport"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "examples/browser", "examples/native", "examples/relay", "examples/snark"]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "GPL-3.0"
 authors = ["RND <dev@ringsnetwork.io>"]
@@ -13,12 +13,12 @@ repository = "https://github.com/RingsNetwork/rings-node"
 async-trait = "0.1.77"
 js-sys = "0.3.64"
 jsonrpc-core = "18.0.0"
-rings-core = { path = "crates/core", version = "0.11.0", default-features = false }
-rings-derive = { path = "crates/derive", version = "0.11.0", default-features = false }
-rings-node = { path = "crates/node", version = "0.11.0" }
-rings-rpc = { path = "crates/rpc", version = "0.11.0", default-features = false }
-rings-snark = { path = "crates/snark", version = "0.11.0", default-features = false }
-rings-transport = { path = "crates/transport", version = "0.11.0" }
+rings-core = { path = "crates/core", version = "0.12.0", default-features = false }
+rings-derive = { path = "crates/derive", version = "0.12.0", default-features = false }
+rings-node = { path = "crates/node", version = "0.12.0" }
+rings-rpc = { path = "crates/rpc", version = "0.12.0", default-features = false }
+rings-snark = { path = "crates/snark", version = "0.12.0", default-features = false }
+rings-transport = { path = "crates/transport", version = "0.12.0" }
 serde-wasm-bindgen = "0.6.5"
 wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.37"

--- a/crates/core/src/measure.rs
+++ b/crates/core/src/measure.rs
@@ -55,11 +55,6 @@ impl PeerQuality {
             Self::Degraded => 2,
         }
     }
-
-    /// Return whether this quality still permits the normal preferred path.
-    pub const fn permits_preferred_path(self) -> bool {
-        !matches!(self, Self::Degraded)
-    }
 }
 
 /// Failure limits used to classify local peer-quality evidence.
@@ -186,18 +181,22 @@ pub trait Measure {
     async fn get_count(&self, did: Did, counter: MeasureCounter) -> u64;
 }
 
-/// `BehaviourJudgement` trait defines a method `good` for assessing whether a node behaves well.
-/// Any structure implementing this trait should provide a way to measure the "goodness" of a node.
+/// `BehaviourJudgement` classifies local evidence about a peer.
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
 pub trait BehaviourJudgement: Measure {
     /// Classify local peer quality for DHT connection scheduling.
+    ///
+    /// This value is advisory. It orders connection attempts and does not gate
+    /// Chord membership, routing, ownership, or storage placement.
     async fn quality(&self, did: Did) -> PeerQuality;
 
-    /// This asynchronous method should return a boolean indicating whether the node identified by `did` is behaving well.
-    async fn good(&self, did: Did) -> bool {
-        self.quality(did).await.permits_preferred_path()
-    }
+    /// Return the legacy boolean judgement for callers that need a yes/no decision.
+    ///
+    /// This method is intentionally independent from [Self::quality]. Mapping
+    /// the three-valued quality order to a boolean would turn advisory DHT
+    /// scheduling evidence into a hidden gating rule.
+    async fn good(&self, did: Did) -> bool;
 }
 
 /// `ConnectBehaviour` trait offers a default implementation for the `good` method, providing a judgement
@@ -272,6 +271,10 @@ mod tests {
         );
         assert_eq!(
             PeerQualityEvidence::new(1, 0, 0, 10, 0, 0).classify(thresholds),
+            PeerQuality::Degraded
+        );
+        assert_eq!(
+            PeerQualityEvidence::new(1, 0, 0, 0, 0, 10).classify(thresholds),
             PeerQuality::Degraded
         );
     }

--- a/crates/core/src/measure.rs
+++ b/crates/core/src/measure.rs
@@ -1,17 +1,19 @@
 //! This module provide the `Measure` struct and its implementations.
 //! It is used to assess the reliability of remote peers.
 #![warn(missing_docs)]
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::dht::Did;
 
 /// Type of Measure, see [Measure].
 #[cfg(not(feature = "wasm"))]
-pub type MeasureImpl = Box<dyn BehaviourJudgement + Send + Sync>;
+pub type MeasureImpl = Arc<dyn BehaviourJudgement + Send + Sync>;
 
 /// Type of Measure, see [crate::measure::Measure].
 #[cfg(feature = "wasm")]
-pub type MeasureImpl = Box<dyn BehaviourJudgement>;
+pub type MeasureImpl = Arc<dyn BehaviourJudgement>;
 
 /// The tag of counters in measure.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -28,6 +30,148 @@ pub enum MeasureCounter {
     Connect,
     /// The number of disconnect.
     Disconnected,
+}
+
+/// Local peer-quality class derived from observation counters.
+///
+/// This value is advisory. It orders DHT connection attempts, but it is not a
+/// Chord membership, ownership, or storage-placement proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerQuality {
+    /// The peer has positive successful observations and remains below failure limits.
+    Healthy,
+    /// The local node has no useful recent evidence for this peer.
+    Unknown,
+    /// The peer reached one or more local failure limits.
+    Degraded,
+}
+
+impl PeerQuality {
+    /// Return the stable connection-priority rank: smaller is tried first.
+    pub const fn connection_rank(self) -> u8 {
+        match self {
+            Self::Healthy => 0,
+            Self::Unknown => 1,
+            Self::Degraded => 2,
+        }
+    }
+
+    /// Return whether this quality still permits the normal preferred path.
+    pub const fn permits_preferred_path(self) -> bool {
+        !matches!(self, Self::Degraded)
+    }
+}
+
+/// Failure limits used to classify local peer-quality evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PeerQualityThresholds {
+    disconnected: u64,
+    failed_to_send: u64,
+    failed_to_receive: u64,
+}
+
+impl PeerQualityThresholds {
+    /// Create classification thresholds.
+    pub const fn new(disconnected: u64, failed_to_send: u64, failed_to_receive: u64) -> Self {
+        Self {
+            disconnected,
+            failed_to_send,
+            failed_to_receive,
+        }
+    }
+}
+
+/// Recent local evidence used to classify a peer.
+///
+/// The counters are local observations only. They do not claim global
+/// reputation and are not signed or replicated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PeerQualityEvidence {
+    connected: u64,
+    disconnected: u64,
+    sent: u64,
+    failed_to_send: u64,
+    received: u64,
+    failed_to_receive: u64,
+}
+
+impl PeerQualityEvidence {
+    /// Build evidence from explicit counter values.
+    pub const fn new(
+        connected: u64,
+        disconnected: u64,
+        sent: u64,
+        failed_to_send: u64,
+        received: u64,
+        failed_to_receive: u64,
+    ) -> Self {
+        Self {
+            connected,
+            disconnected,
+            sent,
+            failed_to_send,
+            received,
+            failed_to_receive,
+        }
+    }
+
+    /// Read all counters for `did` from a measurement implementation.
+    pub async fn from_measure<M>(measure: &M, did: Did) -> Self
+    where M: Measure + ?Sized {
+        Self {
+            connected: measure.get_count(did, MeasureCounter::Connect).await,
+            disconnected: measure.get_count(did, MeasureCounter::Disconnected).await,
+            sent: measure.get_count(did, MeasureCounter::Sent).await,
+            failed_to_send: measure.get_count(did, MeasureCounter::FailedToSend).await,
+            received: measure.get_count(did, MeasureCounter::Received).await,
+            failed_to_receive: measure
+                .get_count(did, MeasureCounter::FailedToReceive)
+                .await,
+        }
+    }
+
+    /// Classify this evidence under the supplied thresholds.
+    pub const fn classify(self, thresholds: PeerQualityThresholds) -> PeerQuality {
+        if self.reaches_failure_limit(thresholds) {
+            PeerQuality::Degraded
+        } else if self.has_positive_observation() {
+            PeerQuality::Healthy
+        } else {
+            PeerQuality::Unknown
+        }
+    }
+
+    /// Return whether any successful local observation exists.
+    pub const fn has_positive_observation(self) -> bool {
+        self.connected > 0 || self.sent > 0 || self.received > 0
+    }
+
+    /// Return whether any failure counter has reached its configured limit.
+    pub const fn reaches_failure_limit(self, thresholds: PeerQualityThresholds) -> bool {
+        self.disconnected >= thresholds.disconnected
+            || self.failed_to_send >= thresholds.failed_to_send
+            || self.failed_to_receive >= thresholds.failed_to_receive
+    }
+}
+
+/// Order DHT connection candidates by advisory peer quality.
+///
+/// Invariant: the returned list is a stable permutation of the input candidate
+/// sequence. The transformation never inserts or removes a `Did`; it only moves
+/// `Healthy` before `Unknown` before `Degraded`.
+/// Preservation: because the set of candidates is unchanged, Chord ownership,
+/// successor responsibility, and storage placement remain determined only by the
+/// DHT transition that produced those candidates.
+pub fn order_peers_by_quality(
+    candidates: impl IntoIterator<Item = (Did, PeerQuality)>,
+) -> Vec<Did> {
+    let mut ranked = candidates
+        .into_iter()
+        .enumerate()
+        .map(|(index, (did, quality))| (quality.connection_rank(), index, did))
+        .collect::<Vec<_>>();
+    ranked.sort_by_key(|(rank, index, _)| (*rank, *index));
+    ranked.into_iter().map(|(_, _, did)| did).collect()
 }
 
 /// `Measure` is used to assess the reliability of peers by counting their behaviour.
@@ -47,28 +191,32 @@ pub trait Measure {
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
 pub trait BehaviourJudgement: Measure {
+    /// Classify local peer quality for DHT connection scheduling.
+    async fn quality(&self, did: Did) -> PeerQuality;
+
     /// This asynchronous method should return a boolean indicating whether the node identified by `did` is behaving well.
-    async fn good(&self, did: Did) -> bool;
+    async fn good(&self, did: Did) -> bool {
+        self.quality(did).await.permits_preferred_path()
+    }
 }
 
 /// `ConnectBehaviour` trait offers a default implementation for the `good` method, providing a judgement
 /// based on a node's behavior in establishing connections.
-/// The "goodness" of a node is measured by comparing the connection and disconnection counts against a given threshold.
+/// The "goodness" of a node is measured by comparing disconnection counts against a given threshold.
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
-pub trait ConnectBehaviour<const THRESHOLD: i64>: Measure {
+pub trait ConnectBehaviour<const THRESHOLD: u64>: Measure {
     /// This asynchronous method returns a boolean indicating whether the node identified by `did` has a satisfactory connection behavior.
     async fn good(&self, did: Did) -> bool {
-        let conn = self.get_count(did, MeasureCounter::Connect).await as i64;
-        let disconn = self.get_count(did, MeasureCounter::Disconnected).await as i64;
+        let conn = self.get_count(did, MeasureCounter::Connect).await;
+        let disconn = self.get_count(did, MeasureCounter::Disconnected).await;
         tracing::debug!(
-            "[ConnectBehaviour] in Threadhold: {:}, connect: {:}, disconn: {:}, delta: {:}",
+            "[ConnectBehaviour] in threshold: {:}, connect: {:}, disconn: {:}",
             THRESHOLD,
             conn,
-            disconn,
-            conn - disconn
+            disconn
         );
-        (conn - disconn) < THRESHOLD
+        disconn < THRESHOLD
     }
 }
 
@@ -77,11 +225,11 @@ pub trait ConnectBehaviour<const THRESHOLD: i64>: Measure {
 /// The "goodness" of a node is measured by comparing the sent and failed-to-send counts against a given threshold.
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
-pub trait MessageSendBehaviour<const THRESHOLD: i64>: Measure {
+pub trait MessageSendBehaviour<const THRESHOLD: u64>: Measure {
     /// This asynchronous method returns a boolean indicating whether the node identified by `did` has a satisfactory message sending behavior.
     async fn good(&self, did: Did) -> bool {
         let failed = self.get_count(did, MeasureCounter::FailedToSend).await;
-        (failed as i64) < THRESHOLD
+        failed < THRESHOLD
     }
 }
 
@@ -90,10 +238,58 @@ pub trait MessageSendBehaviour<const THRESHOLD: i64>: Measure {
 /// The "goodness" of a node is measured by comparing the received and failed-to-receive counts against a given threshold.
 #[cfg_attr(feature = "wasm", async_trait(?Send))]
 #[cfg_attr(not(feature = "wasm"), async_trait)]
-pub trait MessageRecvBehaviour<const THRESHOLD: i64>: Measure {
+pub trait MessageRecvBehaviour<const THRESHOLD: u64>: Measure {
     /// This asynchronous method returns a boolean indicating whether the node identified by `did` has a satisfactory message receiving behavior.
     async fn good(&self, did: Did) -> bool {
         let failed = self.get_count(did, MeasureCounter::FailedToReceive).await;
-        (failed as i64) < THRESHOLD
+        failed < THRESHOLD
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ecc::SecretKey;
+
+    fn did() -> Did {
+        SecretKey::random().address().into()
+    }
+
+    #[test]
+    fn peer_quality_evidence_classifies_unknown_healthy_and_degraded() {
+        let thresholds = PeerQualityThresholds::new(3, 10, 10);
+        assert_eq!(
+            PeerQualityEvidence::new(0, 0, 0, 0, 0, 0).classify(thresholds),
+            PeerQuality::Unknown
+        );
+        assert_eq!(
+            PeerQualityEvidence::new(1, 0, 0, 0, 0, 0).classify(thresholds),
+            PeerQuality::Healthy
+        );
+        assert_eq!(
+            PeerQualityEvidence::new(1, 3, 0, 0, 0, 0).classify(thresholds),
+            PeerQuality::Degraded
+        );
+        assert_eq!(
+            PeerQualityEvidence::new(1, 0, 0, 10, 0, 0).classify(thresholds),
+            PeerQuality::Degraded
+        );
+    }
+
+    #[test]
+    fn order_peers_by_quality_is_stable_permutation() {
+        let degraded = did();
+        let unknown_a = did();
+        let healthy = did();
+        let unknown_b = did();
+
+        let ordered = order_peers_by_quality([
+            (degraded, PeerQuality::Degraded),
+            (unknown_a, PeerQuality::Unknown),
+            (healthy, PeerQuality::Healthy),
+            (unknown_b, PeerQuality::Unknown),
+        ]);
+
+        assert_eq!(ordered, vec![healthy, unknown_a, unknown_b, degraded]);
     }
 }

--- a/crates/core/src/message/effects.rs
+++ b/crates/core/src/message/effects.rs
@@ -355,9 +355,10 @@ impl DhtActionFunctor {
 
 /// Natural transformation from a single DHT leaf action to Core effects.
 ///
-/// `MultiActions` preserve their old concurrent best-effort behavior in
-/// `MessageHandler::handle_dht_events`, so this function intentionally handles
-/// only the leaf actions emitted by Core DHT operations.
+/// `MultiActions` are flattened by `MessageHandler::handle_dht_events`, which
+/// can quality-order connection leaves while preserving best-effort execution.
+/// This function intentionally handles only the leaf actions emitted by Core DHT
+/// operations.
 pub(crate) fn lower_dht_action<'payload>(
     act: &PeerRingAction,
     is_connected: impl Fn(Did) -> bool,

--- a/crates/core/src/message/handlers/connection.rs
+++ b/crates/core/src/message/handlers/connection.rs
@@ -6,7 +6,6 @@ use crate::dht::PeerRingAction;
 use crate::dht::TopoInfo;
 use crate::error::Error;
 use crate::error::Result;
-use crate::message::effects::MessageSendFunctor;
 use crate::message::effects::PayloadRelayFunctor;
 use crate::message::types::ConnectNodeReport;
 use crate::message::types::ConnectNodeSend;
@@ -56,12 +55,12 @@ impl HandleMsg<QueryForTopoInfoReport> for MessageHandler {
             <QueryForTopoInfoReport as Then>::Then::Stabilization => {
                 // Establish stabilization-learned candidates first so the
                 // resulting Notify/Query actions can usually send immediately.
-                if let Some(peer) = msg.info.predecessor {
-                    self.connect_dht_peer(peer).await?;
-                }
-                for peer in msg.info.successors.iter() {
-                    self.connect_dht_peer(*peer).await?;
-                }
+                let candidates = msg
+                    .info
+                    .predecessor
+                    .into_iter()
+                    .chain(msg.info.successors.iter().copied());
+                self.connect_dht_peers(candidates).await?;
                 let ev = self.dht.stabilize(msg.info.clone())?;
                 self.handle_dht_events(&ev).await?;
             }
@@ -163,30 +162,12 @@ impl HandleMsg<FindSuccessorReport> for MessageHandler {
             FindSuccessorReportHandler::FixFingerTable { index } => {
                 self.dht.apply_fixed_finger(*index, msg.did)?;
                 if msg.reports_remote_successor(self.dht.did) {
-                    let offer_msg = self
-                        .transport
-                        .prepare_connection_offer(msg.did, self.inner_callback())
-                        .await?;
-                    self.run_effects([MessageSendFunctor::send_message(
-                        Message::ConnectNodeSend(offer_msg),
-                        msg.did,
-                    )
-                    .into()])
-                        .await?;
+                    self.connect_dht_peer(msg.did).await?;
                 }
             }
             FindSuccessorReportHandler::Connect => {
                 if msg.reports_remote_successor(self.dht.did) {
-                    let offer_msg = self
-                        .transport
-                        .prepare_connection_offer(msg.did, self.inner_callback())
-                        .await?;
-                    self.run_effects([MessageSendFunctor::send_message(
-                        Message::ConnectNodeSend(offer_msg),
-                        msg.did,
-                    )
-                    .into()])
-                        .await?;
+                    self.connect_dht_peer(msg.did).await?;
                 }
             }
             _ => {}

--- a/crates/core/src/message/handlers/mod.rs
+++ b/crates/core/src/message/handlers/mod.rs
@@ -88,6 +88,17 @@ impl MessageHandler {
             .await
     }
 
+    /// Idempotently establish DHT-driven transport connections in local quality order.
+    pub(crate) async fn connect_dht_peers(
+        &self,
+        peers: impl IntoIterator<Item = Did>,
+    ) -> Result<()> {
+        for peer in self.transport.order_dht_candidates_by_quality(peers).await {
+            self.connect_dht_peer(peer).await?;
+        }
+        Ok(())
+    }
+
     pub(crate) async fn join_dht(&self, peer: Did) -> Result<()> {
         // Default HMCC/Zave join path: maps to the JoinThenSync operation in
         // the CorrectChord spec (see tests/default/dht_convergence.rs).
@@ -128,28 +139,71 @@ impl MessageHandler {
         Ok(())
     }
 
-    #[cfg_attr(feature = "wasm", async_recursion(?Send))]
-    #[cfg_attr(not(feature = "wasm"), async_recursion)]
-    pub(crate) async fn handle_dht_events(&self, act: &PeerRingAction) -> Result<()> {
+    fn collect_dht_effects(
+        &self,
+        act: &PeerRingAction,
+        effects: &mut Vec<CoreEffect<'static>>,
+    ) -> Result<()> {
         match act {
             PeerRingAction::MultiActions(acts) => {
-                let jobs = acts
-                    .iter()
-                    .map(|act| async move { self.handle_dht_events(act).await });
-
-                for res in futures::future::join_all(jobs).await {
-                    if res.is_err() {
-                        tracing::error!("Failed on handle multi actions: {:#?}", res)
-                    }
+                for act in acts {
+                    self.collect_dht_effects(act, effects)?;
                 }
-
                 Ok(())
             }
             act => {
-                let effects =
-                    lower_dht_action(act, |did| self.transport.get_connection(did).is_some())?;
-                self.run_effects(effects).await
+                if let Some(effect) =
+                    lower_dht_action(act, |did| self.transport.get_connection(did).is_some())?
+                {
+                    effects.push(effect);
+                }
+                Ok(())
             }
+        }
+    }
+
+    async fn run_prioritized_dht_effects(&self, effects: Vec<CoreEffect<'static>>) -> Result<()> {
+        let mut connection_peers = Vec::new();
+        let mut other_effects = Vec::new();
+        for effect in effects {
+            match effect {
+                CoreEffect::Connection(ConnectionFunctor::ConnectDhtPeer { peer }) => {
+                    connection_peers.push(peer);
+                }
+                effect => other_effects.push(effect),
+            }
+        }
+
+        for peer in self
+            .transport
+            .order_dht_candidates_by_quality(connection_peers)
+            .await
+        {
+            if let Err(e) = self.connect_dht_peer(peer).await {
+                tracing::error!("Failed on handle multi connection action: {e:?}");
+            }
+        }
+
+        for effect in other_effects {
+            if let Err(e) = self.run_effects([effect]).await {
+                tracing::error!("Failed on handle multi action: {e:?}");
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(feature = "wasm", async_recursion(?Send))]
+    #[cfg_attr(not(feature = "wasm"), async_recursion)]
+    pub(crate) async fn handle_dht_events(&self, act: &PeerRingAction) -> Result<()> {
+        if matches!(act, PeerRingAction::MultiActions(_)) {
+            let mut effects = Vec::new();
+            self.collect_dht_effects(act, &mut effects)?;
+            self.run_prioritized_dht_effects(effects).await
+        } else {
+            let effects =
+                lower_dht_action(act, |did| self.transport.get_connection(did).is_some())?;
+            self.run_effects(effects).await
         }
     }
 }

--- a/crates/core/src/swarm/callback.rs
+++ b/crates/core/src/swarm/callback.rs
@@ -154,10 +154,29 @@ impl InnerSwarmCallback {
 #[cfg_attr(not(feature = "wasm"), async_trait)]
 impl TransportCallback for InnerSwarmCallback {
     async fn on_message(&self, cid: &str, msg: &[u8]) -> Result<(), CallbackError> {
-        let payload = MessagePayload::from_bincode(msg)?;
+        let peer = Did::from_str(cid).ok();
+        let payload = match MessagePayload::from_bincode(msg) {
+            Ok(payload) => payload,
+            Err(e) => {
+                if let Some(peer) = peer {
+                    self.transport
+                        .record_peer_message_receive_failed(peer)
+                        .await;
+                }
+                return Err(e.into());
+            }
+        };
         if !(payload.verify() && payload.transaction.verify()) {
             tracing::error!("Cannot verify msg or it's expired: {:?}", payload);
+            if let Some(peer) = peer {
+                self.transport
+                    .record_peer_message_receive_failed(peer)
+                    .await;
+            }
             return Err("Cannot verify msg or it's expired".into());
+        }
+        if let Some(peer) = peer {
+            self.transport.record_peer_message_received(peer).await;
         }
         self.callback.on_validate(&payload).await?;
         self.handle_payload(cid, &payload).await
@@ -177,6 +196,7 @@ impl TransportCallback for InnerSwarmCallback {
             // `Failed` and `Closed` are terminal states, so we remove the peer
             // from the DHT here.
             WebrtcConnectionState::Failed | WebrtcConnectionState::Closed => {
+                self.transport.record_peer_disconnected(did).await;
                 self.message_handler.leave_dht(did).await?;
             }
             // `Disconnected` is a transient ICE state that frequently recovers
@@ -186,6 +206,7 @@ impl TransportCallback for InnerSwarmCallback {
             // with no reconnect path. We leave it alone: it will either recover,
             // or degrade to `Failed`, which is handled above.
             WebrtcConnectionState::Disconnected => {
+                self.transport.record_peer_disconnected(did).await;
                 tracing::info!("Connection to {did} is disconnected, waiting for recovery");
             }
             _ => {}
@@ -212,6 +233,7 @@ impl TransportCallback for InnerSwarmCallback {
             return Ok(());
         };
 
+        self.transport.record_peer_connected(did).await;
         self.message_handler.join_dht(did).await?;
 
         // Notify Connected state here instead of on_peer_connection_state_change.
@@ -236,6 +258,7 @@ impl TransportCallback for InnerSwarmCallback {
         // instead of waiting for the ICE state to reach `Failed`. This is the
         // graceful counterpart to a local `disconnect()`: the remote learns of
         // it promptly without relying on the transient `Disconnected` state.
+        self.transport.record_peer_disconnected(did).await;
         self.message_handler.leave_dht(did).await?;
         Ok(())
     }

--- a/crates/core/src/swarm/transport.rs
+++ b/crates/core/src/swarm/transport.rs
@@ -39,7 +39,10 @@ use crate::dht::LiveDid;
 use crate::dht::PeerRing;
 use crate::error::Error;
 use crate::error::Result;
+use crate::measure::order_peers_by_quality;
+use crate::measure::MeasureCounter;
 use crate::measure::MeasureImpl;
+use crate::measure::PeerQuality;
 use crate::message::ConnectNodeReport;
 use crate::message::ConnectNodeSend;
 use crate::message::Message;
@@ -68,7 +71,7 @@ pub struct SwarmTransport {
     storage_redundancy: u16,
     reassembly_limits: ReassemblyLimits,
     storage_lookup_observations: Mutex<StorageLookupObservationMap>,
-    #[allow(dead_code)]
+    measured_disconnects: Mutex<BTreeSet<Did>>,
     measure: Option<MeasureImpl>,
 }
 
@@ -158,26 +161,40 @@ pub struct SwarmConnection {
     pub connection: ConnectionRef<ConnectionOwner>,
 }
 
-/// Drive a message's [DeliveryFuture] to completion on the runtime, logging if
-/// the message was lost before it could be flushed. This keeps delivery
-/// tracking confined to the send site: the status never propagates up through
-/// the swarm/node layers.
+async fn record_measurement(measure: Option<MeasureImpl>, did: Did, counter: MeasureCounter) {
+    if let Some(measure) = measure {
+        measure.incr(did, counter).await;
+    }
+}
+
+/// Drive a message's [DeliveryFuture] to completion on the runtime, recording
+/// the eventual peer-quality observation. This keeps delivery tracking confined
+/// to the send site: the status never propagates up through the swarm/node
+/// layers.
 #[cfg(feature = "wasm")]
-fn spawn_delivery(fut: DeliveryFuture, did: Did) {
+fn spawn_delivery(fut: DeliveryFuture, did: Did, measure: Option<MeasureImpl>) {
     wasm_bindgen_futures::spawn_local(async move {
-        if let Err(e) = fut.await {
-            tracing::warn!("Message to {did} was not delivered: {e}");
+        match fut.await {
+            Ok(()) => record_measurement(measure, did, MeasureCounter::Sent).await,
+            Err(e) => {
+                tracing::warn!("Message to {did} was not delivered: {e}");
+                record_measurement(measure, did, MeasureCounter::FailedToSend).await;
+            }
         }
     });
 }
 
-/// Drive a message's [DeliveryFuture] to completion on the runtime, logging if
-/// the message was lost before it could be flushed.
+/// Drive a message's [DeliveryFuture] to completion on the runtime, recording
+/// the eventual peer-quality observation.
 #[cfg(not(feature = "wasm"))]
-fn spawn_delivery(fut: DeliveryFuture, did: Did) {
+fn spawn_delivery(fut: DeliveryFuture, did: Did, measure: Option<MeasureImpl>) {
     tokio::spawn(async move {
-        if let Err(e) = fut.await {
-            tracing::warn!("Message to {did} was not delivered: {e}");
+        match fut.await {
+            Ok(()) => record_measurement(measure, did, MeasureCounter::Sent).await,
+            Err(e) => {
+                tracing::warn!("Message to {did} was not delivered: {e}");
+                record_measurement(measure, did, MeasureCounter::FailedToSend).await;
+            }
         }
     });
 }
@@ -208,9 +225,11 @@ async fn run_chunked_send(
     first_delivery: DeliveryFuture,
     session_sk: SessionSk,
     did: Did,
+    measure: Option<MeasureImpl>,
 ) {
     if let Err(e) = first_delivery.await {
         tracing::warn!("Chunked send to {did} stopped before the first chunk flushed: {e}");
+        record_measurement(measure, did, MeasureCounter::FailedToSend).await;
         return;
     }
     for chunk in tail {
@@ -225,15 +244,18 @@ async fn run_chunked_send(
             Ok(delivery) => {
                 if let Err(e) = delivery.await {
                     tracing::warn!("Chunked send to {did} stopped before flush: {e}");
+                    record_measurement(measure, did, MeasureCounter::FailedToSend).await;
                     return;
                 }
             }
             Err(e) => {
                 tracing::warn!("Chunked send to {did} stopped: {e}");
+                record_measurement(measure, did, MeasureCounter::FailedToSend).await;
                 return;
             }
         }
     }
+    record_measurement(measure, did, MeasureCounter::Sent).await;
 }
 
 /// Drive the tail of a chunked send on the runtime (one bounded task per large message). See
@@ -245,6 +267,7 @@ fn spawn_chunked_send(
     first_delivery: DeliveryFuture,
     session_sk: SessionSk,
     did: Did,
+    measure: Option<MeasureImpl>,
 ) {
     wasm_bindgen_futures::spawn_local(run_chunked_send(
         conn,
@@ -252,6 +275,7 @@ fn spawn_chunked_send(
         first_delivery,
         session_sk,
         did,
+        measure,
     ));
 }
 
@@ -264,6 +288,7 @@ fn spawn_chunked_send(
     first_delivery: DeliveryFuture,
     session_sk: SessionSk,
     did: Did,
+    measure: Option<MeasureImpl>,
 ) {
     tokio::spawn(run_chunked_send(
         conn,
@@ -271,6 +296,7 @@ fn spawn_chunked_send(
         first_delivery,
         session_sk,
         did,
+        measure,
     ));
 }
 
@@ -295,6 +321,7 @@ impl SwarmTransport {
             storage_redundancy: settings.storage_redundancy,
             reassembly_limits: settings.reassembly_limits,
             storage_lookup_observations: Mutex::new(BTreeMap::new()),
+            measured_disconnects: Mutex::new(BTreeSet::new()),
             measure,
         }
     }
@@ -307,6 +334,84 @@ impl SwarmTransport {
     /// Chunk reassembly limits enforced by inbound callbacks.
     pub(crate) fn reassembly_limits(&self) -> ReassemblyLimits {
         self.reassembly_limits
+    }
+
+    async fn record_peer_measurement(&self, peer: Did, counter: MeasureCounter) {
+        record_measurement(self.measure.clone(), peer, counter).await;
+    }
+
+    /// Record that `peer` reached an open data channel.
+    pub(crate) async fn record_peer_connected(&self, peer: Did) {
+        match self.measured_disconnects.lock() {
+            Ok(mut measured) => {
+                measured.remove(&peer);
+            }
+            Err(_) => {
+                tracing::warn!("Failed to update disconnect epoch for connected peer {peer}");
+            }
+        }
+        self.record_peer_measurement(peer, MeasureCounter::Connect)
+            .await;
+    }
+
+    /// Record that `peer` left the usable connection epoch.
+    ///
+    /// Invariant: for one connection epoch, at most one `Disconnected` counter is
+    /// recorded. `record_peer_connected` starts a new epoch by clearing the marker.
+    pub(crate) async fn record_peer_disconnected(&self, peer: Did) {
+        let should_record = match self.measured_disconnects.lock() {
+            Ok(mut measured) => measured.insert(peer),
+            Err(_) => {
+                tracing::warn!("Failed to update disconnect epoch for disconnected peer {peer}");
+                true
+            }
+        };
+        if should_record {
+            self.record_peer_measurement(peer, MeasureCounter::Disconnected)
+                .await;
+        }
+    }
+
+    /// Record that a payload from `peer` was accepted and verified by the swarm.
+    pub(crate) async fn record_peer_message_received(&self, peer: Did) {
+        self.record_peer_measurement(peer, MeasureCounter::Received)
+            .await;
+    }
+
+    /// Record that a payload from `peer` could not be decoded or verified.
+    pub(crate) async fn record_peer_message_receive_failed(&self, peer: Did) {
+        self.record_peer_measurement(peer, MeasureCounter::FailedToReceive)
+            .await;
+    }
+
+    /// Record that an outbound payload to `peer` failed before delivery.
+    pub(crate) async fn record_peer_message_send_failed(&self, peer: Did) {
+        self.record_peer_measurement(peer, MeasureCounter::FailedToSend)
+            .await;
+    }
+
+    /// Return this node's local quality judgement for `peer`.
+    pub(crate) async fn peer_quality(&self, peer: Did) -> PeerQuality {
+        match &self.measure {
+            Some(measure) => measure.quality(peer).await,
+            None => PeerQuality::Unknown,
+        }
+    }
+
+    /// Order DHT-produced connection candidates by local quality evidence.
+    ///
+    /// Invariant: this is a stable permutation of the DHT-produced candidate
+    /// sequence. It changes attempt order only; it never changes Chord ownership,
+    /// successor responsibility, or storage placement.
+    pub(crate) async fn order_dht_candidates_by_quality(
+        &self,
+        candidates: impl IntoIterator<Item = Did>,
+    ) -> Vec<Did> {
+        let mut measured = Vec::new();
+        for did in candidates {
+            measured.push((did, self.peer_quality(did).await));
+        }
+        order_peers_by_quality(measured)
     }
 
     /// Ensure the storage API redundancy matches repair redundancy.
@@ -507,7 +612,14 @@ impl SwarmTransport {
     /// Connect a given Did. If the did is already connected, return Err,
     /// else try prepare offer and establish connection by dht.
     pub async fn connect(&self, peer: Did, callback: InnerSwarmCallback) -> Result<()> {
-        let offer_msg = self.prepare_connection_offer(peer, callback).await?;
+        let offer_msg = match self.prepare_connection_offer(peer, callback).await {
+            Ok(offer_msg) => offer_msg,
+            Err(Error::AlreadyConnected) => return Err(Error::AlreadyConnected),
+            Err(e) => {
+                self.record_peer_message_send_failed(peer).await;
+                return Err(e);
+            }
+        };
         self.send_message(Message::ConnectNodeSend(offer_msg), peer)
             .await?;
         Ok(())
@@ -670,10 +782,10 @@ impl PayloadSender for SwarmTransport {
     }
 
     async fn do_send_payload(&self, did: Did, payload: MessagePayload) -> Result<()> {
-        let conn = self
-            .get_and_check_connection(did)
-            .await
-            .ok_or(Error::SwarmMissDidInTable(did))?;
+        let Some(conn) = self.get_and_check_connection(did).await else {
+            self.record_peer_message_send_failed(did).await;
+            return Err(Error::SwarmMissDidInTable(did));
+        };
 
         tracing::debug!(
             "Try send {:?}, to node {:?}",
@@ -696,11 +808,18 @@ impl PayloadSender for SwarmTransport {
         // `DeliveryFuture` to the runtime, and a chunked message is driven by one bounded background
         // task (one chunk in flight; see `run_chunked_send`), so a large payload never blocks the
         // caller's path while keeping memory and the runtime task count bounded.
-        let plan = WireReserves::PRODUCTION
-            .plan(data.len(), conn.max_message_size())
-            .ok_or(Error::PeerMaxMessageSizeTooSmall(conn.max_message_size()))?;
+        let Some(plan) = WireReserves::PRODUCTION.plan(data.len(), conn.max_message_size()) else {
+            self.record_peer_message_send_failed(did).await;
+            return Err(Error::PeerMaxMessageSizeTooSmall(conn.max_message_size()));
+        };
         match plan {
-            Framing::Whole => spawn_delivery(conn.send_data(data).await?, did),
+            Framing::Whole => match conn.send_data(data).await {
+                Ok(delivery) => spawn_delivery(delivery, did, self.measure.clone()),
+                Err(e) => {
+                    self.record_peer_message_send_failed(did).await;
+                    return Err(e);
+                }
+            },
             Framing::Chunked { chunk_size } => {
                 // Frame and accept the FIRST chunk on the caller's path, so an immediate send
                 // failure (the buffer rejecting the bytes) surfaces here exactly as it does for a
@@ -710,14 +829,22 @@ impl PayloadSender for SwarmTransport {
                 let mut chunks = ChunkList::stream(data, chunk_size);
                 if let Some(first) = chunks.next() {
                     let first = frame_chunk(&self.session_sk, did, first)?;
-                    let first_delivery = conn.send_data(first).await?;
-                    spawn_chunked_send(
-                        conn,
-                        Box::new(chunks),
-                        first_delivery,
-                        self.session_sk.clone(),
-                        did,
-                    );
+                    match conn.send_data(first).await {
+                        Ok(first_delivery) => {
+                            spawn_chunked_send(
+                                conn,
+                                Box::new(chunks),
+                                first_delivery,
+                                self.session_sk.clone(),
+                                did,
+                                self.measure.clone(),
+                            );
+                        }
+                        Err(e) => {
+                            self.record_peer_message_send_failed(did).await;
+                            return Err(e);
+                        }
+                    }
                 }
             }
         }
@@ -745,3 +872,6 @@ impl From<SwarmConnection> for Did {
         conn.peer
     }
 }
+
+#[cfg(all(test, not(feature = "wasm")))]
+mod tests;

--- a/crates/core/src/swarm/transport/tests.rs
+++ b/crates/core/src/swarm/transport/tests.rs
@@ -1,0 +1,121 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use super::*;
+use crate::dht::DEFAULT_FINGER_TABLE_SIZE;
+use crate::ecc::SecretKey;
+use crate::measure::BehaviourJudgement;
+use crate::measure::Measure;
+use crate::storage::MemStorage;
+
+#[derive(Default)]
+struct RecordingMeasure {
+    counters: Mutex<Vec<(Did, MeasureCounter)>>,
+    qualities: Mutex<BTreeMap<Did, PeerQuality>>,
+}
+
+impl RecordingMeasure {
+    fn snapshot_counters(&self) -> std::io::Result<Vec<(Did, MeasureCounter)>> {
+        self.counters
+            .lock()
+            .map(|counters| counters.clone())
+            .map_err(|_| std::io::Error::other("counters poisoned"))
+    }
+
+    fn set_quality(&self, did: Did, quality: PeerQuality) -> std::io::Result<()> {
+        self.qualities
+            .lock()
+            .map(|mut qualities| {
+                qualities.insert(did, quality);
+            })
+            .map_err(|_| std::io::Error::other("qualities poisoned"))
+    }
+}
+
+#[async_trait]
+impl Measure for RecordingMeasure {
+    async fn incr(&self, did: Did, counter: MeasureCounter) {
+        match self.counters.lock() {
+            Ok(mut counters) => counters.push((did, counter)),
+            Err(_) => tracing::error!("RecordingMeasure counters mutex is poisoned"),
+        }
+    }
+
+    async fn get_count(&self, _did: Did, _counter: MeasureCounter) -> u64 {
+        0
+    }
+}
+
+#[async_trait]
+impl BehaviourJudgement for RecordingMeasure {
+    async fn quality(&self, did: Did) -> PeerQuality {
+        match self.qualities.lock() {
+            Ok(qualities) => qualities.get(&did).copied().unwrap_or(PeerQuality::Unknown),
+            Err(_) => {
+                tracing::error!("RecordingMeasure qualities mutex is poisoned");
+                PeerQuality::Unknown
+            }
+        }
+    }
+}
+
+fn transport_with_measure(measure: MeasureImpl) -> Result<SwarmTransport> {
+    let key = SecretKey::random();
+    let session_sk = SessionSk::new_with_seckey(&key)?;
+    let dht = Arc::new(PeerRing::new_with_storage_and_finger_table_size(
+        session_sk.account_did(),
+        3,
+        Box::new(MemStorage::new()),
+        DEFAULT_FINGER_TABLE_SIZE,
+    ));
+    Ok(SwarmTransport::new(
+        0,
+        SwarmWebrtcConfig::new("".to_string(), None, None),
+        session_sk,
+        dht,
+        Some(measure),
+        SwarmTransportSettings::new(1, ReassemblyLimits::production()),
+    ))
+}
+
+#[tokio::test]
+async fn disconnected_observation_is_once_per_connection_epoch() -> Result<()> {
+    let measure = Arc::new(RecordingMeasure::default());
+    let transport = transport_with_measure(measure.clone())?;
+    let peer = SecretKey::random().address().into();
+
+    transport.record_peer_disconnected(peer).await;
+    transport.record_peer_disconnected(peer).await;
+    transport.record_peer_connected(peer).await;
+    transport.record_peer_disconnected(peer).await;
+
+    assert_eq!(measure.snapshot_counters()?.as_slice(), &[
+        (peer, MeasureCounter::Disconnected),
+        (peer, MeasureCounter::Connect),
+        (peer, MeasureCounter::Disconnected),
+    ]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn dht_candidate_order_uses_peer_quality_without_dropping_candidates() -> Result<()> {
+    let degraded = SecretKey::random().address().into();
+    let unknown = SecretKey::random().address().into();
+    let healthy = SecretKey::random().address().into();
+    let measure = Arc::new(RecordingMeasure::default());
+    measure.set_quality(degraded, PeerQuality::Degraded)?;
+    measure.set_quality(healthy, PeerQuality::Healthy)?;
+    let transport = transport_with_measure(measure)?;
+
+    let ordered = transport
+        .order_dht_candidates_by_quality([degraded, unknown, healthy])
+        .await;
+
+    assert_eq!(ordered, vec![healthy, unknown, degraded]);
+
+    Ok(())
+}

--- a/crates/core/src/swarm/transport/tests.rs
+++ b/crates/core/src/swarm/transport/tests.rs
@@ -60,6 +60,10 @@ impl BehaviourJudgement for RecordingMeasure {
             }
         }
     }
+
+    async fn good(&self, _did: Did) -> bool {
+        true
+    }
 }
 
 fn transport_with_measure(measure: MeasureImpl) -> Result<SwarmTransport> {

--- a/crates/derive/src/derives.rs
+++ b/crates/derive/src/derives.rs
@@ -4,13 +4,13 @@ pub fn impl_measure_behaviour_traits(ast: &syn::DeriveInput) -> proc_macro2::Tok
     let impl_token = quote! {
     #[cfg_attr(feature = "node", async_trait)]
     #[cfg_attr(feature = "browser", async_trait(?Send))]
-    impl<const T: i64> MessageSendBehaviour<T> for #name {}
+    impl<const T: u64> MessageSendBehaviour<T> for #name {}
     #[cfg_attr(feature = "node", async_trait)]
     #[cfg_attr(feature = "browser", async_trait(?Send))]
-    impl<const T: i64> MessageRecvBehaviour<T> for #name {}
+    impl<const T: u64> MessageRecvBehaviour<T> for #name {}
     #[cfg_attr(feature = "node", async_trait)]
     #[cfg_attr(feature = "browser", async_trait(?Send))]
-    impl<const T: i64> ConnectBehaviour<T> for #name {}
+    impl<const T: u64> ConnectBehaviour<T> for #name {}
     };
 
     #[cfg(not(feature = "core_crate"))]

--- a/crates/node/src/consts.rs
+++ b/crates/node/src/consts.rs
@@ -4,10 +4,10 @@ pub const BACKEND_MTU: usize = TRANSPORT_MAX_SIZE - TRANSPORT_MTU;
 /// Redundant setting of entry data storage
 pub const DATA_REDUNDANT: u16 = 6;
 /// Connect Behaviour
-pub const CONNECT_FAILED_LIMIT: i64 = 3;
+pub const CONNECT_FAILED_LIMIT: u64 = 3;
 /// Message Send Behaviour
-pub const MSG_SEND_FAILED_LIMIT: i64 = 10;
+pub const MSG_SEND_FAILED_LIMIT: u64 = 10;
 /// Message Received Behaviour
-pub const MSG_RECV_FAILED_LIMIT: i64 = 10;
+pub const MSG_RECV_FAILED_LIMIT: u64 = 10;
 /// Timeout for proxied TCP connections
 pub const TCP_SERVER_TIMEOUT: u64 = 30;

--- a/crates/node/src/measure.rs
+++ b/crates/node/src/measure.rs
@@ -222,6 +222,22 @@ impl measure::BehaviourJudgement for PeriodicMeasure {
             .await
             .classify(thresholds)
     }
+
+    async fn good(&self, did: Did) -> bool {
+        let connection_is_good = <Self as measure::ConnectBehaviour<
+            { crate::consts::CONNECT_FAILED_LIMIT },
+        >>::good(self, did)
+        .await;
+        let send_is_good = <Self as measure::MessageSendBehaviour<
+            { crate::consts::MSG_SEND_FAILED_LIMIT },
+        >>::good(self, did)
+        .await;
+        let receive_is_good = <Self as measure::MessageRecvBehaviour<
+            { crate::consts::MSG_RECV_FAILED_LIMIT },
+        >>::good(self, did)
+        .await;
+        connection_is_good && send_is_good && receive_is_good
+    }
 }
 
 #[cfg(test)]
@@ -406,7 +422,6 @@ mod tests {
         }
 
         assert_eq!(measure.quality(did).await, PeerQuality::Degraded);
-        assert!(!BehaviourJudgement::good(&measure, did).await);
         Ok(())
     }
 }

--- a/crates/node/src/measure.rs
+++ b/crates/node/src/measure.rs
@@ -15,6 +15,9 @@ use rings_core::dht::Did;
 use rings_core::measure;
 use rings_core::measure::Measure;
 use rings_core::measure::MeasureCounter;
+use rings_core::measure::PeerQuality;
+use rings_core::measure::PeerQualityEvidence;
+use rings_core::measure::PeerQualityThresholds;
 use rings_core::storage::KvStorageInterface;
 use rings_derive::MeasureBehaviour;
 
@@ -209,10 +212,15 @@ impl Measure for PeriodicMeasure {
 #[cfg_attr(feature = "node", async_trait)]
 #[cfg_attr(feature = "browser", async_trait(?Send))]
 impl measure::BehaviourJudgement for PeriodicMeasure {
-    async fn good(&self, did: Did) -> bool {
-        <Self as measure::ConnectBehaviour<{crate::consts::CONNECT_FAILED_LIMIT}>>::good(self, did).await &&
-	    <Self as measure::MessageSendBehaviour<{crate::consts::MSG_SEND_FAILED_LIMIT}>>::good(self, did).await &&
-            <Self as measure::MessageRecvBehaviour<{crate::consts::MSG_RECV_FAILED_LIMIT}>>::good(self, did).await
+    async fn quality(&self, did: Did) -> PeerQuality {
+        let thresholds = PeerQualityThresholds::new(
+            crate::consts::CONNECT_FAILED_LIMIT,
+            crate::consts::MSG_SEND_FAILED_LIMIT,
+            crate::consts::MSG_RECV_FAILED_LIMIT,
+        );
+        PeerQualityEvidence::from_measure(self, did)
+            .await
+            .classify(thresholds)
     }
 }
 
@@ -223,6 +231,7 @@ mod tests {
     use std::sync::Arc;
     use std::sync::Mutex;
 
+    use rings_core::measure::BehaviourJudgement;
     use rings_core::storage::sled::SledStorage;
     use rings_core::storage::MemStorage;
 
@@ -377,5 +386,27 @@ mod tests {
         // Will take previous count from storage.
         assert_eq!(measure2.get_count(did, MeasureCounter::Sent).await, 2);
         assert_eq!(measure2.get_count(did, MeasureCounter::Received).await, 1);
+    }
+
+    #[tokio::test]
+    async fn repeated_disconnections_degrade_peer_quality(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let ms = Box::new(MemStorage::new());
+        let did = Did::from_str("0x11E807fcc88dD319270493fB2e822e388Fe36ab0")?;
+        let clock = ManualMeasureClock::new(Utc::now());
+        let measure = PeriodicMeasure::new_with_clock(ms, Arc::new(clock));
+
+        assert_eq!(measure.quality(did).await, PeerQuality::Unknown);
+
+        measure.incr(did, MeasureCounter::Connect).await;
+        assert_eq!(measure.quality(did).await, PeerQuality::Healthy);
+
+        for _ in 0..crate::consts::CONNECT_FAILED_LIMIT {
+            measure.incr(did, MeasureCounter::Disconnected).await;
+        }
+
+        assert_eq!(measure.quality(did).await, PeerQuality::Degraded);
+        assert!(!BehaviourJudgement::good(&measure, did).await);
+        Ok(())
     }
 }

--- a/crates/node/src/processor.rs
+++ b/crates/node/src/processor.rs
@@ -286,7 +286,7 @@ impl ProcessorBuilder {
 
     /// Set the measure for the processor.
     pub fn measure(mut self, implement: PeriodicMeasure) -> Self {
-        self.measure = Some(Box::new(implement));
+        self.measure = Some(Arc::new(implement));
         self
     }
 

--- a/examples/dweb/Cargo.lock
+++ b/examples/dweb/Cargo.lock
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "rings-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "rings-derive"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "rings-node"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "rings-rpc"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "rings-transport"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bincode",

--- a/examples/proof-demo/Cargo.lock
+++ b/examples/proof-demo/Cargo.lock
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "rings-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "rings-derive"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "rings-node"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "rings-rpc"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -4044,7 +4044,7 @@ dependencies = [
 
 [[package]]
 name = "rings-snark"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bellpepper-core",
  "byteorder",
@@ -4072,7 +4072,7 @@ dependencies = [
 
 [[package]]
 name = "rings-transport"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bincode",


### PR DESCRIPTION
## Summary

- closes #639
- add an advisory peer-quality model derived from existing measure counters
- record peer observations at transport/callback side-effect boundaries
- order DHT-produced connection candidates by local quality without changing Chord ownership, successor, or storage placement semantics
- bump the workspace and tracked lockfiles to 0.12.0

## Correctness notes

- `PeerQuality` is local evidence only: `Healthy`, `Unknown`, or `Degraded`.
- Candidate ordering is a stable permutation, so it changes connection attempt order only.
- Disconnect observations are bounded to one `Disconnected` counter per connection epoch.
- Send/receive observations are recorded at transport delivery and callback validation boundaries.

## Validation

- `cargo +nightly fmt --check`
- `cargo test -p rings-core --features dummy measure::tests -- --nocapture`
- `cargo test -p rings-core --features dummy swarm::transport::tests -- --nocapture`
- `cargo test -p rings-node --features node measure::tests -- --nocapture`
- `cargo test -p rings-core --features dummy test_message_handler -- --nocapture`
- `cargo test -p rings-core --features dummy test_stabilization -- --nocapture`
- `cargo test -p rings-core --features dummy dht_schedule -- --nocapture`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo clippy -p rings-core --features wasm --no-deps --no-default-features --target=wasm32-unknown-unknown --tests -- -D warnings`
- `cargo clippy -p rings-node --features browser_default --no-deps --no-default-features --target=wasm32-unknown-unknown --tests -- -D warnings`
- `git diff --check`
- `rg "0\\.11\\.0" Cargo.toml Cargo.lock crates examples -S`
