### PR TITLE
fix(measure): stop the sub-second test reliability window from flaking peer-measurement tests

### DIFF
--- a/crates/node/src/measure.rs
+++ b/crates/node/src/measure.rs
@@ -43,9 +43,13 @@ const PERSISTENCE_MIN_INTERVAL: Duration = Duration::from_millis(50);
 // this interval. A hard crash may lose at most one interval of advisory state.
 #[cfg(not(test))]
 const PERSISTENCE_MIN_INTERVAL: Duration = Duration::from_secs(60);
-#[cfg(test)]
-const RELIABILITY_WINDOW: NonZeroU64 = NonZeroU64::MIN;
-#[cfg(not(test))]
+// One window for tests and production. Controlled-clock unit tests advance the clock by
+// `RELIABILITY_WINDOW` to drive epoch rollover deterministically, so they need no shorter
+// window. A sub-second test window instead broke wall-clock integration tests: reliability
+// evidence is windowed (reset when a fresh observation lands in a later epoch) while credit
+// is cumulative, so under live keepalive traffic an epoch boundary between a send and a
+// later read could reset `evidence.sent` to 0 even though credit had grown — a flaky
+// `evidence.sent >= 1`. A production-sized window is never crossed within a test.
 #[allow(
     clippy::unwrap_used,
     reason = "the non-zero integer literal is validated during const evaluation"


### PR DESCRIPTION
## Symptom

Master QACI (the `#709` merge run) failed in `Build and test` on:

```
test processor::tests::test_network::test_provider_exposes_sent_and_received_peer_measurements ... FAILED
thread '…' panicked at crates/node/src/processor/tests/test_network.rs:274:5:
assertion failed: provider_measurement.evidence.sent >= 1
```

## Root cause — a flaky test, not a regression

`#709` (`0d361402`) only touched an *unrelated* test in the same file (adding a `.clone()`), so it did not change this test's behaviour. The failure is a pre-existing wall-clock race introduced with the measure crate:

- Reliability **evidence** is *windowed* — `observe_batch` resets it to zero when a fresh observation lands in a later epoch (`crates/measure/src/reliability.rs:317`).
- **Credit** is *cumulative* and survives epoch rollover.
- Under `cfg(test)` the window was **one second** (`RELIABILITY_WINDOW = NonZeroU64::MIN`).

The test sends one message, waits for the cumulative *credit* to grow, then asserts on *evidence*. With a one-second window, live keepalive traffic can cross an epoch boundary between the send and the later read: a received-keepalive in the new second resets the record and re-counts only `received`, leaving `evidence.sent == 0` while credit is unchanged. Hence the intermittent failure.

## Fix

Use the production-sized window (3600s) in tests too, removing the `cfg(test)` override:

- Controlled-clock unit tests (`compatibility_counters_follow_the_live_epoch`, …) advance the clock by `RELIABILITY_WINDOW` itself, so they still drive epoch rollover deterministically regardless of its size.
- Wall-clock integration tests now never cross an epoch boundary mid-test, so windowed evidence is effectively cumulative within a test and the `evidence.sent`/`counters.sent` assertions are stable.

Production behaviour is unchanged (it was already 3600s). `PERSISTENCE_MIN_INTERVAL` keeps its fast test override — it does not affect measurement correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)