### PR TITLE
test(core): await measurement event, not wall clock, in chunk-e2e delta test

### DIFF
--- a/crates/core/src/tests/default/test_chunk_e2e.rs
+++ b/crates/core/src/tests/default/test_chunk_e2e.rs
@@ -9,6 +9,7 @@ use std::sync::Mutex;
 use async_trait::async_trait;
 use rings_transport::connections::dummy_controlled;
 use rings_transport::core::transport::WebrtcConnectionState;
+use tokio::sync::watch;
 use tokio::time::sleep;
 use tokio::time::Duration;
 
@@ -55,10 +56,25 @@ use crate::tests::manually_establish_connection;
 use crate::tests::multi_frame_storage_sync_entries;
 use crate::tests::outbound_capacity_released;
 
-#[derive(Default)]
 struct CountingMeasure {
     counters: Mutex<Vec<(crate::dht::Did, MeasureCounter)>>,
     events: Mutex<Vec<(crate::dht::Did, MeasurementEvent)>>,
+    /// Monotonic generation bumped after every recorded event. It lets a test await
+    /// a specific measurement *landing* rather than poll a wall-clock window: `watch`
+    /// retains the latest value, so a bump that races a waiter's predicate re-check is
+    /// never lost, and a measurement that never lands surfaces as a deterministic hang
+    /// (bounded by the test harness) instead of an intermittent timeout.
+    recorded: watch::Sender<u64>,
+}
+
+impl Default for CountingMeasure {
+    fn default() -> Self {
+        Self {
+            counters: Mutex::new(Vec::new()),
+            events: Mutex::new(Vec::new()),
+            recorded: watch::channel(0).0,
+        }
+    }
 }
 
 impl CountingMeasure {
@@ -96,6 +112,18 @@ impl CountingMeasure {
             Err(_) => 0,
         }
     }
+
+    /// Await until `predicate` holds, re-checking only when a new measurement is
+    /// recorded. This is an event wait, not a timed poll: it parks on the `recorded`
+    /// generation and never consults the wall clock, so it cannot flake on a slow
+    /// runner. `wait_for` evaluates `predicate` immediately and again on each bump.
+    async fn await_event(&self, predicate: impl Fn(&Self) -> bool) {
+        let mut recorded = self.recorded.subscribe();
+        // The sender outlives every waiter (it is owned by this measure), so the
+        // only `Err` is an impossible closed channel; discard it and let the parked
+        // future resolve on the next recorded event.
+        let _ = recorded.wait_for(|_generation| predicate(self)).await;
+    }
 }
 
 #[async_trait]
@@ -122,6 +150,7 @@ impl Measure for CountingMeasure {
         if let Ok(mut events) = self.events.lock() {
             events.push((did, event));
         }
+        self.recorded.send_modify(|generation| *generation += 1);
         self.incr(did, MeasureCounter::from_event(event)).await;
         Ok(ApplyOutcome::Applied)
     }
@@ -138,6 +167,7 @@ impl Measure for CountingMeasure {
         if let Ok(mut events) = self.events.lock() {
             events.push((did, batch.event()));
         }
+        self.recorded.send_modify(|generation| *generation += 1);
         let counter = MeasureCounter::from_event(batch.event());
         for _ in 0..batch.occurrences().get() {
             self.incr(did, counter).await;
@@ -225,11 +255,11 @@ async fn test_whole_and_chunked_payloads_have_identical_measurement_delta() {
         .expect("whole send should succeed");
     let whole = recv_custom(&node2).await.expect("whole custom message");
     assert_eq!(whole, big);
-    wait_for_test_condition("whole send must be measured once", || {
-        sender_measure.logical_transfer_count(node2.did(), false, expected_useful_bytes)
-            > sent_before
-    })
-    .await;
+    sender_measure
+        .await_event(|measure| {
+            measure.logical_transfer_count(node2.did(), false, expected_useful_bytes) > sent_before
+        })
+        .await;
     assert_eq!(
         sender_measure.logical_transfer_count(node2.did(), false, expected_useful_bytes),
         sent_before + 1
@@ -249,11 +279,12 @@ async fn test_whole_and_chunked_payloads_have_identical_measurement_delta() {
         .await
         .expect("reassembled custom message");
     assert_eq!(chunked, big);
-    wait_for_test_condition("chunked send must be measured once", || {
-        sender_measure.logical_transfer_count(node2.did(), false, expected_useful_bytes)
-            >= sent_before + 2
-    })
-    .await;
+    sender_measure
+        .await_event(|measure| {
+            measure.logical_transfer_count(node2.did(), false, expected_useful_bytes)
+                >= sent_before + 2
+        })
+        .await;
     assert_eq!(
         sender_measure.logical_transfer_count(node2.did(), false, expected_useful_bytes),
         sent_before + 2,

--- a/crates/core/src/tests/default/test_chunk_e2e.rs
+++ b/crates/core/src/tests/default/test_chunk_e2e.rs
@@ -59,11 +59,12 @@ use crate::tests::outbound_capacity_released;
 struct CountingMeasure {
     counters: Mutex<Vec<(crate::dht::Did, MeasureCounter)>>,
     events: Mutex<Vec<(crate::dht::Did, MeasurementEvent)>>,
-    /// Monotonic generation bumped after every recorded event. It lets a test await
-    /// a specific measurement *landing* rather than poll a wall-clock window: `watch`
-    /// retains the latest value, so a bump that races a waiter's predicate re-check is
-    /// never lost, and a measurement that never lands surfaces as a deterministic hang
-    /// (bounded by the test harness) instead of an intermittent timeout.
+    /// Monotonic generation bumped once each recording is fully applied (its event and
+    /// counters both visible). It lets a test await a specific measurement *landing*
+    /// rather than poll a wall-clock window: `watch` retains the latest value, so a bump
+    /// that races a waiter's predicate re-check is never lost, and a measurement that
+    /// never lands surfaces as a deterministic hang (caught by the CI job timeout)
+    /// instead of an intermittent sub-second timeout.
     recorded: watch::Sender<u64>,
 }
 
@@ -72,7 +73,7 @@ impl Default for CountingMeasure {
         Self {
             counters: Mutex::new(Vec::new()),
             events: Mutex::new(Vec::new()),
-            recorded: watch::channel(0).0,
+            recorded: watch::Sender::new(0),
         }
     }
 }
@@ -113,15 +114,17 @@ impl CountingMeasure {
         }
     }
 
-    /// Await until `predicate` holds, re-checking only when a new measurement is
-    /// recorded. This is an event wait, not a timed poll: it parks on the `recorded`
-    /// generation and never consults the wall clock, so it cannot flake on a slow
-    /// runner. `wait_for` evaluates `predicate` immediately and again on each bump.
-    async fn await_event(&self, predicate: impl Fn(&Self) -> bool) {
+    /// Await until `predicate` holds over the fully-applied measure state, re-checking
+    /// only when a recording lands. This is an event wait, not a timed poll: it parks on
+    /// the `recorded` generation and never consults the wall clock, so it cannot flake
+    /// on a slow runner. `wait_for` evaluates `predicate` immediately and again on each
+    /// bump, and a bump lands only after the recording's counters are visible, so a
+    /// predicate over either `events` or `counters` is sound.
+    async fn await_recorded(&self, predicate: impl Fn(&Self) -> bool) {
         let mut recorded = self.recorded.subscribe();
         // The sender outlives every waiter (it is owned by this measure), so the
         // only `Err` is an impossible closed channel; discard it and let the parked
-        // future resolve on the next recorded event.
+        // future resolve on the next recording.
         let _ = recorded.wait_for(|_generation| predicate(self)).await;
     }
 }
@@ -150,8 +153,8 @@ impl Measure for CountingMeasure {
         if let Ok(mut events) = self.events.lock() {
             events.push((did, event));
         }
-        self.recorded.send_modify(|generation| *generation += 1);
         self.incr(did, MeasureCounter::from_event(event)).await;
+        self.recorded.send_modify(|generation| *generation += 1);
         Ok(ApplyOutcome::Applied)
     }
 
@@ -167,11 +170,11 @@ impl Measure for CountingMeasure {
         if let Ok(mut events) = self.events.lock() {
             events.push((did, batch.event()));
         }
-        self.recorded.send_modify(|generation| *generation += 1);
         let counter = MeasureCounter::from_event(batch.event());
         for _ in 0..batch.occurrences().get() {
             self.incr(did, counter).await;
         }
+        self.recorded.send_modify(|generation| *generation += 1);
         Ok(ApplyOutcome::Applied)
     }
 }
@@ -256,7 +259,7 @@ async fn test_whole_and_chunked_payloads_have_identical_measurement_delta() {
     let whole = recv_custom(&node2).await.expect("whole custom message");
     assert_eq!(whole, big);
     sender_measure
-        .await_event(|measure| {
+        .await_recorded(|measure| {
             measure.logical_transfer_count(node2.did(), false, expected_useful_bytes) > sent_before
         })
         .await;
@@ -280,7 +283,7 @@ async fn test_whole_and_chunked_payloads_have_identical_measurement_delta() {
         .expect("reassembled custom message");
     assert_eq!(chunked, big);
     sender_measure
-        .await_event(|measure| {
+        .await_recorded(|measure| {
             measure.logical_transfer_count(node2.did(), false, expected_useful_bytes)
                 >= sent_before + 2
         })


### PR DESCRIPTION
## Summary

Fixes the flaky `test_whole_and_chunked_payloads_have_identical_measurement_delta` (`rings-core`, dummy backend) by turning its wall-clock poll into an **event wait**.

The sender-side `Sent` measurement lands on a **detached pipeline** — `send_direct_message` returns after enqueueing, then `outbound dispatch → record → wake → coalescing worker applies`. The test bridged that gap by polling the counter under a **1s `tokio::time::timeout`** (`wait_for_test_condition`); under CI load the async hops occasionally exceed 1s and it panicked `"... must be measured once"`. Root-cause writeup: #721.

## Why the wait can't just be deleted

`send_direct_message` is detached, so at the moment it returns the `Sent` event is not yet even in the aggregate — the sender has **no happens-before point** for measurement application (the receiver does: `recv_custom` returning). A "queue empty / quiesce" barrier would pass prematurely. A wait for *the measurement landing* is intrinsic.

## Change

`CountingMeasure` (the test's own `Measure` double) gains a monotonic `watch` generation, bumped **once each recording is fully applied** (event and counters both visible). `await_recorded(predicate)` parks on that generation and re-checks the predicate **only when a recording lands**:

- **No wall clock** — it cannot flake on a slow runner.
- **No lost wake** — `watch` retains the latest value, so a bump racing the predicate re-check is still observed (`wait_for` checks immediately, then on each change). The bump lands only after the recording's counters are visible, so a predicate over either `events` or `counters` is sound.
- **Better failure mode** — a measurement that genuinely never lands now surfaces as a **deterministic hang** (caught by the CI job `timeout-minutes`), not a 1% timeout. This directly answers the "does a specific condition cause a real timeout?" question: such a condition would now be unmissable rather than intermittent.

Scoped to the two measurement-counter waits in this one test; the other `wait_for_test_condition` call sites gate on different signals (e.g. `dummy_controlled` counts) and are left unchanged. Entirely test-only — no production or `#[cfg(test)]` hook added.

## Verification

- `cargo test -p rings-core --features dummy` (full CI-equivalent suite): **655 passed, 0 failed**.
- The target test run 30× in isolation: 30/30 pass, converging in ~1.3s each with no timeout.
- `cargo +nightly fmt` applied.

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)
