### PR TITLE
Fix BiasId observer-relative ordering

### DIFF
--- a/crates/core/src/dht/did.rs
+++ b/crates/core/src/dht/did.rs
@@ -37,6 +37,7 @@
 //! width arithmetic, and DHT placement. Protocol handlers depend on `Did`
 //! operations and do not perform byte-level arithmetic.
 
+use std::cmp::Ordering;
 use std::num::NonZeroU32;
 use std::ops::Add;
 use std::ops::Deref;
@@ -89,6 +90,10 @@ impl std::fmt::Display for Did {
 /// Invariant: `did` is always stored as `raw_did - bias`.
 ///
 /// Law: `BiasId::new(x, y).to_did() == y`.
+///
+/// `BiasId` intentionally has no total [`Ord`] implementation. Values with
+/// different observers live in different reference frames, so callers must
+/// either compare same-observer values or name the observer explicitly.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize, Hash)]
 pub struct BiasId {
     /// the zero point for determine order of Did.
@@ -133,11 +138,22 @@ impl BiasId {
     pub fn pos(&self) -> Did {
         self.did
     }
+
+    /// Compare two biased identifiers only when they share the same observer.
+    pub fn cmp_same_observer(&self, other: &Self) -> Option<Ordering> {
+        (self.bias == other.bias).then(|| self.did.cmp(&other.did))
+    }
+
+    /// Compare two raw identifiers from one explicit Chord observer.
+    pub fn cmp_from_observer(observer: Did, left: Did, right: Did) -> Ordering {
+        let (left, right) = (left - observer, right - observer);
+        left.cmp(&right)
+    }
 }
 
 impl PartialOrd for BiasId {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.cmp_same_observer(other)
     }
 }
 
@@ -145,18 +161,6 @@ impl PartialEq<Did> for BiasId {
     fn eq(&self, rhs: &Did) -> bool {
         let id: Did = self.into();
         id == *rhs
-    }
-}
-
-impl Ord for BiasId {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        if other.bias != self.bias {
-            let did: Did = other.into();
-            let bid = BiasId::new(self.bias, did);
-            self.did.cmp(&bid.did)
-        } else {
-            self.did.cmp(&other.did)
-        }
     }
 }
 
@@ -452,6 +456,7 @@ fn set_ring_bit(bytes: &mut [u8; Did::BYTE_LEN], bit: usize) {
 
 #[cfg(test)]
 mod tests {
+    use std::cmp::Ordering;
     use std::collections::BTreeSet;
     use std::str::FromStr;
 
@@ -544,6 +549,41 @@ mod tests {
         assert_eq!(v, vec![c, d, a, b]);
         v.sort(d);
         assert_eq!(v, vec![d, a, b, c]);
+    }
+
+    fn former_mixed_observer_cmp(left: BiasId, right: BiasId) -> Ordering {
+        let right_raw = right.to_did();
+        let right_in_left_observer = BiasId::new(left.bias, right_raw);
+        left.pos().cmp(&right_in_left_observer.pos())
+    }
+
+    #[test]
+    fn bias_id_orders_same_observer() {
+        let observer = Did::from(10u32);
+        let near = BiasId::new(observer, Did::from(11u32));
+        let far = BiasId::new(observer, Did::from(12u32));
+
+        assert_eq!(near.cmp_same_observer(&far), Some(Ordering::Less));
+        assert_eq!(far.cmp_same_observer(&near), Some(Ordering::Greater));
+        assert_eq!(near.partial_cmp(&far), Some(Ordering::Less));
+        assert_eq!(
+            BiasId::cmp_from_observer(observer, Did::from(11u32), Did::from(12u32)),
+            Ordering::Less
+        );
+    }
+
+    #[test]
+    fn bias_id_rejects_mixed_observer_ordering() {
+        let a = BiasId::new(Did::from(0u32), Did::from(1u32));
+        let b = BiasId::new(
+            Did::power_of_two(159),
+            Did::from(ring_size() - BigUint::from(1u8)),
+        );
+
+        assert_eq!(former_mixed_observer_cmp(a, b), Ordering::Less);
+        assert_eq!(former_mixed_observer_cmp(b, a), Ordering::Less);
+        assert_eq!(a.partial_cmp(&b), None);
+        assert_eq!(b.partial_cmp(&a), None);
     }
 
     #[test]

--- a/crates/core/src/dht/finger.rs
+++ b/crates/core/src/dht/finger.rs
@@ -6,6 +6,7 @@ use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::dht::did::BiasId;
 use crate::dht::Did;
 
 /// Default number of Chord finger slots for a 160-bit `Did`.
@@ -88,7 +89,8 @@ impl FingerTable {
 
     /// Join FingerTable
     pub fn join(&mut self, did: Did) {
-        let bias = did.bias(self.did);
+        let observer = self.did;
+        let bias = did.bias(observer);
 
         for k in 0..self.size {
             let pos = Did::power_of_two(k);
@@ -98,7 +100,7 @@ impl FingerTable {
             }
 
             if let Some(v) = self.finger.get(k).copied().flatten() {
-                if bias > v.bias(self.did) {
+                if BiasId::cmp_from_observer(observer, did, v) == std::cmp::Ordering::Greater {
                     continue;
                 }
             }
@@ -114,11 +116,11 @@ impl FingerTable {
 
     /// get closest predecessor
     pub fn closest_predecessor(&self, did: Did) -> Did {
-        let bias = did.bias(self.did);
+        let observer = self.did;
 
         for i in (0..self.size).rev() {
             if let Some(v) = self.finger.get(i).copied().flatten() {
-                if v.bias(self.did) < bias {
+                if BiasId::cmp_from_observer(observer, v, did) == std::cmp::Ordering::Less {
                     return v;
                 }
             }

--- a/crates/core/src/dht/storage/sync.rs
+++ b/crates/core/src/dht/storage/sync.rs
@@ -11,6 +11,7 @@ use crate::consts::MAX_CHUNK_ENVELOPE_OVERHEAD;
 use crate::consts::TRANSPORT_CUSTOM_OVERHEAD;
 use crate::dht::chord::PeerRing;
 use crate::dht::chord::PeerRingAction;
+use crate::dht::did::BiasId;
 use crate::dht::entry::Entry;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::SyncedEntryAck;
@@ -136,7 +137,9 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
         // transition and does not define storage convergence.
         for (entry_key_str, entry) in all_items {
             let entry_key = Did::from_str(&entry_key_str)?;
-            if self.bias(entry_key) > self.bias(new_successor) {
+            if BiasId::cmp_from_observer(self.did, entry_key, new_successor)
+                == std::cmp::Ordering::Greater
+            {
                 data.push(PlacedEntry::new(entry_key, entry));
             }
         }

--- a/crates/core/src/dht/successor.rs
+++ b/crates/core/src/dht/successor.rs
@@ -104,8 +104,11 @@ impl SuccessorSeq {
             return Ok(false);
         }
 
-        if self.bias(did) >= self.bias(self.max()?) && self.is_full()? {
-            return Ok(false);
+        if self.is_full()? {
+            let max = self.max()?;
+            if BiasId::cmp_from_observer(self.did, did, max) != std::cmp::Ordering::Less {
+                return Ok(false);
+            }
         }
         Ok(true)
     }

--- a/crates/core/src/swarm/transport/connection.rs
+++ b/crates/core/src/swarm/transport/connection.rs
@@ -15,6 +15,7 @@ use super::pending::SharedConnectionLifecycles;
 use super::PendingConnectionAttempt;
 use super::SwarmConnection;
 use super::SwarmTransport;
+use crate::dht::did::BiasId;
 use crate::dht::Chord;
 use crate::dht::CorrectChord;
 use crate::dht::Did;
@@ -440,7 +441,8 @@ impl SwarmTransport {
             .map(PendingConnectionAttempt::peer)
             .filter(|candidate| *candidate != self.dht.did && *candidate != removed)
             .collect::<Vec<_>>();
-        candidates.sort_by_key(|candidate| self.dht.bias(*candidate));
+        let observer = self.dht.did;
+        candidates.sort_by(|left, right| BiasId::cmp_from_observer(observer, *left, *right));
         candidates.dedup();
 
         let capacity = self.dht.successors().capacity();


### PR DESCRIPTION
## Summary

- Remove the total `Ord` implementation from `BiasId`, because biased identifiers are only comparable inside one observer reference frame.
- Add explicit same-observer and explicit-observer comparison helpers.
- Update finger table, successor retention, storage handoff, and successor failover candidate ordering to name the observer directly.
- Add regression coverage showing the old mixed-observer comparison could report both `a < b` and `b < a`, while same-observer ordering remains available.

## Root Cause

`BiasId::cmp` previously converted the right-hand value into the left-hand value's bias when observers differed. Reversing operands therefore changed the comparison reference frame, so mixed-observer comparisons could violate the `Ord` contract.

Closes #668.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo test -p rings-core bias_id`
- `cargo test -p rings-core test_sort`
- `cargo test -p rings-core successor`
- `cargo test -p rings-core finger`
- `cargo test -p rings-core sync_entries_with_successor`
- `cargo test -p rings-core --features dummy successor_failover_considers_active_peer_outside_topology_hints`
- `cargo check -p rings-core`
- `cargo clippy -p rings-core --all-targets --features dummy -- -D warnings`
- `git diff --check`