### PR TITLE
build: fix the release pipeline (complete publish set, exclude examples, auto-tag)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,76 @@
+name: Auto Tag
+
+# Turn a version bump into a real release. When a PR that bumps
+# `[workspace.package].version` lands on master, this creates and pushes the matching
+# `vX.Y.Z` tag and kicks off `Auto Release` for it.
+#
+# Why an explicit dispatch instead of relying on the tag push: a tag pushed with the
+# built-in `GITHUB_TOKEN` does not trigger another workflow (GitHub suppresses recursive
+# runs), so `Auto Release`'s `push: tags: v*` path would never fire. We push the tag for
+# provenance (it points at the merge commit) and then dispatch `Auto Release` ourselves.
+#
+# This runs alongside the existing rolling `prerelease` that `Auto Release` publishes on
+# every master push; it only adds a real, versioned release when the version changes.
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - Cargo.toml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-tag-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: tag version bump
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
+        with:
+          fetch-depth: 0
+
+      - name: Read workspace version
+        id: version
+        run: |
+          version="$(awk '
+            /^\[workspace\.package\]/ { in_section = 1; next }
+            /^\[/ { in_section = 0 }
+            in_section && /^version[[:space:]]*=/ {
+              gsub(/.*=[[:space:]]*"|".*/, "")
+              print
+              exit
+            }
+          ' Cargo.toml)"
+          if [ -z "$version" ]; then
+            echo "could not read [workspace.package] version from Cargo.toml" >&2
+            exit 1
+          fi
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Tag and trigger release when the version tag is new
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git fetch --tags --quiet
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "tag ${TAG} already exists; nothing to release."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin "${TAG}"
+
+          echo "created ${TAG}; dispatching Auto Release."
+          gh workflow run auto-release.yml --ref master -f "tags=${TAG}"

--- a/crates/node/src/measure.rs
+++ b/crates/node/src/measure.rs
@@ -43,9 +43,13 @@ const PERSISTENCE_MIN_INTERVAL: Duration = Duration::from_millis(50);
 // this interval. A hard crash may lose at most one interval of advisory state.
 #[cfg(not(test))]
 const PERSISTENCE_MIN_INTERVAL: Duration = Duration::from_secs(60);
-#[cfg(test)]
-const RELIABILITY_WINDOW: NonZeroU64 = NonZeroU64::MIN;
-#[cfg(not(test))]
+// One window for tests and production. Controlled-clock unit tests advance the clock by
+// `RELIABILITY_WINDOW` to drive epoch rollover deterministically, so they need no shorter
+// window. A sub-second test window instead broke wall-clock integration tests: reliability
+// evidence is windowed (reset when a fresh observation lands in a later epoch) while credit
+// is cumulative, so under live keepalive traffic an epoch boundary between a send and a
+// later read could reset `evidence.sent` to 0 even though credit had grown — a flaky
+// `evidence.sent >= 1`. A production-sized window is never crossed within a test.
 #[allow(
     clippy::unwrap_used,
     reason = "the non-zero integer literal is validated during const evaluation"

--- a/examples/native/Cargo.toml
+++ b/examples/native/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
+publish = false
 
 [dependencies]
 async-trait = { workspace = true }

--- a/examples/relay/Cargo.toml
+++ b/examples/relay/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
+publish = false
 
 [dependencies]
 rings-core = { workspace = true }

--- a/scripts/cargo-publish-crates.sh
+++ b/scripts/cargo-publish-crates.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CRATES="rings-derive rings-transport rings-measure rings-core rings-rpc rings-node"
-INTERNAL_CRATES="rings-core rings-derive rings-measure rings-node rings-rpc rings-transport"
+# Publish order is a topological sort of the internal dependency graph: every crate
+# appears after all internal crates it depends on. `rings-codec` (a hard dep of
+# transport/core/node) and `rings-gateway` (an optional dep of node) must ship before
+# their dependents; `rings-webview` is an independent leaf crate with no dependents.
+CRATES="rings-derive rings-codec rings-measure rings-gateway rings-webview rings-transport rings-core rings-rpc rings-node"
+
+# Internal crates that appear as `{ workspace = true }` dependencies of a publishable
+# crate; used to validate workspace dependency metadata and to gate publishing on
+# crates.io indexing. `rings-webview` is omitted: it is published but never depended on,
+# so it has no `[workspace.dependencies]` entry to validate.
+INTERNAL_CRATES="rings-core rings-codec rings-derive rings-gateway rings-measure rings-node rings-rpc rings-transport"
 ROOT_MANIFEST="Cargo.toml"
 
 usage() {
@@ -17,12 +26,15 @@ USAGE
 
 manifest_for() {
   case "$1" in
+    rings-codec) echo "crates/codec/Cargo.toml" ;;
     rings-core) echo "crates/core/Cargo.toml" ;;
     rings-derive) echo "crates/derive/Cargo.toml" ;;
+    rings-gateway) echo "crates/gateway/Cargo.toml" ;;
     rings-measure) echo "crates/measure/Cargo.toml" ;;
     rings-node) echo "crates/node/Cargo.toml" ;;
     rings-rpc) echo "crates/rpc/Cargo.toml" ;;
     rings-transport) echo "crates/transport/Cargo.toml" ;;
+    rings-webview) echo "crates/webview/Cargo.toml" ;;
     *) echo "unknown crate: $1" >&2; return 1 ;;
   esac
 }


### PR DESCRIPTION
Fixes several problems in the crates.io publish path (`make publish`) and adds real-release automation on version bumps.

## 1. Exclude example crates from publishing

`cargo publish --workspace` for 0.20.0 tried to upload the two example crates, which are not meant to be published:

```
error: failed to publish rings-native-example v0.20.0 to registry at https://crates.io
Caused by: ... missing or empty metadata fields: description
```

Set `publish = false` on `examples/native` and `examples/relay`, matching the existing `examples/dweb` convention. This also clears the `manifest has no description` warnings.

## 2. Complete the publishable crate set in `make publish`

`rings-codec`, `rings-gateway` and `rings-webview` were split out as **new crates in 0.20.0** but never added to `scripts/cargo-publish-crates.sh`, so the script only published 6 of the 9 library crates. Since `rings-codec` is a hard dependency of transport/core/node and `rings-gateway` an optional dependency of node, `cargo publish -p rings-core` cannot succeed for a fresh version until they are indexed — the 0.20.0 release only completed via an ad-hoc `cargo publish --workspace`.

- Add all three to `CRATES` in dependency-topological order (codec/gateway before their dependents).
- Add codec/gateway to `INTERNAL_CRATES` for metadata + index-wait validation (`rings-webview` is an independent leaf with no `[workspace.dependencies]` entry, so it stays out).
- Register their manifest paths.

`scripts/cargo-publish-crates.sh check` now validates all 9 crates, and the script publishes the same set as `cargo publish --workspace`. (crates.io publishing stays a manual `make publish`; this PR does not automate it.)

## 3. Auto-tag version bumps to trigger a real release

New `Auto Tag` workflow: on a master push touching `Cargo.toml`, it reads `[workspace.package].version` and — when the matching `vX.Y.Z` tag does not yet exist — creates and pushes it, then dispatches `Auto Release` for that tag.

A tag pushed with the built-in `GITHUB_TOKEN` does not trigger another workflow (GitHub suppresses recursive runs), so `Auto Release`'s `push: tags: v*` path would never fire on its own; the workflow pushes the tag for provenance and dispatches `Auto Release` explicitly. It runs **alongside** the existing rolling `prerelease` (unchanged), adding a real versioned release only when the version changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)