### PR TITLE
Update repository links for RingsNetwork migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.14.0"
 edition = "2021"
 license = "GPL-3.0"
 authors = ["RND <dev@ringsnetwork.io>"]
-repository = "https://github.com/RyanKung/rings"
+repository = "https://github.com/RingsNetwork/rings"
 
 [workspace.dependencies]
 async-trait = "0.1.77"

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 Rings Network
 ===============
 
-[![rings-node](https://github.com/RyanKung/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RyanKung/rings/actions/workflows/auto-release.yml)
+[![rings-node](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml)
 [![cargo](https://img.shields.io/crates/v/rings-node.svg)](https://crates.io/crates/rings-node)
 [![docs](https://docs.rs/rings-node/badge.svg)](https://docs.rs/rings-node/latest/rings_node/)
-![GitHub](https://img.shields.io/github/license/RyanKung/rings)
+![GitHub](https://img.shields.io/github/license/RingsNetwork/rings)
 [![Sponsor](https://img.shields.io/badge/Sponsor-RingsNetwork-ea4aaa?logo=githubsponsors)](https://github.com/sponsors/RingsNetwork)
 
 **A peer-to-peer network for the sovereign age.**
@@ -41,8 +41,8 @@ If you cite Rings in academic or technical writing, use:
   title = {Rings: A peer-to-peer network for sovereign age},
   year = {2023},
   month = feb,
-  url = {https://github.com/RyanKung/rings/blob/master/papers/rings.pdf},
-  note = {Repository-owned whitepaper and LaTeX source: https://github.com/RyanKung/rings/tree/master/papers}
+  url = {https://github.com/RingsNetwork/rings/blob/master/papers/rings.pdf},
+  note = {Repository-owned whitepaper and LaTeX source: https://github.com/RingsNetwork/rings/tree/master/papers}
 }
 ```
 
@@ -90,7 +90,7 @@ cargo install rings-node
 Install the CLI from a local checkout:
 
 ```sh
-git clone git@github.com:RyanKung/rings.git
+git clone git@github.com:RingsNetwork/rings.git
 cd ./rings
 cargo install --path crates/node
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,6 +73,6 @@ The substrate both layers build on:
 ## Contributing to the roadmap
 
 Direction is shaped through RFCs and issues on
-[GitHub](https://github.com/RyanKung/rings/issues). If you want to help build either
+[GitHub](https://github.com/RingsNetwork/rings/issues). If you want to help build either
 layer, an extension protocol is the lightest way in — see **Extending Rings** in the
 [README](./README.md).

--- a/cliff.toml
+++ b/cliff.toml
@@ -46,7 +46,7 @@ footer = """
 trim = true
 # postprocessors
 postprocessors = [
-  { pattern = '<REPO>', replace = "https://github.com/RyanKung/rings" },
+  { pattern = '<REPO>', replace = "https://github.com/RingsNetwork/rings" },
 ]
 
 [git]

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -1,13 +1,13 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RyanKung/rings/master/assets/logo/rings_network_red.png">
-  <img alt="Rings Network" src="https://raw.githubusercontent.com/RyanKung/rings/master/assets/logo/rings_network_black.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RingsNetwork/rings/master/assets/logo/rings_network_red.png">
+  <img alt="Rings Network" src="https://raw.githubusercontent.com/RingsNetwork/rings/master/assets/logo/rings_network_black.svg">
 </picture>
 
 
 Rings Core
 ===============
 
-[![rings-node](https://github.com/RyanKung/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RyanKung/rings/actions/workflows/auto-release.yml)
+[![rings-node](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml)
 [![cargo](https://img.shields.io/crates/v/rings-core.svg)](https://crates.io/crates/rings-node)
 [![docs](https://docs.rs/rings-core/badge.svg)](https://docs.rs/rings-node/latest/rings_node/)
 
@@ -36,7 +36,7 @@ Assuming Node A and Node B want to create a WebRTC connection, they would need t
 
 For native implementation, the transport layer is based on `webrtc.rs`, and for browser case, we implemented based on `web_sys` and `wasm_bindgen`.
 
-To check the implementation of transport layer: https://github.com/RyanKung/rings/tree/master/crates/transport
+To check the implementation of transport layer: https://github.com/RingsNetwork/rings/tree/master/crates/transport
 
 
 #### Network Layer

--- a/crates/derive/README.md
+++ b/crates/derive/README.md
@@ -1,9 +1,9 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RyanKung/rings/master/assets/logo/rings_network_red.png">
-  <img alt="Rings Network" src="https://raw.githubusercontent.com/RyanKung/rings/master/assets/logo/rings_network_black.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RingsNetwork/rings/master/assets/logo/rings_network_red.png">
+  <img alt="Rings Network" src="https://raw.githubusercontent.com/RingsNetwork/rings/master/assets/logo/rings_network_black.svg">
 </picture>
 
 Rings Derive
 ===============
 
-[![rings-node](https://github.com/RyanKung/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RyanKung/rings/actions/workflows/auto-release.yml)
+[![rings-node](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml)

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -1,15 +1,15 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RyanKung/rings/master/assets/logo/rings_network_red.png">
-  <img alt="Rings Network" src="https://raw.githubusercontent.com/RyanKung/rings/master/assets/logo/rings_network_black.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RingsNetwork/rings/master/assets/logo/rings_network_red.png">
+  <img alt="Rings Network" src="https://raw.githubusercontent.com/RingsNetwork/rings/master/assets/logo/rings_network_black.svg">
 </picture>
 
 Rings Node (The node service of Rings Network)
 ===============
 
-[![rings-node](https://github.com/RyanKung/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RyanKung/rings/actions/workflows/auto-release.yml)
+[![rings-node](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml)
 [![cargo](https://img.shields.io/crates/v/rings-node.svg)](https://crates.io/crates/rings-node)
 [![docs](https://docs.rs/rings-node/badge.svg)](https://docs.rs/rings-node/latest/rings_node/)
-![GitHub](https://img.shields.io/github/license/RyanKung/rings)
+![GitHub](https://img.shields.io/github/license/RingsNetwork/rings)
 
 
 Rings is a structured peer-to-peer network implementation using WebRTC, Chord algorithm, and full WebAssembly (WASM) support.
@@ -33,9 +33,9 @@ cargo install rings-node
 To install rings-node from source, follow these steps:
 
 ```sh
-git clone git@github.com:RyanKung/rings.git
+git clone git@github.com:RingsNetwork/rings.git
 cd ./rings
-cargo install --path .
+cargo install --path crates/node
 ```
 
 ### Build for WebAssembly

--- a/crates/node/src/tests/wasm/test_snark.rs
+++ b/crates/node/src/tests/wasm/test_snark.rs
@@ -31,8 +31,8 @@ fn test_map_array_to_input() {
 #[wasm_bindgen_test]
 async fn test_send_snark_backend_message() {
     setup_log();
-    let wasm = "https://raw.githubusercontent.com/RyanKung/rings/master/crates/snark/src/tests/native/circoms/simple_bn256.wasm";
-    let r1cs = "https://raw.githubusercontent.com/RyanKung/rings/master/crates/snark/src/tests/native/circoms/simple_bn256.r1cs";
+    let wasm = "https://raw.githubusercontent.com/RingsNetwork/rings/master/crates/snark/src/tests/native/circoms/simple_bn256.wasm";
+    let r1cs = "https://raw.githubusercontent.com/RingsNetwork/rings/master/crates/snark/src/tests/native/circoms/simple_bn256.r1cs";
 
     let snark_behaviour = crate::extension::snark::SNARKBehaviour::new_instance();
     let snark_task_builder = crate::extension::snark::SNARKTaskBuilder::from_remote(

--- a/crates/rpc/README.md
+++ b/crates/rpc/README.md
@@ -1,13 +1,13 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RyanKung/rings/master/assets/logo/rings_network_red.png">
-  <img alt="Rings Network" src="https://raw.githubusercontent.com/RyanKung/rings/master/assets/logo/rings_network_black.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RingsNetwork/rings/master/assets/logo/rings_network_red.png">
+  <img alt="Rings Network" src="https://raw.githubusercontent.com/RingsNetwork/rings/master/assets/logo/rings_network_black.svg">
 </picture>
 
 
 Rings RPC
 ===============
 
-[![rings-node](https://github.com/RyanKung/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RyanKung/rings/actions/workflows/auto-release.yml)
+[![rings-node](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml)
 
 
 # JSON-RPC API endpoints

--- a/crates/snark/README.md
+++ b/crates/snark/README.md
@@ -1,15 +1,15 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RyanKung/rings/master/assets/logo/rings_network_red.png">
-  <img alt="Rings Network" src="https://raw.githubusercontent.com/RyanKung/rings/master/assets/logo/rings_network_black.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RingsNetwork/rings/master/assets/logo/rings_network_red.png">
+  <img alt="Rings Network" src="https://raw.githubusercontent.com/RingsNetwork/rings/master/assets/logo/rings_network_black.svg">
 </picture>
 
 # Rings SNARK
 ======================
 
-[![rings-node](https://github.com/RyanKung/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RyanKung/rings/actions/workflows/auto-release.yml)
+[![rings-node](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml)
 [![cargo](https://img.shields.io/crates/v/rings-node.svg)](https://crates.io/crates/rings-node)
 [![docs](https://docs.rs/rings-node/badge.svg)](https://docs.rs/rings-node/latest/rings_node/)
-![GitHub](https://img.shields.io/github/license/RyanKung/rings)
+![GitHub](https://img.shields.io/github/license/RingsNetwork/rings)
 
 This crate contains the implementation of Rings SNARK, which is based on Nova
 

--- a/crates/snark/src/tests/wasm/test_wasm_witness.rs
+++ b/crates/snark/src/tests/wasm/test_wasm_witness.rs
@@ -9,7 +9,7 @@ use crate::r1cs;
 pub async fn test_wasm_load_witness_remote() -> Result<()> {
     type F = <VestaEngine as Engine>::Base;
 
-    let url = "https://raw.githubusercontent.com/RyanKung/rings/master/crates/snark/src/tests/native/circoms/simple_bn256.wasm";
+    let url = "https://raw.githubusercontent.com/RingsNetwork/rings/master/crates/snark/src/tests/native/circoms/simple_bn256.wasm";
     let mut witness_calculator =
         r1cs::load_circom_witness_calculator(r1cs::Path::Remote(url.to_string()))
             .await

--- a/crates/transport/README.md
+++ b/crates/transport/README.md
@@ -1,15 +1,15 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RyanKung/rings/master/assets/logo/rings_network_red.png">
-  <img alt="Rings Network" src="https://raw.githubusercontent.com/RyanKung/rings/master/assets/logo/rings_network_black.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RingsNetwork/rings/master/assets/logo/rings_network_red.png">
+  <img alt="Rings Network" src="https://raw.githubusercontent.com/RingsNetwork/rings/master/assets/logo/rings_network_black.svg">
 </picture>
 
 # Rings Transport
 ======================
 
-[![rings-node](https://github.com/RyanKung/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RyanKung/rings/actions/workflows/auto-release.yml)
+[![rings-node](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml/badge.svg)](https://github.com/RingsNetwork/rings/actions/workflows/auto-release.yml)
 [![cargo](https://img.shields.io/crates/v/rings-node.svg)](https://crates.io/crates/rings-node)
 [![docs](https://docs.rs/rings-node/badge.svg)](https://docs.rs/rings-node/latest/rings_node/)
-![GitHub](https://img.shields.io/github/license/RyanKung/rings)
+![GitHub](https://img.shields.io/github/license/RingsNetwork/rings)
 
 
 This crate encompasses the transport layer implementations for the Rings Network, specifically designed for seamless integration in various computing environments. It is integral for enabling effective network communication within both native and browser contexts. The crate includes two primary Rust-based implementations:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "GPL-3.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/RyanKung/rings"
+    "url": "https://github.com/RingsNetwork/rings"
   },
   "scripts": {
     "wasm_pack": "wasm-pack build crates/node --release --scope ringsnetwork -t web --no-default-features --features browser_default --features console_error_panic_hook",


### PR DESCRIPTION
## Summary

- Update repository, badge, clone, roadmap, whitepaper, and changelog links from `RyanKung/rings` to `RingsNetwork/rings`.
- Update crate README raw asset URLs and workspace/package repository metadata for the migration.
- Update wasm/snark test fixture URLs that fetch raw GitHub assets so they follow the migrated repository location.
- Correct the `crates/node` source install example to install from `crates/node` after cloning the repository.

## Validation

- `git diff --check`
- `rg -n "RyanKung|github\.com/RyanKung|raw\.githubusercontent\.com/RyanKung|git@github\.com:RyanKung|rings-node\.git|RingsNetwork/rings-node"`
- `cargo +nightly fmt --all -- --check`

Note: stable `cargo fmt --all -- --check` is not usable for this repository because the repo rustfmt configuration uses nightly-only options.