### PR TITLE
Harden secret key and signature handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Secret signing keys are no longer `Copy`; signing helpers now borrow keys and return explicit
   errors instead of silently substituting invalid signatures or scalars.
+- Secret key containers now zeroize their long-lived scalar or seed storage on drop.
+- Secp256r1 verification now rejects high-s signatures, so persisted high-s secp256r1 session
+  proofs from older builds no longer verify. Ed25519 verification now uses strict signature
+  validation.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.20.0
 
+### Breaking changes
+
+- Secret signing keys are no longer `Copy`; signing helpers now borrow keys and return explicit
+  errors instead of silently substituting invalid signatures or scalars.
+
 ### Added
 
 - Add the opt-in native IPv4/TCP gateway for explicitly selected destination prefixes, with

--- a/crates/core/src/dht/mod.rs
+++ b/crates/core/src/dht/mod.rs
@@ -60,11 +60,11 @@ pub use virtual_node::MAX_STORAGE_VIRTUAL_POSITIONS_PER_OWNER;
 pub mod tests {
     //! test
     use super::*;
-    use crate::ecc::tests::gen_ordered_keys;
+    use crate::ecc::tests::gen_ordered_key_vec;
 
     /// Test get ordered did list
     pub fn gen_ordered_dids(n: usize) -> Vec<Did> {
-        gen_ordered_keys(n)
+        gen_ordered_key_vec(n)
             .iter()
             .map(|x| x.address().into())
             .collect()

--- a/crates/core/src/ecc/elgamal/impls/secp256k1/mod.rs
+++ b/crates/core/src/ecc/elgamal/impls/secp256k1/mod.rs
@@ -377,14 +377,14 @@ pub fn encrypt_bytes_with_rng(
 }
 
 /// Decrypt ciphertext produced by the current secp256k1 compatibility adapter.
-pub fn decrypt(m: &[CiphertextBlock], k: SecretKey) -> Result<String> {
+pub fn decrypt(m: &[CiphertextBlock], k: &SecretKey) -> Result<String> {
     String::from_utf8(decrypt_bytes(m, k)?).map_err(Error::Utf8Encoding)
 }
 
 /// Decrypt arbitrary bytes produced by [`encrypt_bytes_with_rng`].
-pub fn decrypt_bytes(m: &[CiphertextBlock], k: SecretKey) -> Result<Vec<u8>> {
+pub fn decrypt_bytes(m: &[CiphertextBlock], k: &SecretKey) -> Result<Vec<u8>> {
     let secret_key =
-        ElGamalSecretKey::<Point<Secp256k1>>::from_scalar(GroupScalar::<Secp256k1>::from(k));
+        ElGamalSecretKey::<Point<Secp256k1>>::from_scalar(GroupScalar::<Secp256k1>::try_from(k)?);
     let ciphertext = m
         .iter()
         .map(|(c1, c2)| Ok(((*c1).try_into()?, (*c2).try_into()?)))
@@ -431,7 +431,7 @@ pub fn encrypt_aead_with_rng(
 pub fn decrypt_aead(
     sealed: &AeadCiphertext,
     aad: &[u8],
-    recipient_secret: SecretKey,
+    recipient_secret: &SecretKey,
 ) -> Result<Vec<u8>> {
     if sealed.version != AEAD_VERSION {
         return Err(Error::MessageDecryptionFailed(format!(

--- a/crates/core/src/ecc/elgamal/impls/secp256k1/test_secp256k1.rs
+++ b/crates/core/src/ecc/elgamal/impls/secp256k1/test_secp256k1.rs
@@ -117,7 +117,7 @@ fn test_algorithm() {
         31, 146, 117, 219, 175, 223, 186, 129, 148, 46, 179, 51, 11, 7, 243, 140, 190, 228, 235,
         184, 107, 220, 33, 116, 175, 150, 72, 213, 245, 80, 154, 84,
     ];
-    let r_sca = GroupScalar::<Secp256k1>::from(r).into_inner();
+    let r_sca = GroupScalar::<Secp256k1>::try_from(&r).unwrap().into_inner();
     let mut got_r = [0u8; 32];
     got_r.copy_from_slice(r_sca.to_bytes().as_slice());
     assert_eq!(got_r, r_v);
@@ -164,7 +164,10 @@ fn test_algorithm() {
     assert_eq!(got_c2_x, c2_x);
     assert_eq!(got_c2_y, c2_y);
 
-    let t = K256ProjectivePoint::from(a_c1) * GroupScalar::<Secp256k1>::from(key).into_inner();
+    let t = K256ProjectivePoint::from(a_c1)
+        * GroupScalar::<Secp256k1>::try_from(&key)
+            .unwrap()
+            .into_inner();
     let a_t = t.to_affine();
     let t_x = [
         218, 19, 55, 137, 15, 46, 160, 160, 208, 222, 206, 77, 46, 79, 32, 80, 64, 243, 93, 23,
@@ -189,7 +192,7 @@ fn test_encrypt_decrypt() {
             .unwrap();
     let pubkey = key.pubkey();
     let t: String = random(1024);
-    assert_eq!(decrypt(&encrypt(&t, pubkey).unwrap(), key).unwrap(), t)
+    assert_eq!(decrypt(&encrypt(&t, pubkey).unwrap(), &key).unwrap(), t)
 }
 
 #[test]
@@ -200,7 +203,7 @@ fn test_encrypt_decrypt_keeps_nul_bytes() {
     let pubkey = key.pubkey();
     let message = format!("\0{}{}", "a".repeat(FIELD_CHUNK_SIZE - 1), "\0tail");
     assert_eq!(
-        decrypt(&encrypt(&message, pubkey).unwrap(), key).unwrap(),
+        decrypt(&encrypt(&message, pubkey).unwrap(), &key).unwrap(),
         message
     );
 }
@@ -217,7 +220,7 @@ fn test_encrypt_decrypt_binary_bytes() {
 
     let ciphertext = encrypt_bytes_with_rng(&payload, pubkey, &mut rng).unwrap();
 
-    assert_eq!(decrypt_bytes(&ciphertext, key).unwrap(), payload);
+    assert_eq!(decrypt_bytes(&ciphertext, &key).unwrap(), payload);
 }
 
 #[test]
@@ -234,7 +237,7 @@ fn test_encrypt_with_rng_is_reproducible_for_same_seed() {
     let ciphertext_b = encrypt_with_rng(&message, pubkey, &mut rng_b).unwrap();
 
     assert_eq!(ciphertext_a, ciphertext_b);
-    assert_eq!(decrypt(&ciphertext_a, key).unwrap(), message);
+    assert_eq!(decrypt(&ciphertext_a, &key).unwrap(), message);
 }
 
 #[test]
@@ -260,7 +263,7 @@ fn test_decrypt_malformed_ciphertext_returns_error() {
         SecretKey::try_from("65860affb4b570dba06db294aa7c676f68e04a5bf2721243ad3cbc05a79c68c0")
             .unwrap();
     let malformed = PublicKey([0u8; 33]);
-    let result = std::panic::catch_unwind(|| decrypt(&[(malformed, malformed)], key));
+    let result = std::panic::catch_unwind(|| decrypt(&[(malformed, malformed)], &key));
 
     assert!(result.is_ok());
     assert!(result.unwrap().is_err());
@@ -279,7 +282,7 @@ fn test_aead_encrypt_decrypt_binary_bytes() {
 
     let sealed = encrypt_aead_with_rng(&payload, aad, pubkey, &mut rng).unwrap();
 
-    assert_eq!(decrypt_aead(&sealed, aad, key).unwrap(), payload);
+    assert_eq!(decrypt_aead(&sealed, aad, &key).unwrap(), payload);
 }
 
 #[test]
@@ -294,7 +297,7 @@ fn test_aead_rejects_ciphertext_tampering() {
     *first ^= 1;
 
     assert!(matches!(
-        decrypt_aead(&sealed, b"aad", key),
+        decrypt_aead(&sealed, b"aad", &key),
         Err(Error::MessageDecryptionFailed(_))
     ));
 }
@@ -309,7 +312,7 @@ fn test_aead_rejects_associated_data_tampering() {
     let sealed = encrypt_aead_with_rng(b"authenticated", b"aad", pubkey, &mut rng).unwrap();
 
     assert!(matches!(
-        decrypt_aead(&sealed, b"other-aad", key),
+        decrypt_aead(&sealed, b"other-aad", &key),
         Err(Error::MessageDecryptionFailed(_))
     ));
 }
@@ -327,7 +330,7 @@ fn test_aead_rejects_empty_wrapped_key() {
     };
 
     assert!(matches!(
-        decrypt_aead(&sealed, b"aad", key),
+        decrypt_aead(&sealed, b"aad", &key),
         Err(Error::MessageDecryptionFailed(_))
     ));
 }
@@ -345,7 +348,7 @@ fn test_bench_encrypt_decrypt_4kb() {
 
     for _ in 0..rounds {
         let ciphertext = encrypt(std::hint::black_box(&message), pubkey).unwrap();
-        let plaintext = decrypt(std::hint::black_box(&ciphertext), key).unwrap();
+        let plaintext = decrypt(std::hint::black_box(&ciphertext), &key).unwrap();
         assert_eq!(plaintext, message);
     }
 

--- a/crates/core/src/ecc/group.rs
+++ b/crates/core/src/ecc/group.rs
@@ -724,9 +724,19 @@ impl_curve_group_adapter! {
     }
 }
 
-impl From<SecretKey> for Scalar<Secp256k1> {
-    fn from(secret_key: SecretKey) -> Self {
-        Self::new(secret_key.secp256k1_scalar())
+impl TryFrom<&SecretKey> for Scalar<Secp256k1> {
+    type Error = Error;
+
+    fn try_from(secret_key: &SecretKey) -> Result<Self> {
+        Ok(Self::new(secret_key.secp256k1_scalar()?))
+    }
+}
+
+impl TryFrom<SecretKey> for Scalar<Secp256k1> {
+    type Error = Error;
+
+    fn try_from(secret_key: SecretKey) -> Result<Self> {
+        Self::try_from(&secret_key)
     }
 }
 

--- a/crates/core/src/ecc/group.rs
+++ b/crates/core/src/ecc/group.rs
@@ -728,15 +728,7 @@ impl TryFrom<&SecretKey> for Scalar<Secp256k1> {
     type Error = Error;
 
     fn try_from(secret_key: &SecretKey) -> Result<Self> {
-        Ok(Self::new(secret_key.secp256k1_scalar()?))
-    }
-}
-
-impl TryFrom<SecretKey> for Scalar<Secp256k1> {
-    type Error = Error;
-
-    fn try_from(secret_key: SecretKey) -> Result<Self> {
-        Self::try_from(&secret_key)
+        Ok(Self::new(secret_key.secp256k1_scalar()))
     }
 }
 

--- a/crates/core/src/ecc/keys.rs
+++ b/crates/core/src/ecc/keys.rs
@@ -588,7 +588,7 @@ mod tests {
     }
 
     #[test]
-    fn signing_secrets_redact_debug_and_zeroize_on_drop() {
+    fn signing_secrets_redact_debug_and_need_drop() {
         let ed25519 = Ed25519SecretKey::from_bytes([0xabu8; 32]);
         let signing = SigningSecretKey::Ed25519(ed25519.clone());
 

--- a/crates/core/src/ecc/keys.rs
+++ b/crates/core/src/ecc/keys.rs
@@ -25,6 +25,7 @@ use rand::SeedableRng;
 use rand_hc::Hc128Rng;
 use serde::Deserialize;
 use serde::Serialize;
+use zeroize::Zeroize;
 
 use super::keccak256;
 use super::signers;
@@ -102,11 +103,11 @@ pub enum AccountVerifier {
 }
 
 /// Ed25519 signing seed.
-#[derive(Deserialize, Serialize, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq)]
 pub struct Ed25519SecretKey([u8; 32]);
 
 /// Secret key used for account signatures.
-#[derive(Deserialize, Serialize, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq)]
 pub enum SigningSecretKey {
     /// secp256k1 ECDSA signing key.
     Secp256k1(SecretKey),
@@ -120,6 +121,29 @@ pub enum SigningSecretKey {
     Ed25519(Ed25519SecretKey),
     /// BLS12-381 signing key.
     Bls12381(SecretKey),
+}
+
+impl std::fmt::Debug for Ed25519SecretKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Ed25519SecretKey")
+            .field(&"<redacted>")
+            .finish()
+    }
+}
+
+impl Drop for Ed25519SecretKey {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl std::fmt::Debug for SigningSecretKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SigningSecretKey")
+            .field("algorithm", &self.algorithm())
+            .field("secret", &"<redacted>")
+            .finish()
+    }
 }
 
 impl SignatureAlgorithm {
@@ -354,20 +378,20 @@ impl SigningSecretKey {
     /// Sign raw message bytes using this key's algorithm.
     pub fn sign_raw(&self, msg: &[u8]) -> Result<Vec<u8>> {
         Ok(match self {
-            Self::Secp256k1(sk) => signers::secp256k1::sign_raw(*sk, msg).to_vec(),
-            Self::Eip191(sk) => signers::eip191::sign_raw(*sk, msg).to_vec(),
+            Self::Secp256k1(sk) => signers::secp256k1::sign_raw(sk, msg)?.to_vec(),
+            Self::Eip191(sk) => signers::eip191::sign_raw(sk, msg)?.to_vec(),
             Self::Bip137(sk) => {
-                let signature = sk.sign_hash(&signers::bip137::magic_hash(msg));
+                let signature = sk.sign_hash(&signers::bip137::magic_hash(msg))?;
                 let mut out = Vec::with_capacity(65);
                 out.push(signature[64] + 27);
                 out.extend_from_slice(&signature[..64]);
                 out
             }
             Self::Secp256r1(sk) => {
-                signers::secp256r1::sign(*sk, &signers::secp256r1::hash(msg))?.to_vec()
+                signers::secp256r1::sign(sk, &signers::secp256r1::hash(msg))?.to_vec()
             }
             Self::Ed25519(sk) => sk.sign_raw(msg)?.to_vec(),
-            Self::Bls12381(sk) => signers::bls::sign(*sk, msg)?.0.to_vec(),
+            Self::Bls12381(sk) => signers::bls::sign(sk, msg)?.0.to_vec(),
         })
     }
 
@@ -412,14 +436,14 @@ impl SigningSecretKey {
             Self::Secp256k1(sk) => VerificationPublicKey::Secp256k1(sk.pubkey()),
             Self::Eip191(sk) => VerificationPublicKey::Eip191(sk.pubkey()),
             Self::Bip137(sk) => VerificationPublicKey::Bip137(sk.pubkey()),
-            Self::Secp256r1(sk) => VerificationPublicKey::Secp256r1(secp256r1_public_key(*sk)?),
+            Self::Secp256r1(sk) => VerificationPublicKey::Secp256r1(secp256r1_public_key(sk)?),
             Self::Ed25519(sk) => VerificationPublicKey::Ed25519(sk.public_key()?),
             Self::Bls12381(sk) => VerificationPublicKey::Bls12381(signers::bls::public_key(sk)?),
         })
     }
 }
 
-fn secp256r1_public_key(secret_key: SecretKey) -> Result<PublicKey<33>> {
+fn secp256r1_public_key(secret_key: &SecretKey) -> Result<PublicKey<33>> {
     let sk_bytes: elliptic_curve::FieldBytes<p256::NistP256> = secret_key.into();
     let signing_key = ecdsa::SigningKey::<p256::NistP256>::from_bytes(&sk_bytes)?;
     let encoded = signing_key.verifying_key().to_encoded_point(false);
@@ -460,7 +484,7 @@ mod tests {
             did,
         };
         let msg = b"session proof";
-        let sig = secret.sign_raw(msg);
+        let sig = secret.sign_raw(msg).unwrap();
 
         assert_eq!(reference.did(), did);
         assert!(reference.verify(msg, sig));
@@ -561,6 +585,20 @@ mod tests {
             SigningSecretKey::random_ed25519_with_rng(&mut rng_a),
             SigningSecretKey::random_ed25519_with_rng(&mut rng_b)
         );
+    }
+
+    #[test]
+    fn signing_secrets_redact_debug_and_zeroize_on_drop() {
+        let ed25519 = Ed25519SecretKey::from_bytes([0xabu8; 32]);
+        let signing = SigningSecretKey::Ed25519(ed25519.clone());
+
+        assert_eq!(format!("{ed25519:?}"), "Ed25519SecretKey(\"<redacted>\")");
+        assert_eq!(
+            format!("{signing:?}"),
+            "SigningSecretKey { algorithm: \"ed25519\", secret: \"<redacted>\" }"
+        );
+        assert!(std::mem::needs_drop::<Ed25519SecretKey>());
+        assert!(std::mem::needs_drop::<SigningSecretKey>());
     }
 
     #[test]

--- a/crates/core/src/ecc/mod.rs
+++ b/crates/core/src/ecc/mod.rs
@@ -19,6 +19,7 @@ use serde::Serialize;
 use sha1::Digest;
 use sha1::Sha1;
 use subtle::CtOption;
+use zeroize::Zeroize;
 
 use crate::error::Error;
 use crate::error::Result;
@@ -34,7 +35,6 @@ use elliptic_curve::point::AffineCoordinates;
 use elliptic_curve::point::DecompressPoint;
 use elliptic_curve::sec1::ToEncodedPoint;
 use elliptic_curve::FieldBytes;
-use elliptic_curve::PrimeField as _;
 pub use group::*;
 pub use keys::*;
 use p256::NistP256;
@@ -54,12 +54,18 @@ pub type PublicKeyAddress = H160;
 ///
 /// The bytes are validated at construction time and stay in the canonical
 /// external format used by existing configs and DIDs.
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct SecretKey([u8; 32]);
 
 impl std::fmt::Debug for SecretKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("SecretKey").field(&"<redacted>").finish()
+    }
+}
+
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        self.0.zeroize();
     }
 }
 
@@ -156,6 +162,12 @@ impl PublicKey<33> {
 
 impl From<SecretKey> for FieldBytes<NistP256> {
     fn from(val: SecretKey) -> Self {
+        Self::from(&val)
+    }
+}
+
+impl From<&SecretKey> for FieldBytes<NistP256> {
+    fn from(val: &SecretKey) -> Self {
         GenericArray::<u8, U32>::from(val.ser())
     }
 }
@@ -218,6 +230,12 @@ impl From<K256VerifyingKey> for PublicKey<33> {
 
 impl From<SecretKey> for PublicKey<33> {
     fn from(secret_key: SecretKey) -> Self {
+        secret_key.pubkey()
+    }
+}
+
+impl From<&SecretKey> for PublicKey<33> {
+    fn from(secret_key: &SecretKey) -> Self {
         secret_key.pubkey()
     }
 }
@@ -308,8 +326,9 @@ impl SecretKey {
         Ok(Self(bytes))
     }
 
-    pub(crate) fn secp256k1_scalar(&self) -> K256Scalar {
-        Option::<K256Scalar>::from(K256Scalar::from_repr(self.0.into())).unwrap_or(K256Scalar::ONE)
+    pub(crate) fn secp256k1_scalar(&self) -> Result<K256Scalar> {
+        let secret = K256SecretKey::from_slice(&self.0).map_err(|_| Error::PrivateKeyBadFormat)?;
+        Ok(*secret.to_nonzero_scalar().as_ref())
     }
 
     /// Generate a random secp256k1 secret key.
@@ -325,30 +344,31 @@ impl SecretKey {
     }
 
     /// Sign a UTF-8 message after hashing it with Keccak-256.
-    pub fn sign(&self, message: &str) -> SigBytes {
+    ///
+    /// Returns an error when the stored key is invalid or signing fails.
+    pub fn sign(&self, message: &str) -> Result<SigBytes> {
         self.sign_raw(message.as_bytes())
     }
 
     /// Sign raw message bytes after hashing them with Keccak-256.
-    pub fn sign_raw(&self, message: &[u8]) -> SigBytes {
+    ///
+    /// Returns an error when the stored key is invalid or signing fails.
+    pub fn sign_raw(&self, message: &[u8]) -> Result<SigBytes> {
         let message_hash = keccak256(message);
         self.sign_hash(&message_hash)
     }
 
     /// Sign an already computed 32-byte message hash.
-    pub fn sign_hash(&self, message_hash: &[u8; 32]) -> SigBytes {
-        let signing_key = match K256SigningKey::from_slice(&self.0) {
-            Ok(signing_key) => signing_key,
-            Err(_) => return [0u8; 65],
-        };
-        let (signature, recover_id) = match signing_key.sign_prehash_recoverable(message_hash) {
-            Ok(signature) => signature,
-            Err(_) => return [0u8; 65],
-        };
+    ///
+    /// Returns an error when the stored key is invalid or signing fails.
+    pub fn sign_hash(&self, message_hash: &[u8; 32]) -> Result<SigBytes> {
+        let signing_key =
+            K256SigningKey::from_slice(&self.0).map_err(|_| Error::PrivateKeyBadFormat)?;
+        let (signature, recover_id) = signing_key.sign_prehash_recoverable(message_hash)?;
         let mut sig_bytes: SigBytes = [0u8; 65];
         sig_bytes[0..64].copy_from_slice(signature.to_bytes().as_slice());
         sig_bytes[64] = recover_id.to_byte();
-        sig_bytes
+        Ok(sig_bytes)
     }
 
     /// Derive the compressed public key for this secret key.
@@ -385,6 +405,9 @@ pub fn recover_hash(message_hash: &[u8; 32], sig: &[u8; 65]) -> Result<PublicKey
     let r_s_signature: [u8; 64] = sig[..64].try_into()?;
     let recovery_id: u8 = sig[64];
     let signature = K256Signature::try_from(r_s_signature.as_slice()).map_err(Error::ECDSAError)?;
+    if signature.normalize_s().is_some() {
+        return Err(Error::NonCanonicalSignature);
+    }
     let recovery_id =
         RecoveryId::from_byte(recovery_id).ok_or(Error::InvalidRecoverId(recovery_id))?;
     Ok(
@@ -442,9 +465,9 @@ pub(crate) mod tests {
         let metamask_sig = Vec::from_hex("724fc31d9272b34d8406e2e3a12a182e72510b008de6cc44684577e31e20d9626fb760d6a0badd79a6cf4cd56b2fc0fbd60c438b809aa7d29bfb598c13e7b50e1b").unwrap();
         assert_eq!(metamask_sig.len(), 65);
         let h: [u8; 32] = sig_hash.as_slice().try_into().unwrap();
-        let recover_id = key.sign_hash(&h)[64];
+        let recover_id = key.sign_hash(&h).unwrap()[64];
         assert_eq!(recover_id, 0);
-        let mut sig = key.sign_raw(&prefix_msg);
+        let mut sig = key.sign_raw(&prefix_msg).unwrap();
         sig[64] = 27;
         assert_eq!(sig, metamask_sig.as_slice());
     }
@@ -453,8 +476,52 @@ pub(crate) mod tests {
     fn test_recover() {
         let key = SecretKey::random();
         let pubkey1 = key.pubkey();
-        let pubkey2 = recover("hello".as_bytes(), key.sign("hello")).unwrap();
+        let pubkey2 = recover("hello".as_bytes(), key.sign("hello").unwrap()).unwrap();
         assert_eq!(pubkey1, pubkey2);
+    }
+
+    #[test]
+    fn secret_key_redacts_debug_and_zeroizes_on_drop() {
+        let key =
+            SecretKey::try_from("65860affb4b570dba06db294aa7c676f68e04a5bf2721243ad3cbc05a79c68c0")
+                .unwrap();
+
+        assert_eq!(format!("{key:?}"), "SecretKey(\"<redacted>\")");
+        assert!(std::mem::needs_drop::<SecretKey>());
+    }
+
+    #[test]
+    fn invalid_secret_key_state_returns_explicit_errors() {
+        let invalid = SecretKey([0u8; 32]);
+
+        assert!(matches!(
+            invalid.sign_hash(&[0u8; 32]),
+            Err(Error::PrivateKeyBadFormat)
+        ));
+        assert!(matches!(
+            invalid.secp256k1_scalar(),
+            Err(Error::PrivateKeyBadFormat)
+        ));
+    }
+
+    #[test]
+    fn recover_hash_rejects_high_s_signature() {
+        let key =
+            SecretKey::try_from("65860affb4b570dba06db294aa7c676f68e04a5bf2721243ad3cbc05a79c68c0")
+                .unwrap();
+        let hash = keccak256(b"canonical signature");
+        let mut signature_bytes = key.sign_hash(&hash).unwrap();
+        let signature = K256Signature::try_from(&signature_bytes[..64]).unwrap();
+        let (r, s) = signature.split_scalars();
+        let high_s = K256Signature::from_scalars(r.to_bytes(), (-s).to_bytes()).unwrap();
+
+        signature_bytes[..64].copy_from_slice(&high_s.to_bytes());
+        signature_bytes[64] ^= 1;
+
+        assert!(matches!(
+            recover_hash(&hash, &signature_bytes),
+            Err(Error::NonCanonicalSignature)
+        ));
     }
 
     pub(crate) fn gen_ordered_keys(n: usize) -> Vec<SecretKey> {

--- a/crates/core/src/ecc/mod.rs
+++ b/crates/core/src/ecc/mod.rs
@@ -19,7 +19,7 @@ use serde::Serialize;
 use sha1::Digest;
 use sha1::Sha1;
 use subtle::CtOption;
-use zeroize::Zeroize;
+use zeroize::Zeroizing;
 
 use crate::error::Error;
 use crate::error::Result;
@@ -52,20 +52,14 @@ pub type PublicKeyAddress = H160;
 
 /// Secp256k1 secret key bytes.
 ///
-/// The bytes are validated at construction time and stay in the canonical
-/// external format used by existing configs and DIDs.
+/// The secret scalar is validated at construction time and serializes to the
+/// canonical external byte format used by existing configs and DIDs.
 #[derive(PartialEq, Eq, Clone)]
-pub struct SecretKey([u8; 32]);
+pub struct SecretKey(K256SecretKey);
 
 impl std::fmt::Debug for SecretKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("SecretKey").field(&"<redacted>").finish()
-    }
-}
-
-impl Drop for SecretKey {
-    fn drop(&mut self) {
-        self.0.zeroize();
     }
 }
 
@@ -160,15 +154,9 @@ impl PublicKey<33> {
     }
 }
 
-impl From<SecretKey> for FieldBytes<NistP256> {
-    fn from(val: SecretKey) -> Self {
-        Self::from(&val)
-    }
-}
-
 impl From<&SecretKey> for FieldBytes<NistP256> {
     fn from(val: &SecretKey) -> Self {
-        GenericArray::<u8, U32>::from(val.ser())
+        GenericArray::<u8, U32>::from(*val.ser())
     }
 }
 
@@ -228,18 +216,6 @@ impl From<K256VerifyingKey> for PublicKey<33> {
     }
 }
 
-impl From<SecretKey> for PublicKey<33> {
-    fn from(secret_key: SecretKey) -> Self {
-        secret_key.pubkey()
-    }
-}
-
-impl From<&SecretKey> for PublicKey<33> {
-    fn from(secret_key: &SecretKey) -> Self {
-        secret_key.pubkey()
-    }
-}
-
 impl<T> From<T> for HashStr
 where T: Into<String>
 {
@@ -269,7 +245,8 @@ impl std::str::FromStr for SecretKey {
 #[allow(clippy::to_string_trait_impl)]
 impl ToString for SecretKey {
     fn to_string(&self) -> String {
-        hex::encode(self.0)
+        let bytes = self.ser();
+        hex::encode(*bytes)
     }
 }
 
@@ -322,20 +299,18 @@ fn secret_key_address(secret_key: &SecretKey) -> PublicKeyAddress {
 
 impl SecretKey {
     pub(crate) fn from_bytes(bytes: [u8; 32]) -> Result<Self> {
-        K256SecretKey::from_slice(&bytes).map_err(|_| Error::PrivateKeyBadFormat)?;
-        Ok(Self(bytes))
+        let key = K256SecretKey::from_slice(&bytes).map_err(|_| Error::PrivateKeyBadFormat)?;
+        Ok(Self(key))
     }
 
-    pub(crate) fn secp256k1_scalar(&self) -> Result<K256Scalar> {
-        let secret = K256SecretKey::from_slice(&self.0).map_err(|_| Error::PrivateKeyBadFormat)?;
-        Ok(*secret.to_nonzero_scalar().as_ref())
+    pub(crate) fn secp256k1_scalar(&self) -> K256Scalar {
+        *self.0.to_nonzero_scalar()
     }
 
     /// Generate a random secp256k1 secret key.
     pub fn random() -> Self {
         let mut rng = Hc128Rng::from_entropy();
-        let bytes = K256SecretKey::random(&mut rng).to_bytes();
-        Self(bytes.into())
+        Self(K256SecretKey::random(&mut rng))
     }
 
     /// Derive the Ethereum-style address for this secret key.
@@ -362,8 +337,7 @@ impl SecretKey {
     ///
     /// Returns an error when the stored key is invalid or signing fails.
     pub fn sign_hash(&self, message_hash: &[u8; 32]) -> Result<SigBytes> {
-        let signing_key =
-            K256SigningKey::from_slice(&self.0).map_err(|_| Error::PrivateKeyBadFormat)?;
+        let signing_key = K256SigningKey::from(&self.0);
         let (signature, recover_id) = signing_key.sign_prehash_recoverable(message_hash)?;
         let mut sig_bytes: SigBytes = [0u8; 65];
         sig_bytes[0..64].copy_from_slice(signature.to_bytes().as_slice());
@@ -373,15 +347,12 @@ impl SecretKey {
 
     /// Derive the compressed public key for this secret key.
     pub fn pubkey(&self) -> PublicKey<33> {
-        match K256SecretKey::from_slice(&self.0) {
-            Ok(secret_key) => secret_key.public_key().into(),
-            Err(_) => PublicKey([0u8; 33]),
-        }
+        self.0.public_key().into()
     }
 
     /// Serialize this secret key into its 32-byte representation.
-    pub fn ser(&self) -> [u8; 32] {
-        self.0
+    pub fn ser(&self) -> Zeroizing<[u8; 32]> {
+        Zeroizing::new(self.0.to_bytes().into())
     }
 }
 
@@ -405,7 +376,9 @@ pub fn recover_hash(message_hash: &[u8; 32], sig: &[u8; 65]) -> Result<PublicKey
     let r_s_signature: [u8; 64] = sig[..64].try_into()?;
     let recovery_id: u8 = sig[64];
     let signature = K256Signature::try_from(r_s_signature.as_slice()).map_err(Error::ECDSAError)?;
-    if signature.normalize_s().is_some() {
+    if signers::ecdsa_signature_s_is_high(&signature) {
+        // k256 rejects this during recovery too; this branch preserves the
+        // crate's explicit canonical-signature error.
         return Err(Error::NonCanonicalSignature);
     }
     let recovery_id =
@@ -481,7 +454,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn secret_key_redacts_debug_and_zeroizes_on_drop() {
+    fn secret_key_redacts_debug_and_needs_drop() {
         let key =
             SecretKey::try_from("65860affb4b570dba06db294aa7c676f68e04a5bf2721243ad3cbc05a79c68c0")
                 .unwrap();
@@ -491,15 +464,9 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn invalid_secret_key_state_returns_explicit_errors() {
-        let invalid = SecretKey([0u8; 32]);
-
+    fn zero_secret_key_bytes_are_rejected() {
         assert!(matches!(
-            invalid.sign_hash(&[0u8; 32]),
-            Err(Error::PrivateKeyBadFormat)
-        ));
-        assert!(matches!(
-            invalid.secp256k1_scalar(),
+            SecretKey::from_bytes([0u8; 32]),
             Err(Error::PrivateKeyBadFormat)
         ));
     }
@@ -524,8 +491,21 @@ pub(crate) mod tests {
         ));
     }
 
-    pub(crate) fn gen_ordered_keys(n: usize) -> Vec<SecretKey> {
+    pub(crate) fn gen_ordered_key_vec(n: usize) -> Vec<SecretKey> {
         let mut keys = Vec::from_iter(std::iter::repeat_with(SecretKey::random).take(n));
+        keys.sort_by(|a, b| {
+            if a.address() < b.address() {
+                std::cmp::Ordering::Less
+            } else {
+                std::cmp::Ordering::Greater
+            }
+        });
+        keys
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn gen_ordered_keys<const N: usize>() -> [SecretKey; N] {
+        let mut keys = std::array::from_fn(|_| SecretKey::random());
         keys.sort_by(|a, b| {
             if a.address() < b.address() {
                 std::cmp::Ordering::Less

--- a/crates/core/src/ecc/signers/bip137/mod.rs
+++ b/crates/core/src/ecc/signers/bip137/mod.rs
@@ -6,7 +6,6 @@ use sha2::Sha256;
 
 use crate::ecc::PublicKey;
 use crate::ecc::PublicKeyAddress;
-use crate::error::Error;
 use crate::error::Result;
 
 /// recover pubkey according to signature.
@@ -27,13 +26,8 @@ pub fn recover(msg: &[u8], sig: impl AsRef<[u8]>) -> Result<PublicKey<33>> {
     let sig_byte = array_mut_ref![sig, 0, 65];
     let hash = self::magic_hash(msg);
 
-    if sig_byte[64] >= 27 && sig_byte[64] <= 30 {
-        sig_byte[64] -= 27;
-    } else if sig_byte[64] >= 31 && sig_byte[64] <= 34 {
-        sig_byte[64] -= 31;
-    } else {
-        return Err(Error::InvalidRecoverId(sig_byte[64]));
-    }
+    sig_byte[64] = super::recovery_id_from_v(sig_byte[64], 27)
+        .or_else(|_| super::recovery_id_from_v(sig_byte[64], 31))?;
     crate::ecc::recover_hash(&hash, sig_byte)
 }
 

--- a/crates/core/src/ecc/signers/bls/mod.rs
+++ b/crates/core/src/ecc/signers/bls/mod.rs
@@ -64,6 +64,15 @@ impl TryFrom<SecretKey> for Fr {
     }
 }
 
+impl TryFrom<&SecretKey> for Fr {
+    type Error = Error;
+
+    fn try_from(sk: &SecretKey) -> Result<Fr> {
+        let data = sk.ser();
+        from_compressed(&data)
+    }
+}
+
 impl TryFrom<Fr> for SecretKey {
     type Error = Error;
     fn try_from(sk: Fr) -> Result<SecretKey> {
@@ -118,7 +127,7 @@ pub fn hash_to_curve(msg: &[u8]) -> Result<[u8; 96]> {
 }
 
 /// Sign hashed message with bls privatekey
-pub fn sign_hash(sk: SecretKey, hashed_msg: &[u8; 96]) -> Result<Signature> {
+pub fn sign_hash(sk: &SecretKey, hashed_msg: &[u8; 96]) -> Result<Signature> {
     let sk: Fr = sk.try_into()?;
     let msg: G2Projective = from_compressed(hashed_msg)?;
     Ok(Signature(to_compressed(&(msg * sk))?))
@@ -126,7 +135,7 @@ pub fn sign_hash(sk: SecretKey, hashed_msg: &[u8; 96]) -> Result<Signature> {
 
 /// Sign message with bls privatekey
 /// signature = hash_into_g2(message) * sk
-pub fn sign(sk: SecretKey, msg: &[u8]) -> Result<Signature> {
+pub fn sign(sk: &SecretKey, msg: &[u8]) -> Result<Signature> {
     let sk: Fr = sk.try_into()?;
     let hashed_msg = hash_to_curve(msg)?;
     let msg: G2Projective = from_compressed(&hashed_msg)?;
@@ -184,7 +193,7 @@ pub fn aggregate(signatures: &[Signature]) -> Result<Signature> {
 /// Converts a BLS private key to a BLS public key.
 /// Get the public key for this private key. Calculated by pk = g1 * sk.
 pub fn public_key(key: &SecretKey) -> Result<PublicKey<48>> {
-    let sk: Fr = (*key).try_into()?;
+    let sk: Fr = key.try_into()?;
     let g1 = G1Projective::generator();
     (g1 * sk).try_into()
 }

--- a/crates/core/src/ecc/signers/bls/mod.rs
+++ b/crates/core/src/ecc/signers/bls/mod.rs
@@ -55,15 +55,6 @@ fn to_compressed<T: CanonicalSerialize, const S: usize>(s: &T) -> Result<[u8; S]
     Ok(ret)
 }
 
-impl TryFrom<SecretKey> for Fr {
-    type Error = Error;
-    fn try_from(sk: SecretKey) -> Result<Fr> {
-        let data: [u8; 32] = sk.ser();
-        let ret: Fr = from_compressed(&data)?;
-        Ok(ret)
-    }
-}
-
 impl TryFrom<&SecretKey> for Fr {
     type Error = Error;
 

--- a/crates/core/src/ecc/signers/bls/test_bls.rs
+++ b/crates/core/src/ecc/signers/bls/test_bls.rs
@@ -6,7 +6,7 @@ fn test_sign_and_verify() {
     let msg = "hello world";
     let pk = public_key(&key).unwrap();
     let h = hash_to_curve(msg.as_bytes()).unwrap();
-    let sig = sign_hash(key, &h).unwrap();
+    let sig = sign_hash(&key, &h).unwrap();
     assert!(super::verify_hash(vec![h].as_slice(), &sig, vec![pk].as_slice()).unwrap());
     assert!(super::verify(vec![msg.as_bytes()].as_slice(), &sig, vec![pk].as_slice()).unwrap());
 }
@@ -41,8 +41,8 @@ fn test_aggregate() {
     let h1 = hash_to_curve(msg1.as_bytes()).unwrap();
     let h2 = hash_to_curve(msg2.as_bytes()).unwrap();
 
-    let sig1 = sign_hash(key1, &h1).unwrap();
-    let sig2 = sign_hash(key2, &h2).unwrap();
+    let sig1 = sign_hash(&key1, &h1).unwrap();
+    let sig2 = sign_hash(&key2, &h2).unwrap();
 
     let sig_agg = aggregate(&[sig1, sig2]).unwrap();
 

--- a/crates/core/src/ecc/signers/ed25519/mod.rs
+++ b/crates/core/src/ecc/signers/ed25519/mod.rs
@@ -1,6 +1,5 @@
 //! ed25519 sign algorithm using ed25519_dalek
 use ed25519_dalek::Signer;
-use ed25519_dalek::Verifier;
 
 use crate::ecc::PublicKey;
 use crate::ecc::PublicKeyAddress;
@@ -38,7 +37,7 @@ pub fn verify(
     };
     if let Ok(p) = TryInto::<ed25519_dalek::VerifyingKey>::try_into(*pubkey) {
         let s = ed25519_dalek::Signature::from_bytes(&sig_data);
-        match p.verify(msg, &s) {
+        match p.verify_strict(msg, &s) {
             Ok(()) => true,
             Err(_) => false,
         }

--- a/crates/core/src/ecc/signers/ed25519/test_ed25519.rs
+++ b/crates/core/src/ecc/signers/ed25519/test_ed25519.rs
@@ -26,3 +26,20 @@ fn test_verify_ed25519() {
         &signer
     ))
 }
+
+#[test]
+fn test_verify_strict_rejects_weak_public_key_signature() {
+    let mut weak_key_bytes = [0u8; 32];
+    weak_key_bytes[0] = 1;
+    let weak_key = ed25519_dalek::VerifyingKey::from_bytes(&weak_key_bytes).unwrap();
+    let public_key: PublicKey<33> = weak_key.into();
+    let mut identity_signature = [0u8; 64];
+    identity_signature[0] = 1;
+
+    assert!(!verify(
+        b"message",
+        &public_key.address(),
+        identity_signature,
+        &public_key
+    ));
+}

--- a/crates/core/src/ecc/signers/eip191/mod.rs
+++ b/crates/core/src/ecc/signers/eip191/mod.rs
@@ -8,15 +8,15 @@ use crate::ecc::SecretKey;
 use crate::error::Result;
 
 /// sign function passing raw message parameter.
-pub fn sign_raw(sec: SecretKey, msg: &[u8]) -> [u8; 65] {
+pub fn sign_raw(sec: &SecretKey, msg: &[u8]) -> Result<[u8; 65]> {
     sign(sec, &hash(msg))
 }
 
 /// sign function with `hash` data.
-pub fn sign(sec: SecretKey, hash: &[u8; 32]) -> [u8; 65] {
-    let mut sig = sec.sign_hash(hash);
+pub fn sign(sec: &SecretKey, hash: &[u8; 32]) -> Result<[u8; 65]> {
+    let mut sig = sec.sign_hash(hash)?;
     sig[64] += 27;
-    sig
+    Ok(sig)
 }
 
 /// \x19Ethereum Signed Message\n is used for PersonalSign, which can encode by send `personalSign` rpc call.
@@ -31,6 +31,9 @@ pub fn recover(msg: &[u8], sig: impl AsRef<[u8]>) -> Result<PublicKey<33>> {
     let sig_byte: [u8; 65] = sig.as_ref().try_into()?;
     let hash = hash(msg);
     let mut sig712 = sig_byte;
+    if !(27..=30).contains(&sig712[64]) {
+        return Err(crate::error::Error::InvalidRecoverId(sig712[64]));
+    }
     sig712[64] -= 27;
     crate::ecc::recover_hash(&hash, &sig712)
 }

--- a/crates/core/src/ecc/signers/eip191/mod.rs
+++ b/crates/core/src/ecc/signers/eip191/mod.rs
@@ -31,10 +31,7 @@ pub fn recover(msg: &[u8], sig: impl AsRef<[u8]>) -> Result<PublicKey<33>> {
     let sig_byte: [u8; 65] = sig.as_ref().try_into()?;
     let hash = hash(msg);
     let mut sig712 = sig_byte;
-    if !(27..=30).contains(&sig712[64]) {
-        return Err(crate::error::Error::InvalidRecoverId(sig712[64]));
-    }
-    sig712[64] -= 27;
+    sig712[64] = super::recovery_id_from_v(sig712[64], 27)?;
     crate::ecc::recover_hash(&hash, &sig712)
 }
 

--- a/crates/core/src/ecc/signers/eip191/test_eip191.rs
+++ b/crates/core/src/ecc/signers/eip191/test_eip191.rs
@@ -15,9 +15,21 @@ fn test_eip191() {
     let metamask_sig = Vec::from_hex("724fc31d9272b34d8406e2e3a12a182e72510b008de6cc44684577e31e20d9626fb760d6a0badd79a6cf4cd56b2fc0fbd60c438b809aa7d29bfb598c13e7b50e1b").unwrap();
     let msg = "test";
     let h = self::hash(msg.as_bytes());
-    let sig = self::sign(key, &h);
+    let sig = self::sign(&key, &h).unwrap();
     assert_eq!(metamask_sig.as_slice(), sig);
     let pubkey = self::recover(msg.as_bytes(), sig).unwrap();
     assert_eq!(pubkey.address(), address);
     assert!(self::verify(msg.as_bytes(), &address, sig));
+}
+
+#[test]
+fn recover_rejects_out_of_range_recovery_id_without_panicking() {
+    for recovery_id in [0, 26, 31, u8::MAX] {
+        let mut signature = [0u8; 65];
+        signature[64] = recovery_id;
+        assert!(matches!(
+            recover(b"message", signature),
+            Err(crate::error::Error::InvalidRecoverId(actual)) if actual == recovery_id
+        ));
+    }
 }

--- a/crates/core/src/ecc/signers/mod.rs
+++ b/crates/core/src/ecc/signers/mod.rs
@@ -4,3 +4,30 @@ pub mod ed25519;
 pub mod eip191;
 pub mod secp256k1;
 pub mod secp256r1;
+
+use elliptic_curve::generic_array::ArrayLength;
+use elliptic_curve::scalar::IsHigh;
+use elliptic_curve::CurveArithmetic;
+use elliptic_curve::PrimeCurve;
+
+use crate::error::Error;
+use crate::error::Result;
+
+pub(crate) fn ecdsa_signature_s_is_high<C>(signature: &ecdsa::Signature<C>) -> bool
+where
+    C: PrimeCurve + CurveArithmetic,
+    ecdsa::SignatureSize<C>: ArrayLength<u8>,
+{
+    bool::from(signature.s().is_high())
+}
+
+pub(crate) fn recovery_id_from_v(v: u8, base: u8) -> Result<u8> {
+    let Some(max) = base.checked_add(3) else {
+        return Err(Error::InvalidRecoverId(v));
+    };
+    if (base..=max).contains(&v) {
+        Ok(v - base)
+    } else {
+        Err(Error::InvalidRecoverId(v))
+    }
+}

--- a/crates/core/src/ecc/signers/secp256k1/mod.rs
+++ b/crates/core/src/ecc/signers/secp256k1/mod.rs
@@ -7,12 +7,12 @@ use crate::ecc::SecretKey;
 use crate::error::Result;
 
 /// sign function passing raw message parameter.
-pub fn sign_raw(sec: SecretKey, msg: &[u8]) -> [u8; 65] {
+pub fn sign_raw(sec: &SecretKey, msg: &[u8]) -> Result<[u8; 65]> {
     sign(sec, &hash(msg))
 }
 
 /// sign function with `hash` data.
-pub fn sign(sec: SecretKey, hash: &[u8; 32]) -> [u8; 65] {
+pub fn sign(sec: &SecretKey, hash: &[u8; 32]) -> Result<[u8; 65]> {
     sec.sign_hash(hash)
 }
 

--- a/crates/core/src/ecc/signers/secp256k1/test_secp256k1.rs
+++ b/crates/core/src/ecc/signers/secp256k1/test_secp256k1.rs
@@ -9,6 +9,6 @@ fn test_default_sign() {
 
     let msg = "hello";
     let h = self::hash(msg.as_bytes());
-    let sig = self::sign(key, &h);
-    assert_eq!(sig, key.sign(msg));
+    let sig = self::sign(&key, &h).unwrap();
+    assert_eq!(sig, key.sign(msg).unwrap());
 }

--- a/crates/core/src/ecc/signers/secp256r1/mod.rs
+++ b/crates/core/src/ecc/signers/secp256r1/mod.rs
@@ -62,7 +62,11 @@ pub fn sign(sec: &SecretKey, hash: &[u8; 32]) -> Result<[u8; 64]> {
     let sk_bytes: FieldBytes<p256::NistP256> = sec.into();
     let sk = ecdsa::SigningKey::<p256::NistP256>::from_bytes(&sk_bytes)?;
     let (sig, _rid) = sk.sign_prehash_recoverable(hash)?;
-    let sig = sig.normalize_s().unwrap_or(sig);
+    let sig = if super::ecdsa_signature_s_is_high(&sig) {
+        sig.normalize_s().ok_or(Error::NonCanonicalSignature)?
+    } else {
+        sig
+    };
     let sig_bytes: [u8; 64] = sig.to_bytes().as_slice().try_into()?;
     Ok(sig_bytes)
 }
@@ -101,7 +105,7 @@ pub fn verify(
     }
     let msg_hash = hash(msg);
     let signature = match ecdsa::Signature::<p256::NistP256>::from_slice(sig.as_ref()) {
-        Ok(signature) if signature.normalize_s().is_none() => signature,
+        Ok(signature) if !super::ecdsa_signature_s_is_high(&signature) => signature,
         Ok(_) | Err(_) => return false,
     };
     let res: Result<()> = ct_pk.unwrap().and_then(|pk| {

--- a/crates/core/src/ecc/signers/secp256r1/mod.rs
+++ b/crates/core/src/ecc/signers/secp256r1/mod.rs
@@ -62,12 +62,22 @@ pub fn sign(sec: &SecretKey, hash: &[u8; 32]) -> Result<[u8; 64]> {
     let sk_bytes: FieldBytes<p256::NistP256> = sec.into();
     let sk = ecdsa::SigningKey::<p256::NistP256>::from_bytes(&sk_bytes)?;
     let (sig, _rid) = sk.sign_prehash_recoverable(hash)?;
-    let sig = if super::ecdsa_signature_s_is_high(&sig) {
-        sig.normalize_s().ok_or(Error::NonCanonicalSignature)?
+    normalize_signature(sig.to_bytes())
+}
+
+/// Return the low-S canonical form of a raw 64-byte secp256r1 ECDSA signature.
+pub fn normalize_signature(sig: impl AsRef<[u8]>) -> Result<[u8; 64]> {
+    let signature = ecdsa::Signature::<p256::NistP256>::from_slice(sig.as_ref())?;
+    let signature = if super::ecdsa_signature_s_is_high(&signature) {
+        signature
+            .normalize_s()
+            .ok_or(Error::NonCanonicalSignature)?
     } else {
-        sig
+        signature
     };
-    let sig_bytes: [u8; 64] = sig.to_bytes().as_slice().try_into()?;
+    let bytes = signature.to_bytes();
+    let mut sig_bytes = [0u8; 64];
+    sig_bytes.copy_from_slice(bytes.as_slice());
     Ok(sig_bytes)
 }
 

--- a/crates/core/src/ecc/signers/secp256r1/mod.rs
+++ b/crates/core/src/ecc/signers/secp256r1/mod.rs
@@ -58,10 +58,11 @@ use crate::error::Error;
 use crate::error::Result;
 
 /// sign function with `hash` data. Recover is no needed.
-pub fn sign(sec: SecretKey, hash: &[u8; 32]) -> Result<[u8; 64]> {
+pub fn sign(sec: &SecretKey, hash: &[u8; 32]) -> Result<[u8; 64]> {
     let sk_bytes: FieldBytes<p256::NistP256> = sec.into();
     let sk = ecdsa::SigningKey::<p256::NistP256>::from_bytes(&sk_bytes)?;
     let (sig, _rid) = sk.sign_prehash_recoverable(hash)?;
+    let sig = sig.normalize_s().unwrap_or(sig);
     let sig_bytes: [u8; 64] = sig.to_bytes().as_slice().try_into()?;
     Ok(sig_bytes)
 }
@@ -99,13 +100,13 @@ pub fn verify(
         return false;
     }
     let msg_hash = hash(msg);
+    let signature = match ecdsa::Signature::<p256::NistP256>::from_slice(sig.as_ref()) {
+        Ok(signature) if signature.normalize_s().is_none() => signature,
+        Ok(_) | Err(_) => return false,
+    };
     let res: Result<()> = ct_pk.unwrap().and_then(|pk| {
-        pk.verify_prehash(
-            &msg_hash,
-            &ecdsa::Signature::<p256::NistP256>::from_slice(sig.as_ref())
-                .map_err(Error::ECDSAError)?,
-        )
-        .map_err(Error::ECDSAError)
+        pk.verify_prehash(&msg_hash, &signature)
+            .map_err(Error::ECDSAError)
     });
     res.is_ok()
 }

--- a/crates/core/src/ecc/signers/secp256r1/test_secp256r1.rs
+++ b/crates/core/src/ecc/signers/secp256r1/test_secp256r1.rs
@@ -83,25 +83,26 @@ fn test_secp256r1_sign_and_verify() {
 }
 
 #[test]
-fn test_secp256r1_rejects_high_s_signature() {
+fn test_secp256r1_rejects_high_s_signature() -> Result<()> {
     let sk =
-        SecretKey::try_from("2544acda37415a476d42312969926dc48e529867036cec71922d4177ea9c1038")
-            .unwrap();
-    let pk = super::super::super::keys::SigningSecretKey::Secp256r1(sk.clone())
-        .public_key()
-        .unwrap();
-    let super::super::super::keys::VerificationPublicKey::Secp256r1(pk) = pk else {
-        unreachable!("secp256r1 signing key derives a secp256r1 public key");
-    };
+        SecretKey::try_from("2544acda37415a476d42312969926dc48e529867036cec71922d4177ea9c1038")?;
+    let sk_bytes: FieldBytes<p256::NistP256> = (&sk).into();
+    let signing_key = ecdsa::SigningKey::<p256::NistP256>::from_bytes(&sk_bytes)?;
+    let encoded = signing_key.verifying_key().to_encoded_point(false);
+    let pk = PublicKey::from_u8(
+        encoded
+            .as_bytes()
+            .get(1..)
+            .ok_or(Error::PublicKeyBadFormat)?,
+    )?;
     let msg = b"canonical signature";
-    let low_s =
-        ecdsa::Signature::<p256::NistP256>::from_slice(&sign(&sk, &hash(msg)).unwrap()).unwrap();
+    let low_s = ecdsa::Signature::<p256::NistP256>::from_slice(&sign(&sk, &hash(msg))?)?;
     let (r, s) = low_s.split_scalars();
-    let high_s =
-        ecdsa::Signature::<p256::NistP256>::from_scalars(r.to_bytes(), (-s).to_bytes()).unwrap();
+    let high_s = ecdsa::Signature::<p256::NistP256>::from_scalars(r.to_bytes(), (-s).to_bytes())?;
 
-    assert!(high_s.normalize_s().is_some());
+    assert!(super::super::ecdsa_signature_s_is_high(&high_s));
     assert!(!verify(msg, &pk.address(), high_s.to_bytes(), &pk));
+    Ok(())
 }
 
 #[test]

--- a/crates/core/src/ecc/signers/secp256r1/test_secp256r1.rs
+++ b/crates/core/src/ecc/signers/secp256r1/test_secp256r1.rs
@@ -106,6 +106,30 @@ fn test_secp256r1_rejects_high_s_signature() -> Result<()> {
 }
 
 #[test]
+fn test_secp256r1_normalizes_high_s_signature() -> Result<()> {
+    let sk =
+        SecretKey::try_from("2544acda37415a476d42312969926dc48e529867036cec71922d4177ea9c1038")?;
+    let sk_bytes: FieldBytes<p256::NistP256> = (&sk).into();
+    let signing_key = ecdsa::SigningKey::<p256::NistP256>::from_bytes(&sk_bytes)?;
+    let encoded = signing_key.verifying_key().to_encoded_point(false);
+    let pk = PublicKey::from_u8(
+        encoded
+            .as_bytes()
+            .get(1..)
+            .ok_or(Error::PublicKeyBadFormat)?,
+    )?;
+    let msg = b"canonical signature";
+    let low_s = ecdsa::Signature::<p256::NistP256>::from_slice(&sign(&sk, &hash(msg))?)?;
+    let (r, s) = low_s.split_scalars();
+    let high_s = ecdsa::Signature::<p256::NistP256>::from_scalars(r.to_bytes(), (-s).to_bytes())?;
+    let normalized = normalize_signature(high_s.to_bytes())?;
+
+    assert_eq!(normalized, low_s.to_bytes().as_slice());
+    assert!(verify(msg, &pk.address(), normalized, &pk));
+    Ok(())
+}
+
+#[test]
 fn test_invalid_public_key_does_not_verify() {
     let pk = PublicKey([0u8; 33]);
     let sig = [0u8; 64];

--- a/crates/core/src/ecc/signers/secp256r1/test_secp256r1.rs
+++ b/crates/core/src/ecc/signers/secp256r1/test_secp256r1.rs
@@ -68,7 +68,7 @@ fn test_secp256r1_sign_and_verify() {
     let sig: [u8; 64] = hex::decode("43e9f1ce3f4fc0761805cb13b3ec188ccd3d509b7e563f3794e5daf84eaf43bf4fe1343f0b08a810768475fa87fd061a586e943ca9665ee167a3f63c70c72fd9").unwrap().try_into().unwrap();
 
     // Check our sign and verify work right
-    let our_sig = sign(sk, &hash(msg.as_bytes())).unwrap();
+    let our_sig = sign(&sk, &hash(msg.as_bytes())).unwrap();
     assert!(verify(msg.as_bytes(), &pk.address(), our_sig, &pk));
 
     let hash_msg: [u8; 32] =
@@ -80,6 +80,28 @@ fn test_secp256r1_sign_and_verify() {
     assert_eq!(hashed, hash_msg, "hash ret not equal");
 
     assert!(verify(msg.as_bytes(), &pk.address(), sig, &pk));
+}
+
+#[test]
+fn test_secp256r1_rejects_high_s_signature() {
+    let sk =
+        SecretKey::try_from("2544acda37415a476d42312969926dc48e529867036cec71922d4177ea9c1038")
+            .unwrap();
+    let pk = super::super::super::keys::SigningSecretKey::Secp256r1(sk.clone())
+        .public_key()
+        .unwrap();
+    let super::super::super::keys::VerificationPublicKey::Secp256r1(pk) = pk else {
+        unreachable!("secp256r1 signing key derives a secp256r1 public key");
+    };
+    let msg = b"canonical signature";
+    let low_s =
+        ecdsa::Signature::<p256::NistP256>::from_slice(&sign(&sk, &hash(msg)).unwrap()).unwrap();
+    let (r, s) = low_s.split_scalars();
+    let high_s =
+        ecdsa::Signature::<p256::NistP256>::from_scalars(r.to_bytes(), (-s).to_bytes()).unwrap();
+
+    assert!(high_s.normalize_s().is_some());
+    assert!(!verify(msg, &pk.address(), high_s.to_bytes(), &pk));
 }
 
 #[test]

--- a/crates/core/src/error/kind.rs
+++ b/crates/core/src/error/kind.rs
@@ -209,6 +209,10 @@ pub enum Error {
     #[error("ECDSA Invalid recover Id {0}")]
     InvalidRecoverId(u8),
 
+    /// Signature encoding is valid but not in its canonical form.
+    #[error("Signature is not canonical")]
+    NonCanonicalSignature,
+
     /// Gzip encode error.
     #[error("Gzip encode error.")]
     GzipEncode,

--- a/crates/core/src/message/e2e.rs
+++ b/crates/core/src/message/e2e.rs
@@ -412,7 +412,7 @@ impl E2eStreamDecryptor {
 
         while let Some(frame) = self.pending_frames.get(&self.next_sequence) {
             let frame_plaintext =
-                secp256k1::decrypt_bytes(&frame.ciphertext, self.recipient_secret_key)?;
+                secp256k1::decrypt_bytes(&frame.ciphertext, &self.recipient_secret_key)?;
             let is_final = frame.is_final;
             plaintext.extend_from_slice(&frame_plaintext);
             self.pending_frames.remove(&self.next_sequence);
@@ -625,7 +625,13 @@ mod tests {
                     payload_len.div_ceil(frame_limit.max(1)).max(1)
                 );
                 assert_eq!(
-                    decrypt_stream(&frames, stream_id, sender.address().into(), recipient).unwrap(),
+                    decrypt_stream(
+                        &frames,
+                        stream_id,
+                        sender.address().into(),
+                        recipient.clone(),
+                    )
+                    .unwrap(),
                     payload
                 );
             }

--- a/crates/core/src/message/handlers/connection.rs
+++ b/crates/core/src/message/handlers/connection.rs
@@ -344,7 +344,7 @@ pub mod tests {
 
     #[test]
     fn test_connect_successor_hint_skips_requester_self_report() -> Result<()> {
-        let keys = gen_ordered_keys(4);
+        let keys = gen_ordered_keys::<4>();
         let local = keys[0].address().into();
         let requester = keys[1].address().into();
         let next = keys[2].address().into();
@@ -362,7 +362,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_sync_successor_report_connects_advertised_successor() -> Result<()> {
-        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
         let node1 = prepare_node(key1).await;
         let node2 = prepare_node(key2).await;
         let node3 = prepare_node(key3).await;
@@ -443,7 +443,7 @@ pub mod tests {
     //
     #[tokio::test]
     async fn test_triple_nodes_connection_1_2_3() -> Result<()> {
-        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
         test_triple_ordered_nodes_connection(key1, key2, key3).await?;
         Ok(())
     }
@@ -451,7 +451,7 @@ pub mod tests {
     // The 2_3_1 should have same behavior as 1_2_3 since they are all clockwise.
     #[tokio::test]
     async fn test_triple_nodes_connection_2_3_1() -> Result<()> {
-        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
         test_triple_ordered_nodes_connection(key2, key3, key1).await?;
         Ok(())
     }
@@ -459,7 +459,7 @@ pub mod tests {
     // The 3_1_2 should have same behavior as 1_2_3 since they are all clockwise.
     #[tokio::test]
     async fn test_triple_nodes_connection_3_1_2() -> Result<()> {
-        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
         test_triple_ordered_nodes_connection(key3, key1, key2).await?;
         Ok(())
     }
@@ -485,7 +485,7 @@ pub mod tests {
     //
     #[tokio::test]
     async fn test_triple_nodes_connection_3_2_1() -> Result<()> {
-        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
         test_triple_desc_ordered_nodes_connection(key3, key2, key1).await?;
         Ok(())
     }
@@ -493,7 +493,7 @@ pub mod tests {
     // The 2_1_3 should have same behavior as 3_2_1 since they are all anti-clockwise.
     #[tokio::test]
     async fn test_triple_nodes_connection_2_1_3() -> Result<()> {
-        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
         test_triple_desc_ordered_nodes_connection(key2, key1, key3).await?;
         Ok(())
     }
@@ -501,7 +501,7 @@ pub mod tests {
     // The 1_3_2 should have same behavior as 3_2_1 since they are all anti-clockwise.
     #[tokio::test]
     async fn test_triple_nodes_connection_1_3_2() -> Result<()> {
-        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
         test_triple_desc_ordered_nodes_connection(key1, key3, key2).await?;
         Ok(())
     }
@@ -687,7 +687,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_fourth_node_connection() -> Result<()> {
-        let [key1, key2, key3, key4]: [SecretKey; 4] = gen_ordered_keys(4).try_into().unwrap();
+        let [key1, key2, key3, key4]: [SecretKey; 4] = gen_ordered_keys::<4>();
         let (node1, node2, node3) = test_triple_ordered_nodes_connection(key1, key2, key3).await?;
         // we now have three connected nodes
         // node1 -> node2 -> node3
@@ -816,8 +816,7 @@ pub mod tests {
     #[cfg(feature = "dummy")]
     #[tokio::test]
     async fn test_joining_between_bootstrap_and_successor_connects_successor_hint() -> Result<()> {
-        let [key1, joining_key, key3, key4]: [SecretKey; 4] =
-            gen_ordered_keys(4).try_into().unwrap();
+        let [key1, joining_key, key3, key4]: [SecretKey; 4] = gen_ordered_keys::<4>();
         let (node1, node2, node3) = test_triple_ordered_nodes_connection(key1, key3, key4).await?;
         let joining = prepare_node(joining_key).await;
 

--- a/crates/core/src/message/handlers/connection.rs
+++ b/crates/core/src/message/handlers/connection.rs
@@ -362,10 +362,10 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_sync_successor_report_connects_advertised_successor() -> Result<()> {
-        let keys = gen_ordered_keys(3);
-        let node1 = prepare_node(keys[0]).await;
-        let node2 = prepare_node(keys[1]).await;
-        let node3 = prepare_node(keys[2]).await;
+        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+        let node1 = prepare_node(key1).await;
+        let node2 = prepare_node(key2).await;
+        let node3 = prepare_node(key3).await;
 
         manually_establish_connection(&node1.swarm, &node2.swarm).await;
         wait_for_msgs([&node1, &node2, &node3]).await;
@@ -443,8 +443,7 @@ pub mod tests {
     //
     #[tokio::test]
     async fn test_triple_nodes_connection_1_2_3() -> Result<()> {
-        let keys = gen_ordered_keys(3);
-        let (key1, key2, key3) = (keys[0], keys[1], keys[2]);
+        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
         test_triple_ordered_nodes_connection(key1, key2, key3).await?;
         Ok(())
     }
@@ -452,8 +451,7 @@ pub mod tests {
     // The 2_3_1 should have same behavior as 1_2_3 since they are all clockwise.
     #[tokio::test]
     async fn test_triple_nodes_connection_2_3_1() -> Result<()> {
-        let keys = gen_ordered_keys(3);
-        let (key1, key2, key3) = (keys[0], keys[1], keys[2]);
+        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
         test_triple_ordered_nodes_connection(key2, key3, key1).await?;
         Ok(())
     }
@@ -461,8 +459,7 @@ pub mod tests {
     // The 3_1_2 should have same behavior as 1_2_3 since they are all clockwise.
     #[tokio::test]
     async fn test_triple_nodes_connection_3_1_2() -> Result<()> {
-        let keys = gen_ordered_keys(3);
-        let (key1, key2, key3) = (keys[0], keys[1], keys[2]);
+        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
         test_triple_ordered_nodes_connection(key3, key1, key2).await?;
         Ok(())
     }
@@ -488,8 +485,7 @@ pub mod tests {
     //
     #[tokio::test]
     async fn test_triple_nodes_connection_3_2_1() -> Result<()> {
-        let keys = gen_ordered_keys(3);
-        let (key1, key2, key3) = (keys[0], keys[1], keys[2]);
+        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
         test_triple_desc_ordered_nodes_connection(key3, key2, key1).await?;
         Ok(())
     }
@@ -497,8 +493,7 @@ pub mod tests {
     // The 2_1_3 should have same behavior as 3_2_1 since they are all anti-clockwise.
     #[tokio::test]
     async fn test_triple_nodes_connection_2_1_3() -> Result<()> {
-        let keys = gen_ordered_keys(3);
-        let (key1, key2, key3) = (keys[0], keys[1], keys[2]);
+        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
         test_triple_desc_ordered_nodes_connection(key2, key1, key3).await?;
         Ok(())
     }
@@ -506,8 +501,7 @@ pub mod tests {
     // The 1_3_2 should have same behavior as 3_2_1 since they are all anti-clockwise.
     #[tokio::test]
     async fn test_triple_nodes_connection_1_3_2() -> Result<()> {
-        let keys = gen_ordered_keys(3);
-        let (key1, key2, key3) = (keys[0], keys[1], keys[2]);
+        let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
         test_triple_desc_ordered_nodes_connection(key1, key3, key2).await?;
         Ok(())
     }
@@ -693,8 +687,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_fourth_node_connection() -> Result<()> {
-        let keys = gen_ordered_keys(4);
-        let (key1, key2, key3, key4) = (keys[0], keys[1], keys[2], keys[3]);
+        let [key1, key2, key3, key4]: [SecretKey; 4] = gen_ordered_keys(4).try_into().unwrap();
         let (node1, node2, node3) = test_triple_ordered_nodes_connection(key1, key2, key3).await?;
         // we now have three connected nodes
         // node1 -> node2 -> node3
@@ -823,10 +816,10 @@ pub mod tests {
     #[cfg(feature = "dummy")]
     #[tokio::test]
     async fn test_joining_between_bootstrap_and_successor_connects_successor_hint() -> Result<()> {
-        let keys = gen_ordered_keys(4);
-        let (node1, node2, node3) =
-            test_triple_ordered_nodes_connection(keys[0], keys[2], keys[3]).await?;
-        let joining = prepare_node(keys[1]).await;
+        let [key1, joining_key, key3, key4]: [SecretKey; 4] =
+            gen_ordered_keys(4).try_into().unwrap();
+        let (node1, node2, node3) = test_triple_ordered_nodes_connection(key1, key3, key4).await?;
+        let joining = prepare_node(joining_key).await;
 
         manually_establish_connection(&joining.swarm, &node1.swarm).await;
         wait_until(

--- a/crates/core/src/message/handlers/stabilization/tests/mod.rs
+++ b/crates/core/src/message/handlers/stabilization/tests/mod.rs
@@ -91,45 +91,45 @@ async fn test_notify_predecessor_rejects_unadmitted_origin_without_mutating_topo
 
 #[tokio::test]
 async fn test_triple_nodes_stabilization_1_2_3() -> Result<()> {
-    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
     test_triple_ordered_nodes_stabilization(key1, key2, key3).await
 }
 
 #[tokio::test]
 async fn test_triple_nodes_stabilization_2_3_1() -> Result<()> {
-    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
 
     test_triple_ordered_nodes_stabilization(key2, key3, key1).await
 }
 
 #[tokio::test]
 async fn test_triple_nodes_stabilization_3_1_2() -> Result<()> {
-    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
     test_triple_ordered_nodes_stabilization(key3, key1, key2).await
 }
 
 #[tokio::test]
 async fn test_triple_nodes_stabilization_3_2_1() -> Result<()> {
-    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
     test_triple_desc_ordered_nodes_stabilization(key3, key2, key1).await
 }
 
 #[tokio::test]
 async fn test_triple_nodes_stabilization_2_1_3() -> Result<()> {
-    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
     test_triple_desc_ordered_nodes_stabilization(key2, key1, key3).await
 }
 
 #[tokio::test]
 async fn test_triple_nodes_stabilization_1_3_2() -> Result<()> {
-    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
     test_triple_desc_ordered_nodes_stabilization(key1, key3, key2).await
 }
 
 #[tokio::test]
 async fn test_notify_predecessor_report_acks_local_branch_when_predecessor_already_connected(
 ) -> Result<()> {
-    let mut keys = gen_ordered_keys(3).into_iter();
+    let mut keys = gen_ordered_keys::<3>().into_iter();
     let key1 = next_generated_key(&mut keys)?;
     let key2 = next_generated_key(&mut keys)?;
     let key3 = next_generated_key(&mut keys)?;

--- a/crates/core/src/message/handlers/stabilization/tests/mod.rs
+++ b/crates/core/src/message/handlers/stabilization/tests/mod.rs
@@ -91,44 +91,38 @@ async fn test_notify_predecessor_rejects_unadmitted_origin_without_mutating_topo
 
 #[tokio::test]
 async fn test_triple_nodes_stabilization_1_2_3() -> Result<()> {
-    let keys = gen_ordered_keys(3);
-    let (key1, key2, key3) = (keys[0], keys[1], keys[2]);
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
     test_triple_ordered_nodes_stabilization(key1, key2, key3).await
 }
 
 #[tokio::test]
 async fn test_triple_nodes_stabilization_2_3_1() -> Result<()> {
-    let keys = gen_ordered_keys(3);
-    let (key1, key2, key3) = (keys[0], keys[1], keys[2]);
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
 
     test_triple_ordered_nodes_stabilization(key2, key3, key1).await
 }
 
 #[tokio::test]
 async fn test_triple_nodes_stabilization_3_1_2() -> Result<()> {
-    let keys = gen_ordered_keys(3);
-    let (key1, key2, key3) = (keys[0], keys[1], keys[2]);
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
     test_triple_ordered_nodes_stabilization(key3, key1, key2).await
 }
 
 #[tokio::test]
 async fn test_triple_nodes_stabilization_3_2_1() -> Result<()> {
-    let keys = gen_ordered_keys(3);
-    let (key1, key2, key3) = (keys[0], keys[1], keys[2]);
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
     test_triple_desc_ordered_nodes_stabilization(key3, key2, key1).await
 }
 
 #[tokio::test]
 async fn test_triple_nodes_stabilization_2_1_3() -> Result<()> {
-    let keys = gen_ordered_keys(3);
-    let (key1, key2, key3) = (keys[0], keys[1], keys[2]);
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
     test_triple_desc_ordered_nodes_stabilization(key2, key1, key3).await
 }
 
 #[tokio::test]
 async fn test_triple_nodes_stabilization_1_3_2() -> Result<()> {
-    let keys = gen_ordered_keys(3);
-    let (key1, key2, key3) = (keys[0], keys[1], keys[2]);
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
     test_triple_desc_ordered_nodes_stabilization(key1, key3, key2).await
 }
 

--- a/crates/core/src/message/handlers/storage/tests/test_api.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_api.rs
@@ -19,7 +19,7 @@ use crate::tests::manually_establish_connection;
 
 #[tokio::test]
 async fn test_storage_store_fetches_remote_entry_into_cache() -> Result<()> {
-    let mut keys = gen_ordered_keys(2).into_iter();
+    let mut keys = gen_ordered_keys::<2>().into_iter();
     let key1 = next_generated_key(&mut keys)?;
     let key2 = next_generated_key(&mut keys)?;
     let node1 = prepare_node(key1).await;
@@ -98,7 +98,7 @@ async fn test_storage_store_fetches_remote_entry_into_cache() -> Result<()> {
 
 #[tokio::test]
 async fn test_storage_append_data_preserves_entry_payload_order() -> Result<()> {
-    let mut keys = gen_ordered_keys(2).into_iter();
+    let mut keys = gen_ordered_keys::<2>().into_iter();
     let key1 = next_generated_key(&mut keys)?;
     let key2 = next_generated_key(&mut keys)?;
     let node1 = prepare_node(key1).await;
@@ -172,7 +172,7 @@ async fn test_storage_append_data_preserves_entry_payload_order() -> Result<()> 
 
 #[tokio::test]
 async fn test_storage_touch_data_moves_existing_entry_payload_to_end_once() -> Result<()> {
-    let mut keys = gen_ordered_keys(2).into_iter();
+    let mut keys = gen_ordered_keys::<2>().into_iter();
     let key1 = next_generated_key(&mut keys)?;
     let key2 = next_generated_key(&mut keys)?;
     let node1 = prepare_node(key1).await;
@@ -219,7 +219,7 @@ async fn test_storage_touch_data_moves_existing_entry_payload_to_end_once() -> R
 
 #[tokio::test]
 async fn test_storage_tombstone_data_removes_observed_payload() -> Result<()> {
-    let mut keys = gen_ordered_keys(2).into_iter();
+    let mut keys = gen_ordered_keys::<2>().into_iter();
     let key1 = next_generated_key(&mut keys)?;
     let key2 = next_generated_key(&mut keys)?;
     let node1 = prepare_node(key1).await;
@@ -270,7 +270,7 @@ async fn test_storage_tombstone_data_removes_observed_payload() -> Result<()> {
 
 #[tokio::test]
 async fn test_storage_compact_data_prunes_tombstones_and_preserves_owner_values() -> Result<()> {
-    let mut keys = gen_ordered_keys(2).into_iter();
+    let mut keys = gen_ordered_keys::<2>().into_iter();
     let key1 = next_generated_key(&mut keys)?;
     let key2 = next_generated_key(&mut keys)?;
     let node1 = prepare_node(key1).await;

--- a/crates/core/src/message/handlers/storage/tests/test_repair.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_repair.rs
@@ -233,7 +233,7 @@ async fn test_placed_entry_operation_rejects_non_affine_placement() -> Result<()
 
 #[tokio::test]
 async fn test_remote_redundant_store_writes_split_replica_at_affine_placement() -> Result<()> {
-    let mut keys = gen_ordered_keys(2).into_iter();
+    let mut keys = gen_ordered_keys::<2>().into_iter();
     let node1 = prepare_node_with_storage_redundancy(next_generated_key(&mut keys)?, 2)?;
     let node2 = prepare_node_with_storage_redundancy(next_generated_key(&mut keys)?, 2)?;
 

--- a/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
@@ -138,7 +138,7 @@ async fn test_persist_synced_entries_returns_acks_for_owned_entries() -> Result<
 
 #[tokio::test]
 async fn test_sync_entries_handler_skips_entries_owned_by_another_virtual_owner() -> Result<()> {
-    let mut keys = gen_ordered_keys(2).into_iter();
+    let mut keys = gen_ordered_keys::<2>().into_iter();
     let sender = prepare_node_with_virtual_nodes(next_generated_key(&mut keys)?, 2)?;
     let receiver = prepare_node_with_virtual_nodes(next_generated_key(&mut keys)?, 2)?;
     manually_establish_connection(&sender.swarm, &receiver.swarm).await;
@@ -222,7 +222,7 @@ async fn test_sync_entries_handler_skips_entries_owned_by_another_virtual_owner(
 #[tokio::test]
 async fn test_sync_entries_physical_destination_routes_by_physical_did_not_storage_owner(
 ) -> Result<()> {
-    let mut keys = gen_ordered_keys(6).into_iter();
+    let mut keys = gen_ordered_keys::<6>().into_iter();
     let node = prepare_node_with_virtual_nodes(next_generated_key(&mut keys)?, 4)?;
     let mut peers = Vec::new();
     for _ in 0..5 {

--- a/crates/core/src/message/handlers/storage/tests/test_sync_receive.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_sync_receive.rs
@@ -274,7 +274,7 @@ async fn test_storage_sync_batch_persists_one_entry_per_step_after_validation() 
 
 #[tokio::test]
 async fn test_sync_entries_handler_accepts_placement_destination_on_local_branch() -> Result<()> {
-    let mut keys = gen_ordered_keys(2).into_iter();
+    let mut keys = gen_ordered_keys::<2>().into_iter();
     let node1 = prepare_node(next_generated_key(&mut keys)?).await;
     let node2 = prepare_node(next_generated_key(&mut keys)?).await;
     manually_establish_connection(&node1.swarm, &node2.swarm).await;
@@ -381,7 +381,7 @@ async fn test_additive_repair_sync_persists_without_cleanup_report() -> Result<(
 
 #[tokio::test]
 async fn test_sync_entries_handler_rejects_mismatched_placement_destination() -> Result<()> {
-    let mut keys = gen_ordered_keys(2).into_iter();
+    let mut keys = gen_ordered_keys::<2>().into_iter();
     let sender = prepare_node(next_generated_key(&mut keys)?).await;
     let receiver = prepare_node(next_generated_key(&mut keys)?).await;
     manually_establish_connection(&sender.swarm, &receiver.swarm).await;
@@ -432,7 +432,7 @@ async fn test_sync_entries_handler_rejects_mismatched_placement_destination() ->
 #[tokio::test]
 async fn test_sync_entries_handler_rejects_physical_destination_for_unowned_placement() -> Result<()>
 {
-    let mut keys = gen_ordered_keys(2).into_iter();
+    let mut keys = gen_ordered_keys::<2>().into_iter();
     let sender = prepare_node(next_generated_key(&mut keys)?).await;
     let receiver = prepare_node(next_generated_key(&mut keys)?).await;
     manually_establish_connection(&sender.swarm, &receiver.swarm).await;
@@ -481,7 +481,7 @@ async fn test_sync_entries_handler_rejects_physical_destination_for_unowned_plac
 
 #[tokio::test]
 async fn test_sync_entries_handler_acks_local_branch_with_successor_witness() -> Result<()> {
-    let mut keys = gen_ordered_keys(2).into_iter();
+    let mut keys = gen_ordered_keys::<2>().into_iter();
     let sender = prepare_node(next_generated_key(&mut keys)?).await;
     let receiver = prepare_node(next_generated_key(&mut keys)?).await;
     manually_establish_connection(&sender.swarm, &receiver.swarm).await;

--- a/crates/core/src/session/mod.rs
+++ b/crates/core/src/session/mod.rs
@@ -26,7 +26,7 @@
 //!
 //! let builder = SessionSkBuilder::new(account_entity, account_type);
 //! let unsigned_proof = builder.unsigned_proof();
-//! let session_sig = user_secret_key.sign(&unsigned_proof).to_vec();
+//! let session_sig = user_secret_key.sign(&unsigned_proof).unwrap().to_vec();
 //! let session_sk = builder.set_session_sig(session_sig).build().unwrap();
 //!
 //! assert_eq!(session_sk.account_did(), user_secret_key_did);

--- a/crates/core/src/session/signing_key.rs
+++ b/crates/core/src/session/signing_key.rs
@@ -48,7 +48,7 @@ impl SessionSk {
         let account_entity = Did::from(key.address()).to_string();
         let account_type = "secp256k1".to_string();
         let builder = SessionSkBuilder::new(account_entity, account_type);
-        let sig = key.sign(&builder.unsigned_proof());
+        let sig = key.sign(&builder.unsigned_proof())?;
         builder.set_session_sig(sig.to_vec()).build()
     }
 
@@ -68,13 +68,13 @@ impl SessionSk {
         sealed: &crate::ecc::elgamal::impls::secp256k1::AeadCiphertext,
         aad: &[u8],
     ) -> Result<Vec<u8>> {
-        crate::ecc::elgamal::impls::secp256k1::decrypt_aead(sealed, aad, self.sk)
+        crate::ecc::elgamal::impls::secp256k1::decrypt_aead(sealed, aad, &self.sk)
     }
 
     /// Sign a message with the delegated session key.
     pub fn sign(&self, msg: &[u8]) -> Result<Vec<u8>> {
         let h = keccak256(msg);
-        Ok(signers::secp256k1::sign(self.sk, &h).to_vec())
+        Ok(signers::secp256k1::sign(&self.sk, &h)?.to_vec())
     }
 
     /// Get the authorizing account DID.

--- a/crates/core/src/session/test_session.rs
+++ b/crates/core/src/session/test_session.rs
@@ -46,8 +46,8 @@ pub fn test_session_verify_secp256r1_account_key() {
             .unwrap();
     let mut builder = SessionSkBuilder::new(account_entity.to_string(), "secp256r1".to_string());
     let proof = builder.unsigned_proof();
-    let sig =
-        signers::secp256r1::sign(signing_key, &signers::secp256r1::hash(proof.as_bytes())).unwrap();
+    let sig = signers::secp256r1::sign(&signing_key, &signers::secp256r1::hash(proof.as_bytes()))
+        .unwrap();
     builder = builder.set_session_sig(sig.to_vec());
 
     let session = builder.build().unwrap().session();

--- a/crates/core/src/tests/default/test_connection.rs
+++ b/crates/core/src/tests/default/test_connection.rs
@@ -13,13 +13,13 @@ use crate::tests::manually_establish_connection;
 
 #[tokio::test]
 async fn test_handshake_on_both_sides_ordered() {
-    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
     test_handshake_on_both_sides(key1, key2, key3).await
 }
 
 #[tokio::test]
 async fn test_handshake_on_both_sides_desc_ordered() {
-    let [key3, key2, key1]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+    let [key3, key2, key1]: [SecretKey; 3] = gen_ordered_keys::<3>();
     test_handshake_on_both_sides(key1, key2, key3).await
 }
 
@@ -130,7 +130,7 @@ async fn test_handshake_on_both_sides(key1: SecretKey, key2: SecretKey, key3: Se
 async fn test_dummy_mismatched_data_channel_open_does_not_admit_peer() {
     dummy_controlled::enable(true);
 
-    let [key1, key2]: [SecretKey; 2] = gen_ordered_keys(2).try_into().unwrap();
+    let [key1, key2]: [SecretKey; 2] = gen_ordered_keys::<2>();
     let node1 = prepare_node(key1).await;
     let node2 = prepare_node(key2).await;
 

--- a/crates/core/src/tests/default/test_connection.rs
+++ b/crates/core/src/tests/default/test_connection.rs
@@ -13,15 +13,13 @@ use crate::tests::manually_establish_connection;
 
 #[tokio::test]
 async fn test_handshake_on_both_sides_ordered() {
-    let keys = gen_ordered_keys(3);
-    let (key1, key2, key3) = (keys[0], keys[1], keys[2]);
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
     test_handshake_on_both_sides(key1, key2, key3).await
 }
 
 #[tokio::test]
 async fn test_handshake_on_both_sides_desc_ordered() {
-    let keys = gen_ordered_keys(3);
-    let (key3, key2, key1) = (keys[0], keys[1], keys[2]);
+    let [key3, key2, key1]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
     test_handshake_on_both_sides(key1, key2, key3).await
 }
 
@@ -132,9 +130,9 @@ async fn test_handshake_on_both_sides(key1: SecretKey, key2: SecretKey, key3: Se
 async fn test_dummy_mismatched_data_channel_open_does_not_admit_peer() {
     dummy_controlled::enable(true);
 
-    let keys = gen_ordered_keys(2);
-    let node1 = prepare_node(keys[0]).await;
-    let node2 = prepare_node(keys[1]).await;
+    let [key1, key2]: [SecretKey; 2] = gen_ordered_keys(2).try_into().unwrap();
+    let node1 = prepare_node(key1).await;
+    let node2 = prepare_node(key2).await;
 
     let offer = node1.swarm.create_offer(node2.did()).await.unwrap();
     assert!(node1.swarm.transport.get_connection(node2.did()).is_none());

--- a/crates/core/src/tests/default/test_message_handler.rs
+++ b/crates/core/src/tests/default/test_message_handler.rs
@@ -96,11 +96,7 @@ async fn test_handle_join() -> Result<()> {
     let node2 = prepare_node(key2).await;
     manually_establish_connection(&node1.swarm, &node2.swarm).await;
     assert!(node1.listen_once().await.is_some());
-    assert!(node1
-        .dht()
-        .successors()
-        .list()?
-        .contains(&key2.address().into()));
+    assert!(node1.dht().successors().list()?.contains(&node2.did()));
     Ok(())
 }
 
@@ -139,10 +135,10 @@ async fn test_join_dht_keeps_local_join_when_convergence_send_fails() -> Result<
 async fn test_handle_dht_notify_remote_action_sends_predecessor_to_target() -> Result<()> {
     dummy_controlled::enable(true);
 
-    let keys = gen_ordered_keys(3);
-    let node1 = prepare_node(keys[0]).await;
-    let node2 = prepare_node(keys[1]).await;
-    let node3 = prepare_node(keys[2]).await;
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+    let node1 = prepare_node(key1).await;
+    let node2 = prepare_node(key2).await;
+    let node3 = prepare_node(key3).await;
     manually_establish_connection(&node1.swarm, &node2.swarm).await;
 
     drain_controlled_dummy_events().await;
@@ -178,8 +174,7 @@ async fn test_handle_dht_notify_remote_action_sends_predecessor_to_target() -> R
 
 #[tokio::test]
 async fn test_handle_connect_node() -> Result<()> {
-    let keys = gen_ordered_keys(3);
-    let (key1, key2, key3) = (keys[0], keys[1], keys[2]);
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
 
     let node1 = prepare_node(key1).await;
     let node2 = prepare_node(key2).await;
@@ -193,9 +188,9 @@ async fn test_handle_connect_node() -> Result<()> {
 
     wait_for_connection_state(&node1, node2.did(), WebrtcConnectionState::Connected).await?;
     wait_for_connection_state(&node2, node3.did(), WebrtcConnectionState::Connected).await?;
-    wait_for_successor(&node1, key2.address().into()).await?;
-    wait_for_successor(&node2, key3.address().into()).await?;
-    wait_for_successor(&node3, key2.address().into()).await?;
+    wait_for_successor(&node1, node2.did()).await?;
+    wait_for_successor(&node2, node3.did()).await?;
+    wait_for_successor(&node3, node2.did()).await?;
 
     println!("node1 key address: {:?}", node1.did());
     println!("node2 key address: {:?}", node2.did());
@@ -212,17 +207,17 @@ async fn test_handle_connect_node() -> Result<()> {
         println!("node3.dht() successor: {dht3_successor:?}");
 
         assert!(
-            dht1_successor.list()?.contains(&key2.address().into()),
+            dht1_successor.list()?.contains(&node2.did()),
             "Expect node1.dht() successor is key2, Found: {:?}",
             dht1_successor.list()?
         );
         assert!(
-            dht2_successor.list()?.contains(&key3.address().into()),
+            dht2_successor.list()?.contains(&node3.did()),
             "{:?}",
             dht2_successor.list()
         );
         assert!(
-            dht3_successor.list()?.contains(&key2.address().into()),
+            dht3_successor.list()?.contains(&node2.did()),
             "node3.dht() successor is key2"
         );
     }
@@ -249,24 +244,18 @@ async fn test_handle_notify_predecessor() -> Result<()> {
     manually_establish_connection(&node1.swarm, &node2.swarm).await;
 
     wait_for_connection_state(&node1, node2.did(), WebrtcConnectionState::Connected).await?;
-    wait_for_successor(&node1, key2.address().into()).await?;
-    wait_for_successor(&node2, key1.address().into()).await?;
+    wait_for_successor(&node1, node2.did()).await?;
+    wait_for_successor(&node2, node1.did()).await?;
     node1
         .swarm
         .send_message(
-            Message::NotifyPredecessorSend(message::NotifyPredecessorSend {
-                did: key1.address().into(),
-            }),
+            Message::NotifyPredecessorSend(message::NotifyPredecessorSend { did: node1.did() }),
             node2.did(),
         )
         .await
         .unwrap();
-    wait_for_predecessor(&node2, key1.address().into()).await?;
-    assert!(node1
-        .dht()
-        .successors()
-        .list()?
-        .contains(&key2.address().into()));
+    wait_for_predecessor(&node2, node1.did()).await?;
+    assert!(node1.dht().successors().list()?.contains(&node2.did()));
 
     Ok(())
 }
@@ -283,8 +272,8 @@ async fn test_handle_find_successor_increase() -> Result<()> {
     manually_establish_connection(&node1.swarm, &node2.swarm).await;
 
     wait_for_connection_state(&node1, node2.did(), WebrtcConnectionState::Connected).await?;
-    wait_for_successor(&node1, key2.address().into()).await?;
-    wait_for_successor(&node2, key1.address().into()).await?;
+    wait_for_successor(&node1, node2.did()).await?;
+    wait_for_successor(&node2, node1.did()).await?;
     node1
         .swarm
         .send_message(
@@ -293,12 +282,8 @@ async fn test_handle_find_successor_increase() -> Result<()> {
         )
         .await
         .unwrap();
-    wait_for_predecessor(&node2, key1.address().into()).await?;
-    assert!(node1
-        .dht()
-        .successors()
-        .list()?
-        .contains(&key2.address().into()));
+    wait_for_predecessor(&node2, node1.did()).await?;
+    assert!(node1.dht().successors().list()?.contains(&node2.did()));
 
     println!("node1: {:?}, node2: {:?}", node1.did(), node2.did());
     node2
@@ -314,16 +299,8 @@ async fn test_handle_find_successor_increase() -> Result<()> {
         .await
         .unwrap();
     wait_for_msgs([&node1, &node2]).await;
-    assert!(node2
-        .dht()
-        .successors()
-        .list()?
-        .contains(&key1.address().into()));
-    assert!(node1
-        .dht()
-        .successors()
-        .list()?
-        .contains(&key2.address().into()));
+    assert!(node2.dht().successors().list()?.contains(&node1.did()));
+    assert!(node1.dht().successors().list()?.contains(&node2.did()));
 
     Ok(())
 }
@@ -341,10 +318,10 @@ async fn test_handle_find_successor_decrease() -> Result<()> {
     manually_establish_connection(&node1.swarm, &node2.swarm).await;
 
     wait_for_connection_state(&node1, node2.did(), WebrtcConnectionState::Connected).await?;
-    wait_for_successor(&node1, key2.address().into()).await?;
-    wait_for_successor(&node2, key1.address().into()).await?;
-    wait_for_finger(&node1, key2.address().into()).await?;
-    wait_for_finger(&node2, key1.address().into()).await?;
+    wait_for_successor(&node1, node2.did()).await?;
+    wait_for_successor(&node2, node1.did()).await?;
+    wait_for_finger(&node1, node2.did()).await?;
+    wait_for_finger(&node2, node1.did()).await?;
     node1
         .swarm
         .send_message(
@@ -353,12 +330,8 @@ async fn test_handle_find_successor_decrease() -> Result<()> {
         )
         .await
         .unwrap();
-    wait_for_predecessor(&node2, key1.address().into()).await?;
-    assert!(node1
-        .dht()
-        .successors()
-        .list()?
-        .contains(&key2.address().into()));
+    wait_for_predecessor(&node2, node1.did()).await?;
+    assert!(node1.dht().successors().list()?.contains(&node2.did()));
     println!("node1: {:?}, node2: {:?}", node1.did(), node2.did());
     node2
         .swarm
@@ -375,8 +348,8 @@ async fn test_handle_find_successor_decrease() -> Result<()> {
     wait_for_msgs([&node1, &node2]).await;
     let dht1_successor = node1.dht().successors();
     let dht2_successor = node2.dht().successors();
-    assert!(dht2_successor.list()?.contains(&key1.address().into()));
-    assert!(dht1_successor.list()?.contains(&key2.address().into()));
+    assert!(dht2_successor.list()?.contains(&node1.did()));
+    assert!(dht1_successor.list()?.contains(&node2.did()));
 
     Ok(())
 }
@@ -403,8 +376,8 @@ async fn test_handle_storage() -> Result<()> {
     // node1's successor is node2
     // node2's successor is node1
     wait_for_connection_state(&node1, node2.did(), WebrtcConnectionState::Connected).await?;
-    wait_for_successor(&node1, key2.address().into()).await?;
-    wait_for_successor(&node2, key1.address().into()).await?;
+    wait_for_successor(&node1, node2.did()).await?;
+    wait_for_successor(&node2, node1.did()).await?;
     node1
         .swarm
         .send_message(
@@ -413,12 +386,8 @@ async fn test_handle_storage() -> Result<()> {
         )
         .await
         .unwrap();
-    wait_for_predecessor(&node2, key1.address().into()).await?;
-    assert!(node1
-        .dht()
-        .successors()
-        .list()?
-        .contains(&key2.address().into()));
+    wait_for_predecessor(&node2, node1.did()).await?;
+    assert!(node1.dht().successors().list()?.contains(&node2.did()));
 
     assert!(node2.dht().storage.count().await.unwrap() == 0);
     let message = String::from("this is a test string");

--- a/crates/core/src/tests/default/test_message_handler.rs
+++ b/crates/core/src/tests/default/test_message_handler.rs
@@ -135,7 +135,7 @@ async fn test_join_dht_keeps_local_join_when_convergence_send_fails() -> Result<
 async fn test_handle_dht_notify_remote_action_sends_predecessor_to_target() -> Result<()> {
     dummy_controlled::enable(true);
 
-    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
     let node1 = prepare_node(key1).await;
     let node2 = prepare_node(key2).await;
     let node3 = prepare_node(key3).await;
@@ -174,7 +174,7 @@ async fn test_handle_dht_notify_remote_action_sends_predecessor_to_target() -> R
 
 #[tokio::test]
 async fn test_handle_connect_node() -> Result<()> {
-    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys(3).try_into().unwrap();
+    let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
 
     let node1 = prepare_node(key1).await;
     let node2 = prepare_node(key2).await;

--- a/crates/core/src/tests/default/test_stabilization/mod.rs
+++ b/crates/core/src/tests/default/test_stabilization/mod.rs
@@ -213,13 +213,13 @@ async fn test_stabilization_once() -> Result<()> {
     manually_establish_connection(&node1.swarm, &node2.swarm).await;
     println!("swarm1: {:?}, swarm2: {:?}", node1.did(), node2.did());
 
-    wait_for_successor(&node1, key2.address().into()).await?;
-    wait_for_successor(&node2, key1.address().into()).await?;
+    wait_for_successor(&node1, node2.did()).await?;
+    wait_for_successor(&node2, node1.did()).await?;
 
     let stabilizer = node1.swarm.stabilizer();
     stabilizer.stabilize().await?;
-    wait_for_predecessor(&node2, key1.address().into()).await?;
-    wait_for_successor(&node1, key2.address().into()).await?;
+    wait_for_predecessor(&node2, node1.did()).await?;
+    wait_for_successor(&node1, node2.did()).await?;
 
     Ok(())
 }
@@ -776,14 +776,14 @@ async fn test_stabilization() -> Result<()> {
     let node2 = prepare_node(key2).await;
     manually_establish_connection(&node1.swarm, &node2.swarm).await;
 
-    wait_for_successor(&node1, key2.address().into()).await?;
-    wait_for_successor(&node2, key1.address().into()).await?;
+    wait_for_successor(&node1, node2.did()).await?;
+    wait_for_successor(&node2, node1.did()).await?;
 
     let stabilizer1 = node1.swarm.stabilizer();
     let stabilizer2 = node2.swarm.stabilizer();
     tokio::try_join!(stabilizer1.stabilize(), stabilizer2.stabilize())?;
 
-    wait_for_predecessor(&node2, key1.address().into()).await?;
-    wait_for_predecessor(&node1, key2.address().into()).await?;
+    wait_for_predecessor(&node2, node1.did()).await?;
+    wait_for_predecessor(&node1, node2.did()).await?;
     Ok(())
 }

--- a/crates/node/bin/rings.rs
+++ b/crates/node/bin/rings.rs
@@ -462,7 +462,7 @@ impl SessionArgs {
             .set_ttl(self.ttl * 1000);
         let unsigned_proof = ssk_builder.unsigned_proof();
 
-        let sig = key.sign(&unsigned_proof).to_vec();
+        let sig = key.sign(&unsigned_proof)?.to_vec();
         let ssk_builder = ssk_builder.set_session_sig(sig);
 
         let ssk = ssk_builder.build()?;
@@ -477,8 +477,8 @@ impl SessionArgs {
     }
 
     fn load_or_create_key(&self) -> anyhow::Result<SecretKey> {
-        if let Some(key) = self.ecdsa_key {
-            return Ok(key);
+        if let Some(key) = &self.ecdsa_key {
+            return Ok(key.clone());
         }
 
         if let Some(key_file) = &self.ecdsa_key_file {

--- a/crates/node/src/processor/tests/test_network.rs
+++ b/crates/node/src/processor/tests/test_network.rs
@@ -375,7 +375,7 @@ async fn test_processor_e2e_message_streams_and_decrypts_with_receiver_identity_
     let identity2 = SecretKey::random();
 
     let p1 = prepare_processor_with_identity_key(identity1).await;
-    let p2 = prepare_processor_with_identity_key(identity2).await;
+    let p2 = prepare_processor_with_identity_key(identity2.clone()).await;
 
     p1.swarm.set_callback(callback1.clone()).unwrap();
     p2.swarm.set_callback(callback2.clone()).unwrap();

--- a/crates/node/src/provider/ffi.rs
+++ b/crates/node/src/provider/ffi.rs
@@ -542,7 +542,7 @@ mod tests {
         }
         let data = unsafe { CStr::from_ptr(data) };
         let key = SecretKey::try_from(TEST_SECRET_KEY).expect("valid test key");
-        let signature = eip191::sign_raw(key, data.to_bytes());
+        let signature = eip191::sign_raw(&key, data.to_bytes()).expect("valid test signature");
         unsafe {
             std::ptr::copy_nonoverlapping(
                 signature.as_ptr().cast::<c_char>(),

--- a/examples/native/src/lib.rs
+++ b/examples/native/src/lib.rs
@@ -141,7 +141,7 @@ where
 pub fn build_session_key(key: &SecretKey) -> rings_core::error::Result<SessionSk> {
     let did = Did::from(key.address());
     let mut builder = SessionSkBuilder::new(did.to_string(), "secp256k1".to_string());
-    let sig = key.sign(&builder.unsigned_proof());
+    let sig = key.sign(&builder.unsigned_proof())?;
     builder = builder.set_session_sig(sig.to_vec());
     builder.build()
 }

--- a/frontend/src/wallet.rs
+++ b/frontend/src/wallet.rs
@@ -6,6 +6,7 @@ use base64::Engine;
 use js_sys::Array;
 use js_sys::Object;
 use js_sys::Uint8Array;
+use rings_node::prelude::rings_core::ecc::signers::secp256r1;
 use wasm_bindgen::JsValue;
 
 use crate::browser_api::await_js;
@@ -221,7 +222,13 @@ async fn sign_webcrypto(private_key: &JsValue, proof: &str) -> Result<Vec<u8>, S
         &message.into(),
     )?)
     .await?;
-    Ok(Uint8Array::new(&signature).to_vec())
+    normalize_webcrypto_signature(Uint8Array::new(&signature).to_vec())
+}
+
+fn normalize_webcrypto_signature(signature: Vec<u8>) -> Result<Vec<u8>, String> {
+    secp256r1::normalize_signature(&signature)
+        .map(|signature| signature.to_vec())
+        .map_err(|error| format!("wallet returned an invalid secp256r1 signature: {error}"))
 }
 
 async fn connect_eip191() -> Result<WalletAccount, String> {
@@ -428,6 +435,20 @@ mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), test)]
     fn test_hex_signature_parser_accepts_prefixed_even_hex() {
         assert_eq!(hex_to_bytes("0x000aff"), Ok(vec![0, 10, 255]));
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    #[cfg_attr(not(target_arch = "wasm32"), test)]
+    fn test_webcrypto_signature_normalizer_rewrites_high_s() {
+        let result = (|| -> Result<(), String> {
+            let low_s = hex_to_bytes("43e9f1ce3f4fc0761805cb13b3ec188ccd3d509b7e563f3794e5daf84eaf43bf4fe1343f0b08a810768475fa87fd061a586e943ca9665ee167a3f63c70c72fd9")?;
+            let high_s = hex_to_bytes("43e9f1ce3f4fc0761805cb13b3ec188ccd3d509b7e563f3794e5daf84eaf43bfb01ecbbff4f757f0897b8a057802f9e564786670fdb13fa38c15d4868b9bf578")?;
+
+            assert_eq!(normalize_webcrypto_signature(high_s), Ok(low_s));
+            Ok(())
+        })();
+
+        assert_eq!(result, Ok(()));
     }
 }
 


### PR DESCRIPTION
## Summary

- redact `Debug` output and zeroize long-lived secp256k1/Ed25519 signing secret storage on drop; remove implicit `Copy` from secret-bearing types
- store secp256k1 `SecretKey` as a construction-time-validated k256 secret, return zeroizing serialized key copies, and remove silent fallback signatures/scalars
- reject high-s secp256r1 signatures, canonicalize WebCrypto P-256 signatures before session authorization, use strict Ed25519 verification, validate EIP-191/BIP-137 recovery IDs through one helper, and keep the secp256k1 high-s check as an explicit error-mapping invariant

## Compatibility

This intentionally changes the public signing surface: `SecretKey::{sign, sign_raw, sign_hash}` and the secp256k1/EIP-191 signing helpers now return `Result`, signing helpers borrow secret keys, `SecretKey::ser()` returns `Zeroizing<[u8; 32]>`, by-value secret conversion impls were removed, and secret key types are no longer `Copy`. Secp256r1 high-s verification and strict Ed25519 verification are called out in the changelog as breaking validation changes. Browser WebCrypto session signatures are normalized to low-S before verification so freshly created frontend P-256 accounts remain accepted under the stricter verifier.

## Validation

- `cargo +nightly-2026-07-02 fmt --all -- --check`
- `cargo check -p rings-node --all-features`
- `cargo check -p rings-node --features browser_default --no-default-features --target=wasm32-unknown-unknown`
- `cargo check --target=wasm32-unknown-unknown` in `frontend/`
- `cargo clippy --all --tests -- -D warnings`
- `cargo clippy --target=wasm32-unknown-unknown --all-targets -- -D warnings` in `frontend/`
- `cargo clippy -p rings-node --features browser_default --no-deps --no-default-features --target=wasm32-unknown-unknown --tests -- -D warnings`
- `cargo clippy -p rings-core --features wasm --no-deps --no-default-features --target=wasm32-unknown-unknown --tests -- -D warnings`
- `cargo test -p rings-core --features dummy --quiet` (655 passed, 4 ignored; doc tests 1 passed, 2 ignored)
- `cargo test -p rings-core --features dummy ecc::signers::secp256r1 --quiet`
- `npm run test:frontend-extension-webview`
- `git diff --check`

Closes #705
Closes #706
Closes #707
