### PR TITLE
Add CI security gates

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -24,7 +24,7 @@ jobs:
       version: ${{ steps.generated-tag.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
         with:
           fetch-depth: 0
       - name: Get latest tag
@@ -35,7 +35,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Bump version
         id: generated-tag
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           script: |
             if (context.ref.startsWith("refs/tags/")) {
@@ -72,22 +72,22 @@ jobs:
       actions: read
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
         with:
           fetch-depth: 0
 
       - name: Generate changelog
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         id: git-cliff
         with:
           config: cliff.toml
           args: "-vv --strip header ${{ needs.gen_version.outputs.version == 'prerelease' && '--unreleased' || '--latest' }}"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       - name: Display fetched artifacts
         run: ls -R
 
-      - uses: softprops/action-gh-release@v2.0.4
+      - uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564 # v2.0.4
         name: Emit a Github Release
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/qaci.yml
+++ b/.github/workflows/qaci.yml
@@ -12,7 +12,15 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_TOOLCHAIN: 1.97.0
+  NIGHTLY_TOOLCHAIN: nightly-2026-07-02
   WASM_BINDGEN_TEST_TIMEOUT: 120
+  WASM_BINDGEN_CLI_VERSION: 0.2.121
+  WASM_PACK_VERSION: 0.15.0
+  NODE_VERSION: 20.20.2
+  PYTHON_VERSION: 3.11.16
+  CARGO_DENY_VERSION: 0.20.2
+  TRUNK_VERSION: 0.21.14
+  TAPLO_CLI_VERSION: 0.10.0
 
 permissions:
   contents: read
@@ -31,6 +39,93 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/release-build.yml
 
+  dependency_policy:
+    name: Dependency policy
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
+
+      - name: Setup rust toolchain
+        run: |
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
+          rustup show
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          shared-key: dependency-policy-v1
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --version "$CARGO_DENY_VERSION" --locked
+
+      - name: Check dependency policy
+        run: cargo deny --locked check advisories licenses bans sources
+
+  miri_core:
+    name: Miri core invariants
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
+
+      - name: Setup Miri toolchain
+        run: |
+          rustup toolchain install "$NIGHTLY_TOOLCHAIN" --profile minimal
+          rustup component add miri rust-src --toolchain "$NIGHTLY_TOOLCHAIN"
+          cargo +"$NIGHTLY_TOOLCHAIN" miri setup
+          rustup show
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          shared-key: miri-core-v1
+
+      - name: Run Miri-compatible core tests
+        env:
+          MIRIFLAGS: -Zmiri-strict-provenance
+        run: |
+          set -euo pipefail
+          for filter in \
+            "lifecycle::tests" \
+            "dht::did::tests" \
+            "dht::virtual_node::tests"
+          do
+            cargo +"$NIGHTLY_TOOLCHAIN" miri test -q -p rings-core --lib "$filter"
+          done
+
+  ffi_sanitizers:
+    name: FFI ASan and LSan
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    env:
+      ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1:check_initialization_order=1
+      LSAN_OPTIONS: print_suppressions=0
+      RUSTFLAGS: -Zsanitizer=address
+    steps:
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
+
+      - name: Setup protoc
+        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup sanitizer toolchain
+        run: |
+          rustup toolchain install "$NIGHTLY_TOOLCHAIN" --profile minimal
+          rustup default "$NIGHTLY_TOOLCHAIN"
+          rustup show
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          shared-key: ffi-asan-lsan-v1
+
+      - name: Run FFI lifecycle tests under ASan and LSan
+        run: |
+          set -euo pipefail
+          output="$(cargo +"$NIGHTLY_TOOLCHAIN" test -p rings-node --features ffi ffi_ -- --nocapture 2>&1)"
+          printf '%s\n' "$output"
+          grep -Eq 'test result: ok\. [1-9][0-9]* passed' <<< "$output"
+
   build_wasm:
     name: Build and test for wasm
     timeout-minutes: 45
@@ -39,10 +134,10 @@ jobs:
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
 
       - name: Setup protoc
-        uses: arduino/setup-protoc@v2.1.0
+        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -53,12 +148,12 @@ jobs:
           rustup target add wasm32-unknown-unknown
           rustup show
 
-      - uses: jetli/wasm-bindgen-action@v0.2.0
+      - uses: jetli/wasm-bindgen-action@20b33e20595891ab1a0ed73145d8a21fc96e7c29 # v0.2.0
         with:
-          version: "0.2.121"
+          version: ${{ env.WASM_BINDGEN_CLI_VERSION }}
 
       # If you need to reset the cache version, increment the number after `v`
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           shared-key: wasm-v1
 
@@ -80,11 +175,11 @@ jobs:
         run: cargo clippy -p rings-node --features browser_default --no-deps --no-default-features --target=wasm32-unknown-unknown --tests -- -D warnings
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: cargo install wasm-pack --version "$WASM_PACK_VERSION" --locked
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install frontend extension script dependencies
         run: npm ci --ignore-scripts
@@ -101,7 +196,7 @@ jobs:
           sudo apt-get install -y librsvg2-bin
 
       - name: Install Trunk
-        run: cargo install trunk --locked
+        run: cargo install trunk --version "$TRUNK_VERSION" --locked
 
       - name: Build Rings frontend extension package
         run: npm run package:frontend-extension
@@ -120,13 +215,13 @@ jobs:
         working-directory: ./frontend
 
       - name: Run Rings frontend tests
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
         with:
           run: cargo test --release --target=wasm32-unknown-unknown
           working-directory: ./frontend
 
       - name: Run dweb example browser tests
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
         with:
           run: |
             wasm-pack test --release --headless --chrome . -- --skip two_nodes_fetch_a_hosted_page
@@ -134,19 +229,19 @@ jobs:
           working-directory: ./examples/dweb
 
       - name: Run proof-demo browser tests
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
         with:
           run: wasm-pack test --release --headless --chrome
           working-directory: ./examples/proof-demo
 
       - name: Run core browser tests
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
         with:
           run: cargo test -p rings-core --release --target=wasm32-unknown-unknown --features wasm --no-default-features
           working-directory: ./
 
       - name: Run node browser tests
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1
         with:
           run: cargo test -p rings-node --release --target=wasm32-unknown-unknown --features browser_default --no-default-features
           working-directory: ./
@@ -159,10 +254,10 @@ jobs:
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
 
       - name: Setup protoc
-        uses: arduino/setup-protoc@v2.1.0
+        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -173,7 +268,7 @@ jobs:
           rustup show
 
       # If you need to reset the cache version, increment the number after `v`
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           shared-key: default-v1
 
@@ -197,10 +292,10 @@ jobs:
         os: ["ubuntu-latest", "macos-latest"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
 
       - name: Setup protoc
-        uses: arduino/setup-protoc@v2.1.0
+        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -211,7 +306,7 @@ jobs:
           rustup show
 
       # If you need to reset the cache version, increment the number after `v`
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           shared-key: ffi-${{ runner.os }}-${{ runner.arch }}-v2
 
@@ -221,9 +316,9 @@ jobs:
       - name: Build
         run: cargo build -p rings-node --features ffi
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Python FFI test dependencies
         run: python -m pip install --upgrade pip wheel && python -m pip install web3 cffi pytest
@@ -241,13 +336,13 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
 
       - name: Check typos
-        uses: crate-ci/typos@v1.47.2
+        uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
 
       - name: Setup protoc
-        uses: arduino/setup-protoc@v2.1.0
+        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -255,12 +350,12 @@ jobs:
         run: |
           rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
           rustup default "$RUST_TOOLCHAIN"
-          rustup install nightly
-          rustup component add rustfmt --toolchain nightly
+          rustup toolchain install "$NIGHTLY_TOOLCHAIN" --profile minimal
+          rustup component add rustfmt --toolchain "$NIGHTLY_TOOLCHAIN"
           rustup show
 
       # If you need to reset the cache version, increment the number after `v`
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           shared-key: static-v1
 
@@ -282,7 +377,7 @@ jobs:
         run: cargo clippy --all --tests -- -D warnings
 
       - name: Check formating
-        run: cargo +nightly fmt --all -- --check
+        run: cargo +"$NIGHTLY_TOOLCHAIN" fmt --all -- --check
 
       - name: Check docs
         env:
@@ -290,7 +385,7 @@ jobs:
         run: cargo doc --all --no-deps
 
       - name: Install taplo
-        run: cargo install taplo-cli --locked
+        run: cargo install taplo-cli --version "$TAPLO_CLI_VERSION" --locked
 
       - name: Check toml file formating by taplo
         run: taplo format --check

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -30,6 +30,9 @@ permissions:
 
 env:
   RUST_TOOLCHAIN: 1.97.0
+  WASM_BINDGEN_CLI_VERSION: 0.2.121
+  WASM_PACK_VERSION: 0.15.0
+  NODE_VERSION: 20.20.2
 
 jobs:
   build_macos:
@@ -42,7 +45,7 @@ jobs:
           - x86_64
           - aarch64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
         with:
           fetch-depth: 0
 
@@ -56,7 +59,7 @@ jobs:
           rustup target add ${{ steps.target.outputs.target }} --toolchain "$RUST_TOOLCHAIN"
 
       - name: Setup protoc
-        uses: arduino/setup-protoc@v2.1.0
+        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
         with:
           # Automatic per-run token — avoids `secrets: inherit` widening the secret surface on
           # the PR path.
@@ -67,7 +70,7 @@ jobs:
           rustup show
 
       # If you need to reset the cache version, increment the number after `v`
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           shared-key: auto-release-${{ steps.target.outputs.target }}-v1
 
@@ -80,7 +83,7 @@ jobs:
         run: |
           zip -j rings-${{ inputs.version }}-${{ steps.target.outputs.target }}.zip ./target/${{ steps.target.outputs.target }}/release/rings
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ inputs.publish_artifacts }}
         name: Upload artifacts
         with:
@@ -99,7 +102,7 @@ jobs:
         platform:
           - musl
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
         with:
           fetch-depth: 0
 
@@ -113,7 +116,7 @@ jobs:
           rustup target add ${{ steps.target.outputs.target }} --toolchain "$RUST_TOOLCHAIN"
 
       - name: Setup protoc
-        uses: arduino/setup-protoc@v2.1.0
+        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
         with:
           # Automatic per-run token — avoids `secrets: inherit` widening the secret surface on
           # the PR path.
@@ -135,7 +138,7 @@ jobs:
           sudo apt-get install -y musl-tools
 
       # If you need to reset the cache version, increment the number after `v`
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           shared-key: auto-release-${{ steps.target.outputs.target }}-v1
 
@@ -148,7 +151,7 @@ jobs:
         run: |
           zip -j rings-${{ inputs.version }}-${{ steps.target.outputs.target }}.zip ./target/${{ steps.target.outputs.target }}/release/rings
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ inputs.publish_artifacts }}
         name: Upload artifacts
         with:
@@ -170,7 +173,7 @@ jobs:
         platform:
           - unknown
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
         with:
           fetch-depth: 0
 
@@ -184,15 +187,15 @@ jobs:
           rustup target add ${{ steps.target.outputs.target }} --toolchain "$RUST_TOOLCHAIN"
           rustup default "$RUST_TOOLCHAIN"
 
-      - uses: jetli/wasm-bindgen-action@v0.2.0
+      - uses: jetli/wasm-bindgen-action@20b33e20595891ab1a0ed73145d8a21fc96e7c29 # v0.2.0
         with:
-          version: "0.2.121"
+          version: ${{ env.WASM_BINDGEN_CLI_VERSION }}
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: cargo install wasm-pack --version "$WASM_PACK_VERSION" --locked
 
       - name: Setup protoc
-        uses: arduino/setup-protoc@v2.1.0
+        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
         with:
           # Automatic per-run token — avoids `secrets: inherit` widening the secret surface on
           # the PR path.
@@ -203,13 +206,13 @@ jobs:
           rustup show
 
       # If you need to reset the cache version, increment the number after `v`
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           shared-key: auto-release-${{ steps.target.outputs.target }}-v1
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Build
         run: |
@@ -221,7 +224,7 @@ jobs:
         run: |
           mv ringsnetwork-rings-node-*.tgz rings-${{ inputs.version }}-${{ steps.target.outputs.target }}.tgz
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ inputs.publish_artifacts }}
         name: Upload artifacts
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["third_party/proc-macro-error2"]
 [workspace.package]
 version = "0.16.0"
 edition = "2021"
-license = "GPL-3.0"
+license = "GPL-3.0-only"
 authors = ["RND <dev@ringsnetwork.io>"]
 repository = "https://github.com/RingsNetwork/rings"
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ We welcome contributions to rings-node!
 
 If you have a bug report or feature request, please open an issue on GitHub.
 
+Security and supply-chain CI gates are documented in
+[docs/ci-security-gates.md](./docs/ci-security-gates.md).
+
 If you'd like to contribute code, please follow these steps:
 
 ```text

--- a/crates/node/src/onion/tcp/pump.rs
+++ b/crates/node/src/onion/tcp/pump.rs
@@ -147,7 +147,6 @@ mod tests {
     use std::sync::Mutex;
     use std::time::Duration;
 
-    use tokio::io::AsyncWriteExt as _;
     use tokio::net::TcpListener;
     use tokio::sync::Notify;
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,47 @@
+[graph]
+all-features = true
+
+[advisories]
+git-fetch-with-cli = false
+ignore = [
+    # Reviewed exceptions must use the structured form below and include a
+    # follow-up issue plus an expiry date.
+    # { id = "RUSTSEC-0000-0000", reason = "tracking in #000 until 2026-12-31" },
+]
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "0BSD",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "GPL-3.0-only",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+[licenses.private]
+ignore = false
+
+[bans]
+multiple-versions = "allow"
+wildcards = "deny"
+highlight = "all"
+allow-workspace = true
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = [
+    "https://github.com/matter-labs/zksync-crypto",
+]

--- a/docs/ci-security-gates.md
+++ b/docs/ci-security-gates.md
@@ -1,0 +1,86 @@
+# CI security gates
+
+The `QACI` workflow contains the blocking pull-request security gates. These
+checks are intentionally narrower than the full build matrix so failures point at
+one security boundary at a time.
+
+## Dependency policy
+
+Status: blocking PR gate on Ubuntu.
+
+Purpose: fail the PR when the lockfile introduces a RustSec advisory, an
+unreviewed license, a wildcard dependency, or a dependency from an unapproved
+registry or git source.
+
+Local reproduction:
+
+```sh
+cargo install cargo-deny --version 0.20.2 --locked
+cargo deny --locked check advisories licenses bans sources
+```
+
+Reviewed exceptions live in `deny.toml`. Advisory exceptions must use the
+structured form with an issue reference and an expiry date. Git sources must be
+listed explicitly under `sources.allow-git`; do not rely on broad organization
+allow-lists for new sources.
+
+## Miri core invariants
+
+Status: blocking PR gate on Ubuntu.
+
+Purpose: run Miri with strict provenance over core modules that do not require
+native sockets, wall-clock access during interpretation, or long elliptic-curve
+searches.
+
+Local reproduction:
+
+```sh
+rustup toolchain install nightly-2026-07-02 --profile minimal
+rustup component add miri rust-src --toolchain nightly-2026-07-02
+cargo +nightly-2026-07-02 miri setup
+MIRIFLAGS=-Zmiri-strict-provenance cargo +nightly-2026-07-02 miri test -q -p rings-core --lib lifecycle::tests
+MIRIFLAGS=-Zmiri-strict-provenance cargo +nightly-2026-07-02 miri test -q -p rings-core --lib dht::did::tests
+MIRIFLAGS=-Zmiri-strict-provenance cargo +nightly-2026-07-02 miri test -q -p rings-core --lib dht::virtual_node::tests
+```
+
+Do not replace these filters with the full core suite without first validating
+runtime and duration locally. Some otherwise valid core tests use wall-clock
+operations or expensive crypto paths that are poor fits for blocking Miri CI.
+
+## FFI ASan and LSan
+
+Status: blocking PR gate on Ubuntu.
+
+Purpose: exercise the native FFI lifecycle under AddressSanitizer with leak
+detection enabled. The job fails if the filtered FFI tests execute zero tests, so
+a renamed or removed lifecycle test cannot silently pass.
+
+Local reproduction on Linux:
+
+```sh
+rustup toolchain install nightly-2026-07-02 --profile minimal
+RUSTFLAGS=-Zsanitizer=address \
+ASAN_OPTIONS=detect_leaks=1:strict_string_checks=1:check_initialization_order=1 \
+LSAN_OPTIONS=print_suppressions=0 \
+cargo +nightly-2026-07-02 test -p rings-node --features ffi ffi_ -- --nocapture
+```
+
+This sanitizer job is Linux-only because the GitHub-hosted Linux runner provides
+the expected sanitizer runtime and leak detector behavior. macOS still runs the
+ordinary FFI build and Python integration tests.
+
+## Pinned tools
+
+Workflow actions are pinned to reviewed commit SHAs with the original tag kept as
+an inline comment. Tool installers use exact versions instead of mutable install
+scripts or major-version aliases:
+
+- Rust stable: `1.97.0`
+- Rust nightly/Miri/rustfmt: `nightly-2026-07-02`
+- `wasm-bindgen`: `0.2.121`
+- `wasm-pack`: `0.15.0`
+- Node.js: `20.20.2`
+- Python: `3.11.16`
+- `cargo-deny`: `0.20.2`
+- `trunk`: `0.21.14`
+- `taplo-cli`: `0.10.0`

--- a/examples/native/Cargo.toml
+++ b/examples/native/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = { workspace = true }
 base64 = "0.13"
 bytes = "1.2.1"
 rings-core = { workspace = true }
-rings-node = { path = "../../crates/node", default-features = false, features = ["node"] }
+rings-node = { path = "../../crates/node", version = "0.16.0", default-features = false, features = ["node"] }
 rings-rpc = { workspace = true }
 serde_json = "1.0.70"
 tokio = { version = "1.13.0", features = ["macros", "rt-multi-thread", "time"] }

--- a/examples/relay/Cargo.toml
+++ b/examples/relay/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 
 [dependencies]
 rings-core = { workspace = true }
-rings-node = { path = "../../crates/node", default-features = false, features = ["node"] }
+rings-node = { path = "../../crates/node", version = "0.16.0", default-features = false, features = ["node"] }
 tokio = { version = "1.13.0", features = ["io-util", "macros", "net", "rt-multi-thread", "time"] }
 
 [[example]]


### PR DESCRIPTION
Depends on #677.

Addresses #670 as a stacked PR. This should be retargeted to `master` after #677 lands so the FFI sanitizer gate can use the opaque-handle FFI tests added there.

Summary:
- Pin GitHub Actions and CI tool versions to immutable refs or exact versions.
- Replace the wasm-pack shell installer with locked Cargo installation.
- Add cargo-deny policy for advisories, licenses, bans, and sources.
- Add focused Miri coverage for rings-core lifecycle, DID, and virtual-node tests.
- Add a Linux FFI ASan/LSan gate with nonzero-test enforcement.
- Document local reproduction commands in `docs/ci-security-gates.md`.

Validation:
- `cargo test -p rings-node --features ffi ffi_`
- `cargo clippy -p rings-node --features ffi --all-targets -- -D warnings`
- workflow YAML parse for qaci/release-build/auto-release
- static search for mutable actions, `curl | sh`, floating nightly/Node/Python, and unpinned Cargo installs
- `cargo deny --locked check licenses bans sources`
- `cargo +nightly-2026-07-02 miri test -q -p rings-core --lib lifecycle::tests`
- earlier full focused Miri sweep also passed for `dht::did::tests` and `dht::virtual_node::tests`

Local note:
- Full `cargo deny --locked check advisories ...` could not fetch the RustSec advisory DB from this machine because outbound GitHub access failed; CI should exercise that gate.
- macOS ASan ran the FFI tests successfully but exited nonzero under LeakSanitizer with allocator/runtime/provider teardown reports. The committed CI gate is Linux-only, matching the documented sanitizer target.