### PR TITLE
Document overlay threat model and Sybil boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ their own network layer instead of a server-owned data path. Browser tabs and na
 daemons can join the same overlay, discover peers by DID, and exchange messages over
 direct WebRTC datachannels routed by a Chord DHT.
 
+The current overlay threat model is documented in [SECURITY.md](./SECURITY.md).
+DID authentication proves key control; it is not, by itself, Sybil or eclipse
+resistance for permissionless public membership.
+
 At the application layer, Rings gives developers a namespace-scoped protocol runtime:
 write a pure state machine, attach an interpreter shell, and run it over a decentralized
 overlay. Built-in protocols already cover peer service relay and fold-scheme zkSNARK
@@ -59,13 +63,15 @@ browser-to-browser connections without an application server in the data path.
 Peers are addressed by decentralized identifiers backed by selectable signature
 schemes, including secp256k1, secp256r1, ed25519, BLS, and bip137. This lets Rings
 bridge browser, daemon, and wallet-oriented identity workflows without binding the
-network to one key system.
+network to one key system. See [the threat model](./SECURITY.md#did-identity) for
+the boundary between DID authentication and Sybil resistance.
 
 ### Structured peer routing
 
 The overlay uses a Chord DHT for successor/finger-table routing, DID lookup, message
 relay, stabilization, and `network_id` isolation. Independent overlays stay separate
-while retaining deterministic routing behavior.
+while retaining deterministic routing behavior. Chord routing assumes an acceptable
+membership model; see [the overlay threat model](./SECURITY.md#chord-routing).
 
 ### Protocol runtime
 
@@ -161,6 +167,7 @@ handler)`. See [`examples/relay`](./examples/relay) and
 | Resource | Link | Notes |
 |---|---|---|
 | Rings Whitepaper | [PDF](./papers/rings.pdf), [LaTeX source](./papers/rings.tex), [citation](#whitepaper) | Canonical protocol paper |
+| Security model | [SECURITY.md](./SECURITY.md) | Overlay assumptions, deployment models, and Sybil boundary |
 | Browser frontend | [`frontend`](./frontend) | Landing guide, web app, and extension workflow |
 | Examples | [`examples/`](./examples) | Native, dweb, proof, relay, snark, and FFI examples |
 
@@ -181,7 +188,8 @@ handler)`. See [`examples/relay`](./examples/relay) and
 ## Architecture
 
 Rings is layered so that **every layer is decentralized — there is no server in the data
-path**. Each layer maps directly to a crate/module:
+path**. This is a data-path topology statement, not a permissionless Sybil-resistance
+claim; see [SECURITY.md](./SECURITY.md). Each layer maps directly to a crate/module:
 
 ```text
 ┌──────────────────────────────────────────────────────────────────────┐

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,113 @@
+# Security And Overlay Threat Model
+
+This document describes the current security boundary for the Rings overlay. It is
+documentation, not a claim that every stronger model is implemented.
+
+## Summary
+
+Rings authenticates peer identities and protocol messages with DIDs and delegated
+session keys. That proves control of a key. It does not make identities scarce,
+expensive, or reputation-bearing.
+
+The current Chord overlay must therefore not be treated as Sybil-resistant
+permissionless membership. A party that can create many identities can influence
+successor, predecessor, finger-table, storage-owner, and onion-route candidate
+placement, and can attempt eclipse behavior.
+
+## Assumptions
+
+- A DID identifies a cryptographic account key, and signature checks authenticate
+  control of that key.
+- Delegated session keys are accepted only according to the protocol checks in the
+  core and node layers.
+- WebRTC transport establishment and data channels provide the expected channel
+  security for a successfully established peer connection.
+- `network_id` separates overlays by configuration. It is not an access-control
+  secret, because a peer can choose to use the same value.
+- Honest peers run the same protocol rules, refresh descriptors before expiry, and
+  participate in stabilization and storage replication.
+
+## Fault Model
+
+The implementation is intended to handle ordinary churn and fail-stop behavior:
+peers can disconnect, crash, restart with a new session, or miss heartbeats. TTLs,
+stabilization, storage repair, and descriptor refreshes are designed for that
+environment.
+
+The current overlay does not provide Byzantine membership safety. A malicious peer
+can drop, delay, or refuse messages; advertise service policy it later ignores;
+withhold stored data; or create many identities to bias topology position. Signed
+descriptors make these claims attributable to a DID, but they do not make the DID
+costly to create.
+
+## Deployment Models
+
+| Model | Current fit | Required assumption |
+|---|---|---|
+| Controlled membership | Supported | Operators decide which keys may join, or run a private overlay whose peers are known. |
+| Authenticated open membership | Partially supported | Anyone can create a DID, but applications accept the Sybil risk and add their own policy, quotas, or allowlists. |
+| Permissionless adversarial membership | Not currently supported | The network would need an admission cost or other Sybil/eclipse mitigation before making strong availability, routing, or privacy claims. |
+
+## Current Non-Goals
+
+- Sybil resistance from DID authentication alone.
+- Eclipse resistance against an attacker that can choose many DIDs.
+- Strong public-network availability when storage owners or route candidates are
+  adversarial.
+- Strong anonymity or traffic-analysis resistance for onion routes chosen from a
+  Sybil-permissive live-node registry.
+- Economic security, stake weighting, proof-of-work admission, reputation, or
+  globally rate-limited identity issuance.
+
+## Feature Boundaries
+
+### DID Identity
+
+DID signatures authenticate the key behind a message, descriptor, or session
+delegation. They do not prove that two DIDs are controlled by different operators,
+and they do not prevent an operator from generating many DIDs.
+
+### Chord Routing
+
+Chord routing assumes the node set is acceptable under the deployment model. It
+gives deterministic routing over the observed topology; it does not defend, by
+itself, against an adversary that can occupy many positions on the identifier ring.
+
+### DHT Storage
+
+Storage ownership and replication are topology-derived. CRDT joins, owner checks,
+TTL cleanup, and read repair improve convergence among honest or fail-stop peers.
+They do not force a Byzantine storage owner to serve data or preserve data it has
+chosen to withhold.
+
+### Online And Onion Registries
+
+Online-node and onion-exit descriptors are signed and expire. This bounds stale
+records and makes advertised claims attributable. It does not prevent a Sybil
+operator from publishing many live descriptors or many exit candidates.
+
+### Onion Routing
+
+Onion circuits protect payload layers from intermediate hops according to the
+implemented circuit protocol. Route security still depends on the candidate set.
+In an authenticated-open overlay, a Sybil operator can try to appear in multiple
+route positions unless the deployment adds independent admission or diversity
+controls.
+
+## Required Work Before Stronger Claims
+
+Before Rings can claim Sybil-resistant permissionless membership, the project
+needs concrete mitigation work such as one or more of:
+
+- admission control through operator allowlists, invitations, stake, proof of
+  work, or another scarcity mechanism;
+- topology diversity rules for successor lists, fingers, storage owners, and onion
+  route selection;
+- multiple independently controlled bootstrap or registry sources;
+- storage audit, challenge, or accountability mechanisms for unavailable owners;
+- application-level quotas, abuse handling, and monitoring for authenticated-open
+  deployments.
+
+Any such mitigation should be tracked and reviewed as a separate design or
+implementation issue. Until then, deployment documentation and feature claims
+should describe Rings as DID-authenticated and Chord-routed, not Sybil-resistant.

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -43,6 +43,9 @@ To check the implementation of transport layer: https://github.com/RingsNetwork/
 
 The network layer is the core component of the Rings Network, responsible for DID (Decentralized Identifier) discovery and services routing within the network. The Rings Network employs the Chord DHT (Distributed Hash Table) algorithm as the implementation for its network layer.
 
+Chord routing and DID authentication do not make open membership Sybil-resistant by
+themselves. See the repository [security and overlay threat model](../../SECURITY.md).
+
 The Chord algorithm is a well-known DHT algorithm characterized by its formation of an abstract circular topology structure among all participating nodes. It has a lookup algorithm complexity of O(log(N)).
 
 #### Protocol Layer
@@ -52,6 +55,10 @@ In the protocol layer, the central design concept revolves around the utilizatio
 It is comprised of a set of elements with two binary operations, addition and multiplication, which satisfy a set of axioms such as associativity, commutativity, and distributivity. The ring is deemed finite due to its having a finite number of elements. Finite rings are widely employed in various domains of mathematics and computer science, including cryptography and coding theory.
 
 At the protocol layer, we have implemented the concept of a Delegated Session Key, which is used to support various cryptographic verification methods associated with DID (Decentralized Identifier). Currently, the supported signature algorithms include ECDSA-secp256k1, ECDSA-secp256r1, and EdDSA-ed25519.
+
+DID signatures authenticate key control, not identity scarcity. Operators should use
+the deployment model in the [threat model](../../SECURITY.md#deployment-models) before
+treating an overlay as public or adversarial.
 
 #### Application Layer
 

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -15,6 +15,8 @@ Rings Node (The node service of Rings Network)
 Rings is a structured peer-to-peer network implementation using WebRTC, Chord algorithm, and full WebAssembly (WASM) support.
 
 For protocol details, see the repository-owned [Rings Whitepaper](../../papers/rings.pdf).
+For security assumptions, supported deployment models, and the Sybil-resistance
+boundary, see the repository [threat model](../../SECURITY.md).
 
 ## Installation
 

--- a/docker/cluster/README.md
+++ b/docker/cluster/README.md
@@ -2,6 +2,10 @@
 
 This image runs N native `rings` daemon processes in one container, generates per-node session keys from external private keys, waits for every HTTP API to become ready, then connects the nodes. It is a demo/test cluster, so onion relay and onion exit advertisement are enabled by default.
 
+This cluster is intended for controlled testing. Random or externally supplied keys
+authenticate DIDs, but they do not make the cluster Sybil-resistant; see the repository
+[threat model](../../SECURITY.md).
+
 Build from the repository root:
 
 ```sh


### PR DESCRIPTION
Closes #671.

Summary:
- Add `SECURITY.md` as the repository-level overlay threat model.
- State explicitly that DID authentication proves key control, not identity scarcity or Sybil resistance.
- Separate controlled membership, authenticated-open membership, and permissionless adversarial membership.
- Document current non-goals around Sybil resistance, eclipse resistance, Byzantine storage owners, and onion-route candidate control.
- Link the threat model from the root README, `crates/core/README.md`, `crates/node/README.md`, and the Docker cluster deployment README.

Validation:
- `rg -n "Sybil|eclipse|threat model|SECURITY\.md|permissionless|Deployment Models" SECURITY.md README.md crates/core/README.md crates/node/README.md docker/cluster/README.md`
- `git diff --check`

Notes:
- This is intentionally docs-only. Concrete Sybil/eclipse mitigations remain future design or implementation work and should be tracked separately before stronger claims are made.