### PR TITLE
Bind message signatures to the overlay and bound DHT storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,15 @@
 - A node that has successors but no known predecessor is no longer responsible for the whole
   ring: it forwards messages instead of holding them, and its responsibility interval is
   `(predecessor, self]` exactly.
+- Storage is partitioned by entry kind: a data topic and a relay inbox at the same position are
+  distinct slots (relay slots render as `relay:<placement>`, data slots keep the bare placement,
+  so values written by earlier builds stay addressable). Previously any node could park a data
+  topic at `d + 1` through `storage_store` and every hold for `d` then failed with
+  `EntryKindNotEqual` for as long as the topic was refreshed. A lookup reads the data slot only.
+- A relay carrier has exactly one placement, its DID, under any configured storage redundancy:
+  a placed operation or a synced entry naming a rotated replica key for a relay carrier is
+  refused, so a hold can no longer be admitted at a rotated position under the authority for
+  that position's own inbox.
 - Node descriptors verify only when the body states the receiver's overlay, and onion backward
   payloads are verified under the receiver's overlay rather than the overlay stated by the exit.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,15 @@
   another. `Transaction`, `MessagePayload`, and `PayloadSender` take a `MessageSigner` (a session
   key acting inside one overlay) instead of a bare `SessionSk`, and
   `MessageVerificationExt::verify` takes the receiver's `network_id`.
-- DHT entries carry a retention bound (`expires_at_ms`) stamped at the operation boundary with
-  `DEFAULT_TTL_MS` and bounded at admission by `MAX_TTL_MS`. Stored values without a bound, or
-  whose bound has elapsed, are retired on their next read and are never replicated or served.
+- DHT entries carry a retention bound (`expires_at_ms`) stamped at the operation boundary and
+  bounded at admission, per entry kind: data entries use `DEFAULT_TTL_MS` / `MAX_TTL_MS`
+  (10 min / 100 min), relayed messages held for an offline destination use
+  `DEFAULT_RELAY_ENTRY_TTL_MS` / `MAX_RELAY_ENTRY_TTL_MS` (24 h / 7 d). Stored values without a
+  bound, or whose bound has elapsed, are retired on their next read and are never replicated or
+  served.
+- Each entry carrier is bounded in bytes as well as in payload count: data entries keep at most
+  `ENTRY_DATA_MAX_BYTES` (1 MiB) and relay inboxes at most `RELAY_INBOX_MAX_BYTES` (16 MiB) of
+  encoded payloads, dropping the oldest first so a busy inbox retains its newest messages.
 - Storage admission rejects peer-supplied CRDT versions whose logical time is more than
   `TS_OFFSET_TOLERANCE_MS` ahead of the receiver's clock, so a forged register floor can no longer
   pin a key.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,24 +27,36 @@
   applied to the peer-supplied delta, never to the receiver's join result.
 - `Entry::operate`, `overwrite`, `extend`, `touch`, `compact_data`, and `EntryOperation::stamped`
   take the operation-boundary time explicitly; the clock is read only at the storage boundary.
-  `Entry::extend` and `compact_data` now apply to relay inboxes as well as data topics, and
-  `Swarm::stabilizer` returns a `Result` because the stabilizer delivers drained inbox messages
-  through the swarm callback.
+  `Entry::extend` applies to relay inboxes as well as data topics; `compact_data` stays a data
+  topic operation. `Session::verify_at`, `MessageVerification::verify_at`, and
+  `MessageVerificationExt::verify_at` judge a signature as of a given instant; the
+  liveness-free `verify_signature` is gone. `MessageSigner::to_owned` is `owned`.
+  `ENTRY_PAYLOAD_MAX_BYTES` is 32 KiB so a full carrier fits one transport message (checked at
+  compile time). The stabilizer resolves the swarm callback at delivery time, so
+  `Swarm::set_callback` after `listen` is honoured by inbox delivery.
 
 ### Added
 
-- Relay inbox for offline peers. An application message that reaches the node responsible for its
-  destination's ring position while the destination is not connected is held in the inbox carrier
-  `destination + 1` (`EntryKind::RelayMessage`). Storage admits an inbox element only under a
-  witness the owner verifies itself: it decodes as a signed `MessagePayload` addressed to the
-  inbox's peer, carries an application message, and both signatures verify inside the local
-  overlay regardless of proof liveness. Inboxes are retained for `DEFAULT_RELAY_INBOX_TTL_MS`
-  (24 h) after the last held message, up to `MAX_RELAY_INBOX_TTL_MS` (7 d). When the peer returns
-  its inbox key falls into its own storage interval and is handed over by ownership sync; every
-  storage repair pass the peer drains its local inbox to the application (`on_validate`, then
-  `on_inbound`) and compacts the delivered messages out of the carrier, so the floor also prunes
-  their tombstones. `MessageVerificationExt::verify_signature` verifies a signature without its
-  liveness check for this purpose.
+- Relay inbox for offline peers. A `CustomMessage` that reaches the node responsible for its
+  destination's ring position while the destination has no connection is *held*: wrapped in a
+  `HeldMessage` under the holder's signature (domain
+  `rings-core:relay-inbox:held-message:v1`, timestamp = hold instant) and written into the inbox
+  carrier `destination + 1` (`EntryKind::RelayMessage`), which is placed by the ring geometry in
+  every storage mode. Storage admits an inbox element only under a witness the owner verifies
+  itself: it is a held `CustomMessage` addressed to the inbox's peer, held no later than the
+  receiver's clock, whose holder signature verifies inside the local overlay and whose payload
+  verifies *as of the hold instant* (`MessageVerificationExt::verify_at`; a sender's session
+  expiring later does not unverify a held message, and a holder can hold only inside the sender's
+  proof lifetime). Authority is checked at the write: a hold only from the node the owner routes
+  the destination to, a removal only from the recipient, a relocation only as an ownership
+  hand-off from the predecessor; a relay carrier is never fetched, cached, replicated, or read by
+  anyone but its recipient. Removal is per element by its add dot (never a reset floor), the
+  carrier keeps at most `RELAY_INBOX_MAX_LEN` (64) newest messages, and inboxes are retained for
+  `DEFAULT_RELAY_INBOX_TTL_MS` (24 h) after the last hold, up to `MAX_RELAY_INBOX_TTL_MS` (7 d).
+  When the peer returns its inbox key falls into its own storage interval and the predecessor's
+  repair pass hands it over; every storage maintenance pass the peer drains its local inbox
+  through the inbound pipeline (application validation, dispatch, `on_inbound`, each under the
+  inbound deadline) and tombstones the drained elements. Delivery is at least once.
 
 ### Fixed
 
@@ -62,6 +74,11 @@
   system operation succeeded, and the budget is restored on open.
 - The local fetched-entry cache is bounded at `LOCAL_CACHE_CAPACITY` entries, evicting the least
   recently written entry.
+- A node that has successors but no known predecessor is no longer responsible for the whole
+  ring: it forwards messages instead of holding them, and its responsibility interval is
+  `(predecessor, self]` exactly.
+- Node descriptors verify only when the body states the receiver's overlay, and onion backward
+  payloads are verified under the receiver's overlay rather than the overlay stated by the exit.
 
 ## 0.20.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.21.0
+
+### Breaking changes
+
+- Message, transaction, and descriptor signatures now sign a domain-separated transcript that
+  binds the signer's `network_id` and a per-message-family tag. Signatures issued by earlier
+  builds no longer verify, and a signature issued inside one overlay does not verify inside
+  another. `Transaction`, `MessagePayload`, and `PayloadSender` take a `MessageSigner` (a session
+  key acting inside one overlay) instead of a bare `SessionSk`, and
+  `MessageVerificationExt::verify` takes the receiver's `network_id`.
+- DHT entries carry a retention bound (`expires_at_ms`) stamped at the operation boundary with
+  `DEFAULT_TTL_MS` and bounded at admission by `MAX_TTL_MS`. Stored values without a bound, or
+  whose bound has elapsed, are retired on their next read and are never replicated or served.
+- Storage admission rejects peer-supplied CRDT versions whose logical time is more than
+  `TS_OFFSET_TOLERANCE_MS` ahead of the receiver's clock, so a forged register floor can no longer
+  pin a key.
+
+### Fixed
+
+- The native file-backed storage now enforces its configured byte capacity: a write beyond the
+  budget retires the least recently written keys first, a value larger than the whole budget is
+  rejected with `Error::StorageValueExceedsCapacity`, and the budget is restored on open.
+- The local fetched-entry cache is bounded at `LOCAL_CACHE_CAPACITY` entries, evicting the least
+  recently written entry.
+
 ## 0.20.2
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,23 +22,20 @@
   write to their key.
 - Storage admission rejects peer-supplied CRDT versions whose logical time is more than
   `TS_OFFSET_TOLERANCE_MS` ahead of the receiver's clock, so a forged register floor can no longer
-  pin a key, and rejects any payload element larger than `ENTRY_PAYLOAD_MAX_BYTES` (64 KiB), so a
+  pin a key, and rejects any payload element larger than `ENTRY_PAYLOAD_MAX_BYTES` (32 KiB), so a
   carrier holds at most `ENTRY_DATA_MAX_LEN * ENTRY_PAYLOAD_MAX_BYTES` encoded bytes. Admission is
   applied to the peer-supplied delta, never to the receiver's join result.
 - `Entry::operate`, `overwrite`, `extend`, `touch`, `compact_data`, and `EntryOperation::stamped`
   take the operation-boundary time explicitly; the clock is read only at the storage boundary.
-  `Entry::extend` applies to relay inboxes as well as data topics; `compact_data` stays a data
-  topic operation. `Session::verify_at`, `MessageVerification::verify_at`, and
-  `MessageVerificationExt::verify_at` judge a signature as of a given instant; the
-  liveness-free `verify_signature` is gone. `MessageSigner::to_owned` is `owned`.
-  `ENTRY_PAYLOAD_MAX_BYTES` is 32 KiB so a full carrier fits one transport message (checked at
-  compile time). The stabilizer resolves the swarm callback at delivery time, so
-  `Swarm::set_callback` after `listen` is honoured by inbox delivery.
+  `Entry::extend` applies to relay inboxes as well as data topics. `Session::verify_at`,
+  `MessageVerification::{verify_at, verify_live, verify_live_at}`, and
+  `MessageVerificationExt::verify_at` judge a signature as of a given instant;
+  `MessageVerification::verify_unexpired` is `verify_live`. A full carrier fits one transport
+  message by a compile-time law over `ENTRY_DATA_MAX_LEN` and `ENTRY_PAYLOAD_MAX_BYTES`.
 - `rings_core::storage::sled::SledStorage` is `rings_core::storage::file::FileStorage`, the name
   of what it has been since the byte budget landed: one file per key under a budget. The three
   poisoned-lock errors (`DHTSyncLockError`, `CallbackSyncLockError`, `StorageLockPoisoned`) are
-  one `Error::LockPoisoned`. `MessageSigner` no longer hands out its session key; it exposes
-  `session_public_key`.
+  one `Error::LockPoisoned`.
 
 ### Added
 
@@ -53,15 +50,16 @@
   verifies *as of the hold instant* (`MessageVerificationExt::verify_at`; a sender's session
   expiring later does not unverify a held message, and a holder can hold only inside the sender's
   proof lifetime). Authority is checked at the write: a hold only from the node the owner routes
-  the destination to, a removal only from the recipient, a relocation only as an ownership
-  hand-off from the predecessor; a relay carrier is never fetched, cached, replicated, or read by
-  anyone but its recipient. Removal is per element by its add dot (never a reset floor), the
+  the destination to and only while the message's sender proof is still live by the owner's own
+  clock, a removal only from the recipient, a relocation only as an ownership hand-off from the
+  authenticated predecessor; a relay carrier is never fetched, cached, replicated, or returned to
+  a lookup. Removal is per element by its add dot (never a reset floor), the
   carrier keeps at most `RELAY_INBOX_MAX_LEN` (64) newest messages, and inboxes are retained for
   `DEFAULT_RELAY_INBOX_TTL_MS` (24 h) after the last hold, up to `MAX_RELAY_INBOX_TTL_MS` (7 d).
   When the peer returns its inbox key falls into its own storage interval and the predecessor's
   repair pass hands it over; every storage maintenance pass the peer drains its local inbox
   through the inbound pipeline (application validation, dispatch, `on_inbound`, each under the
-  inbound deadline) and tombstones the drained elements. Delivery is at least once.
+  inbound deadline) and tombstones each element as it is delivered. Delivery is at least once.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
   `DEFAULT_TTL_MS` and bounded at admission by `MAX_TTL_MS`. Stored values without a bound, or
   whose bound has elapsed, are retired on their next read and are never replicated or served.
   The bound joins by `max` and is refreshed by what is held (adds, overwrites, compaction
-  floors), never by a removal: a tombstone leaves the carrier's bound unchanged.
+  floors), never by a removal: a tombstone leaves the carrier's bound unchanged, and a removal
+  against nothing held stores nothing.
   The native file store also retires a record the current schema cannot decode on the read that
   discovers it, so values written by earlier builds are dropped instead of failing every later
   write to their key.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
   `ENTRY_PAYLOAD_MAX_BYTES` is 32 KiB so a full carrier fits one transport message (checked at
   compile time). The stabilizer resolves the swarm callback at delivery time, so
   `Swarm::set_callback` after `listen` is honoured by inbox delivery.
+- `rings_core::storage::sled::SledStorage` is `rings_core::storage::file::FileStorage`, the name
+  of what it has been since the byte budget landed: one file per key under a budget. The three
+  poisoned-lock errors (`DHTSyncLockError`, `CallbackSyncLockError`, `StorageLockPoisoned`) are
+  one `Error::LockPoisoned`. `MessageSigner` no longer hands out its session key; it exposes
+  `session_public_key`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,24 @@
   applied to the peer-supplied delta, never to the receiver's join result.
 - `Entry::operate`, `overwrite`, `extend`, `touch`, `compact_data`, and `EntryOperation::stamped`
   take the operation-boundary time explicitly; the clock is read only at the storage boundary.
+  `Entry::extend` and `compact_data` now apply to relay inboxes as well as data topics, and
+  `Swarm::stabilizer` returns a `Result` because the stabilizer delivers drained inbox messages
+  through the swarm callback.
+
+### Added
+
+- Relay inbox for offline peers. An application message that reaches the node responsible for its
+  destination's ring position while the destination is not connected is held in the inbox carrier
+  `destination + 1` (`EntryKind::RelayMessage`). Storage admits an inbox element only under a
+  witness the owner verifies itself: it decodes as a signed `MessagePayload` addressed to the
+  inbox's peer, carries an application message, and both signatures verify inside the local
+  overlay regardless of proof liveness. Inboxes are retained for `DEFAULT_RELAY_INBOX_TTL_MS`
+  (24 h) after the last held message, up to `MAX_RELAY_INBOX_TTL_MS` (7 d). When the peer returns
+  its inbox key falls into its own storage interval and is handed over by ownership sync; every
+  stabilization round the peer drains its local inbox to the application (`on_validate`, then
+  `on_inbound`) and compacts the delivered messages out of the carrier, so the floor also prunes
+  their tombstones. `MessageVerificationExt::verify_signature` verifies a signature without its
+  liveness check for this purpose.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,16 +41,19 @@
   overlay regardless of proof liveness. Inboxes are retained for `DEFAULT_RELAY_INBOX_TTL_MS`
   (24 h) after the last held message, up to `MAX_RELAY_INBOX_TTL_MS` (7 d). When the peer returns
   its inbox key falls into its own storage interval and is handed over by ownership sync; every
-  stabilization round the peer drains its local inbox to the application (`on_validate`, then
+  storage repair pass the peer drains its local inbox to the application (`on_validate`, then
   `on_inbound`) and compacts the delivered messages out of the carrier, so the floor also prunes
   their tombstones. `MessageVerificationExt::verify_signature` verifies a signature without its
   liveness check for this purpose.
 
 ### Fixed
 
-- Storage ownership hand-off is now a stabilization step: every round the owner offers the live
-  local entries placed beyond `(self, successor head]` to the head, and the receiver's
-  acknowledgement removes the local copy. Previously the hand-off ran only when the old successor
+- Storage ownership hand-off is now part of the storage repair pass: the pass drains the local
+  inbox, offers the live local entries placed beyond `(self, successor head]` to the head (the
+  receiver's acknowledgement removes the local copy), and republishes to missing affine owners,
+  all through the repair delivery window with its fresh-connection grace. Every topology
+  transition that moves the successor head (`TopologyAction::SuccessorHeadChanged`) requests a
+  repair round instead of sending. Previously the hand-off ran only when the old successor
   replied with `NotifyPredecessorReport`, so a head moved by a topology query or by a directly
   connected peer left entries at a node that no longer owned them until they expired.
 - The native file-backed storage now enforces its configured byte capacity: a write beyond the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - DHT entries carry a retention bound (`expires_at_ms`) stamped at the operation boundary with
   `DEFAULT_TTL_MS` and bounded at admission by `MAX_TTL_MS`. Stored values without a bound, or
   whose bound has elapsed, are retired on their next read and are never replicated or served.
+  The bound joins by `max` and is refreshed by what is held (adds, overwrites, compaction
+  floors), never by a removal: a tombstone leaves the carrier's bound unchanged.
   The native file store also retires a record the current schema cannot decode on the read that
   discovers it, so values written by earlier builds are dropped instead of failing every later
   write to their key.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@
   system operation succeeded, and the budget is restored on open.
 - The local fetched-entry cache is bounded at `LOCAL_CACHE_CAPACITY` entries, evicting the least
   recently written entry.
+- Every read-modify-write of a DHT storage slot (an operation, a join, an acknowledged removal,
+  and the retirement a read performs) runs under one storage transition per ring, so a hold
+  arriving from the inbound actor while the stabilizer drains the same inbox, or a hand-off
+  joining while a repair pass reads, can no longer overwrite each other's write.
 - A node that has successors but no known predecessor is no longer responsible for the whole
   ring: it forwards messages instead of holding them, and its responsibility interval is
   `(predecessor, self]` exactly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,27 +7,33 @@
 - Message, transaction, and descriptor signatures now sign a domain-separated transcript that
   binds the signer's `network_id` and a per-message-family tag. Signatures issued by earlier
   builds no longer verify, and a signature issued inside one overlay does not verify inside
-  another. `Transaction`, `MessagePayload`, and `PayloadSender` take a `MessageSigner` (a session
-  key acting inside one overlay) instead of a bare `SessionSk`, and
-  `MessageVerificationExt::verify` takes the receiver's `network_id`.
-- DHT entries carry a retention bound (`expires_at_ms`) stamped at the operation boundary and
-  bounded at admission, per entry kind: data entries use `DEFAULT_TTL_MS` / `MAX_TTL_MS`
-  (10 min / 100 min), relayed messages held for an offline destination use
-  `DEFAULT_RELAY_ENTRY_TTL_MS` / `MAX_RELAY_ENTRY_TTL_MS` (24 h / 7 d). Stored values without a
-  bound, or whose bound has elapsed, are retired on their next read and are never replicated or
-  served.
-- Each entry carrier is bounded in bytes as well as in payload count: data entries keep at most
-  `ENTRY_DATA_MAX_BYTES` (1 MiB) and relay inboxes at most `RELAY_INBOX_MAX_BYTES` (16 MiB) of
-  encoded payloads, dropping the oldest first so a busy inbox retains its newest messages.
+  another. Every signature is issued by a `MessageSigner` (a session key acting inside one
+  overlay; `MessageSigner<&SessionSk>` borrowed, `MessageSigner<SessionSk>` owned) and verified
+  under the receiver's overlay: `Transaction`, `MessagePayload`, `PayloadSender`, and the node
+  descriptors take a `MessageSigner`, `MessageVerificationExt::verify` and the descriptor
+  `verify_signature` / `is_live_at` / `latest_valid_by_*` take the receiver's `network_id`, and
+  signing a descriptor whose body states another overlay is refused. Domain tags are built with
+  `domain_tag!`.
+- DHT entries carry a retention bound (`expires_at_ms`) stamped at the operation boundary with
+  `DEFAULT_TTL_MS` and bounded at admission by `MAX_TTL_MS`. Stored values without a bound, or
+  whose bound has elapsed, are retired on their next read and are never replicated or served.
+  The native file store also retires a record the current schema cannot decode on the read that
+  discovers it, so values written by earlier builds are dropped instead of failing every later
+  write to their key.
 - Storage admission rejects peer-supplied CRDT versions whose logical time is more than
   `TS_OFFSET_TOLERANCE_MS` ahead of the receiver's clock, so a forged register floor can no longer
-  pin a key.
+  pin a key, and rejects any payload element larger than `ENTRY_PAYLOAD_MAX_BYTES` (64 KiB), so a
+  carrier holds at most `ENTRY_DATA_MAX_LEN * ENTRY_PAYLOAD_MAX_BYTES` encoded bytes. Admission is
+  applied to the peer-supplied delta, never to the receiver's join result.
+- `Entry::operate`, `overwrite`, `extend`, `touch`, `compact_data`, and `EntryOperation::stamped`
+  take the operation-boundary time explicitly; the clock is read only at the storage boundary.
 
 ### Fixed
 
 - The native file-backed storage now enforces its configured byte capacity: a write beyond the
   budget retires the least recently written keys first, a value larger than the whole budget is
-  rejected with `Error::StorageValueExceedsCapacity`, and the budget is restored on open.
+  rejected with `Error::StorageValueExceedsCapacity`, the index is updated only after the file
+  system operation succeeded, and the budget is restored on open.
 - The local fetched-entry cache is bounded at `LOCAL_CACHE_CAPACITY` entries, evicting the least
   recently written entry.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@
 
 ### Fixed
 
+- Storage ownership hand-off is now a stabilization step: every round the owner offers the live
+  local entries placed beyond `(self, successor head]` to the head, and the receiver's
+  acknowledgement removes the local copy. Previously the hand-off ran only when the old successor
+  replied with `NotifyPredecessorReport`, so a head moved by a topology query or by a directly
+  connected peer left entries at a node that no longer owned them until they expired.
 - The native file-backed storage now enforces its configured byte capacity: a write beyond the
   budget retires the least recently written keys first, a value larger than the whole budget is
   rejected with `Error::StorageValueExceedsCapacity`, the index is updated only after the file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "rings-codec"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "postcard",
  "serde",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "rings-core"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "rings-derive"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rings-gateway"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "ipnet",
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "rings-measure"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "rings-native-example"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "rings-network-policy"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "thiserror 1.0.69",
  "url",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "rings-node"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "rings-relay-example"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "rings-core",
  "rings-node",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "rings-rpc"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "rings-transport"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3503,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "rings-webview"
-version = "0.20.2"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.20.2"
+version = "0.21.0"
 edition = "2021"
 license = "GPL-3.0-only"
 authors = ["RND <dev@ringsnetwork.io>"]
@@ -20,15 +20,15 @@ repository = "https://github.com/RingsNetwork/rings"
 async-trait = "0.1.77"
 js-sys = "0.3.98"
 jsonrpc-core = "18.0.0"
-rings-codec = { path = "crates/codec", version = "0.20.2" }
-rings-core = { path = "crates/core", version = "0.20.2", default-features = false }
-rings-derive = { path = "crates/derive", version = "0.20.2", default-features = false }
-rings-gateway = { path = "crates/gateway", version = "0.20.2" }
-rings-measure = { path = "crates/measure", version = "0.20.2" }
-rings-network-policy = { path = "crates/network-policy", version = "0.20.2" }
-rings-node = { path = "crates/node", version = "0.20.2" }
-rings-rpc = { path = "crates/rpc", version = "0.20.2", default-features = false }
-rings-transport = { path = "crates/transport", version = "0.20.2" }
+rings-codec = { path = "crates/codec", version = "0.21.0" }
+rings-core = { path = "crates/core", version = "0.21.0", default-features = false }
+rings-derive = { path = "crates/derive", version = "0.21.0", default-features = false }
+rings-gateway = { path = "crates/gateway", version = "0.21.0" }
+rings-measure = { path = "crates/measure", version = "0.21.0" }
+rings-network-policy = { path = "crates/network-policy", version = "0.21.0" }
+rings-node = { path = "crates/node", version = "0.21.0" }
+rings-rpc = { path = "crates/rpc", version = "0.21.0", default-features = false }
+rings-transport = { path = "crates/transport", version = "0.21.0" }
 serde-wasm-bindgen = "0.6.5"
 wasm-bindgen = "0.2.121"
 wasm-bindgen-futures = "0.4.71"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -139,7 +139,8 @@ that held it, verified inside the local overlay as of the hold instant, and admi
 only from the node the owner itself routes that peer to. A removal is accepted only from
 the recipient, a relocation only as an ownership hand-off from the predecessor, and a
 relay carrier is never fetched, cached, replicated, or returned to a lookup by anyone
-but its recipient. A malicious holder is one identity in one ring position: it can hold
+but its recipient. A relay carrier has one placement and its own storage namespace, so
+a data topic any node parks at the inbox position cannot shadow the inbox. A malicious holder is one identity in one ring position: it can hold
 junk for the peers it is responsible for (bounded to the newest 64 messages per inbox)
 or redeliver a message inside the sender's own proof lifetime, and every element names
 it by signature. Held messages are stored and relocated in the clear between owners, as

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -125,8 +125,12 @@ peers. They do not force a Byzantine storage owner to serve data or preserve dat
 it has chosen to withhold.
 
 Every accepted entry carries a retention bound stamped by its origin and capped at
-admission by the maximum time-to-live, so a peer cannot ask a storage owner to hold
-a value indefinitely; expired values are retired on their next read. Admission
+admission by the maximum time-to-live of its kind (relayed messages held for an
+offline destination are retained longer than data entries), so a peer cannot ask a
+storage owner to hold a value indefinitely; expired values are retired on their
+next read. Each carrier is also bounded in payload count and encoded bytes, with the
+oldest payloads dropped first, so a relay inbox that keeps receiving messages retains
+only its newest ones. Admission
 also rejects CRDT versions whose logical time runs ahead of the receiver's clock
 by more than the message skew tolerance, so a forged version cannot pin a key
 against later honest writes. Native storage enforces its configured byte budget by

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -125,19 +125,18 @@ peers. They do not force a Byzantine storage owner to serve data or preserve dat
 it has chosen to withhold.
 
 Every accepted entry carries a retention bound stamped by its origin and capped at
-admission by the maximum time-to-live of its kind (relayed messages held for an
-offline destination are retained longer than data entries), so a peer cannot ask a
-storage owner to hold a value indefinitely; expired values are retired on their
-next read. Each carrier is also bounded in payload count and encoded bytes, with the
-oldest payloads dropped first, so a relay inbox that keeps receiving messages retains
-only its newest ones. Admission
-also rejects CRDT versions whose logical time runs ahead of the receiver's clock
-by more than the message skew tolerance, so a forged version cannot pin a key
-against later honest writes. Native storage enforces its configured byte budget by
-retiring the least recently written values, and the fetched-entry cache is bounded
-by entry count. These bounds limit resource use by any single writer; they are not a
-Sybil defence, and an adversary with many identities can still fill a budget with
-values that expire only at the maximum time-to-live.
+admission by the maximum time-to-live, so a peer cannot ask a storage owner to hold
+a value indefinitely; expired values are retired on their next read. Each carrier is
+bounded in payload count, and every payload element in encoded bytes, so one carrier
+holds at most their product; when the count cap binds, the oldest payloads are the
+ones dropped. Admission also rejects CRDT versions whose logical time runs ahead of
+the receiver's clock by more than the message skew tolerance, so a forged version can
+dominate honest writes only for that tolerance and cannot pin a key beyond it.
+Native storage enforces its configured byte budget by retiring the least recently
+written values, and the fetched-entry cache is bounded by entry count. These bounds
+limit resource use by any single writer; they are not a Sybil defence, and an
+adversary with many identities can still fill a budget with values that expire only
+at the maximum time-to-live.
 
 ### Online And Onion Registries
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -134,8 +134,16 @@ the receiver's clock by more than the message skew tolerance, so a forged versio
 dominate honest writes only for that tolerance and cannot pin a key beyond it.
 A relay inbox, the messages held for an offline peer, is retained longer than a data
 topic; that policy is safe because the storage owner verifies every inbox element
-itself (a signed application message addressed to the inbox's peer, verifiable inside
-the local overlay), so a peer cannot obtain the inbox policy by declaring the kind.
+itself: a `CustomMessage` addressed to the inbox's peer, wrapped and signed by the node
+that held it, verified inside the local overlay as of the hold instant, and admitted
+only from the node the owner itself routes that peer to. A removal is accepted only from
+the recipient, a relocation only as an ownership hand-off from the predecessor, and a
+relay carrier is never fetched, cached, replicated, or returned to a lookup by anyone
+but its recipient. A malicious holder is one identity in one ring position: it can hold
+junk for the peers it is responsible for (bounded to the newest 64 messages per inbox)
+or redeliver a message inside the sender's own proof lifetime, and every element names
+it by signature. Held messages are stored and relocated in the clear between owners, as
+every DHT value is; confidentiality is the application's E2E layer's.
 Native storage enforces its configured byte budget by retiring the least recently
 written values, and the fetched-entry cache is bounded by entry count. These bounds
 limit resource use by any single writer; they are not a Sybil defence, and an

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -132,6 +132,10 @@ holds at most their product; when the count cap binds, the oldest payloads are t
 ones dropped. Admission also rejects CRDT versions whose logical time runs ahead of
 the receiver's clock by more than the message skew tolerance, so a forged version can
 dominate honest writes only for that tolerance and cannot pin a key beyond it.
+A relay inbox, the messages held for an offline peer, is retained longer than a data
+topic; that policy is safe because the storage owner verifies every inbox element
+itself (a signed application message addressed to the inbox's peer, verifiable inside
+the local overlay), so a peer cannot obtain the inbox policy by declaring the kind.
 Native storage enforces its configured byte budget by retiring the least recently
 written values, and the fetched-entry cache is bounded by entry count. These bounds
 limit resource use by any single writer; they are not a Sybil defence, and an

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,11 @@ placement, and can attempt eclipse behavior.
 - WebRTC transport establishment and data channels provide the expected channel
   security for a successfully established peer connection.
 - `network_id` separates overlays by configuration. It is not an access-control
-  secret, because a peer can choose to use the same value.
+  secret, because a peer can choose to use the same value. Every message and
+  descriptor signature is nevertheless bound to the signer's `network_id` and to a
+  per-message-family domain tag, so a signature issued inside one overlay does not
+  verify inside another, and a signature over one message family does not verify
+  as a different family that shares the same signing surface.
 - Honest peers run the same protocol rules, refresh descriptors before expiry, and
   participate in stabilization and storage replication.
 
@@ -116,9 +120,20 @@ use; it is not a Sybil defence.
 ### DHT Storage
 
 Storage ownership and replication are topology-derived. CRDT joins, owner checks,
-TTL cleanup, and read repair improve convergence among honest or fail-stop peers.
-They do not force a Byzantine storage owner to serve data or preserve data it has
-chosen to withhold.
+retention cleanup, and read repair improve convergence among honest or fail-stop
+peers. They do not force a Byzantine storage owner to serve data or preserve data
+it has chosen to withhold.
+
+Every accepted entry carries a retention bound stamped by its origin and capped at
+admission by the maximum time-to-live, so a peer cannot ask a storage owner to hold
+a value indefinitely; expired values are retired on their next read. Admission
+also rejects CRDT versions whose logical time runs ahead of the receiver's clock
+by more than the message skew tolerance, so a forged version cannot pin a key
+against later honest writes. Native storage enforces its configured byte budget by
+retiring the least recently written values, and the fetched-entry cache is bounded
+by entry count. These bounds limit resource use by any single writer; they are not a
+Sybil defence, and an adversary with many identities can still fill a budget with
+values that expire only at the maximum time-to-live.
 
 ### Online And Onion Registries
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -64,7 +64,6 @@ bytes = { version = "1.2.1", features = ["serde"] }
 chacha20poly1305 = "0.10.1"
 chrono = { version = "0.4.19", features = ["wasmbind"] }
 curve25519-dalek = { version = "4.1.3", optional = true }
-dashmap = "5"
 ecdsa = { version = "0.16.6", features = ["signing"] }
 ed25519 = "1.5.2"
 ed25519-dalek = "2.2.0"
@@ -128,6 +127,7 @@ web-sys = { version = "0.3.56", optional = true, features = [
 ] }
 
 [dev-dependencies]
+dashmap = "5"
 pretty_assertions = "1.4.0"
 tracing-subscriber = { version = "0.3.15", features = ["ansi"] }
 tracing-test = "0.2.4"

--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -9,23 +9,11 @@ use std::num::NonZeroU32;
 pub const DEFAULT_TTL_MS: u64 = 600 * 1000;
 /// Maximum accepted time-to-live in milliseconds for message signatures and DHT entries.
 pub const MAX_TTL_MS: u64 = DEFAULT_TTL_MS * 10;
-/// Default retention in milliseconds of a relayed message held for an offline destination.
-///
-/// Relay entries are the destination's inbox while it is offline, so they outlive data entries
-/// by design: a peer that returns within this window after the last relayed message still
-/// receives the whole inbox.
-pub const DEFAULT_RELAY_ENTRY_TTL_MS: u64 = 24 * 3600 * 1000;
-/// Maximum accepted retention in milliseconds of a relayed message.
-pub const MAX_RELAY_ENTRY_TTL_MS: u64 = DEFAULT_RELAY_ENTRY_TTL_MS * 7;
 /// Accepted timestamp drift in milliseconds.
 pub const TS_OFFSET_TOLERANCE_MS: u128 = 3000;
 /// Maximum number of fetched entries the local DHT cache retains before evicting the
 /// least recently written one.
-pub const LOCAL_CACHE_CAPACITY: NonZeroU32 = match NonZeroU32::new(1024) {
-    Some(capacity) => capacity,
-    // Evaluated at compile time; the literal is non-zero.
-    None => unreachable!(),
-};
+pub const LOCAL_CACHE_CAPACITY: NonZeroU32 = NonZeroU32::MIN.saturating_add(1023);
 /// Default session time-to-live in milliseconds.
 pub const DEFAULT_SESSION_TTL_MS: u64 = 30 * 24 * 3600 * 1000;
 /// 60k
@@ -52,8 +40,8 @@ pub const MAX_CHUNK_ENVELOPE_OVERHEAD: usize = 4096;
 pub const MIN_CHUNK_DATA: usize = 1024;
 /// Maximum number of encoded payloads kept in a single DHT storage entry.
 pub const ENTRY_DATA_MAX_LEN: usize = 1024;
-/// Maximum encoded bytes kept in a single data entry; older payloads are dropped first.
-pub const ENTRY_DATA_MAX_BYTES: usize = 1024 * 1024;
-/// Maximum encoded bytes kept in one relay inbox (the relayed messages held for an offline
-/// destination); older messages are dropped first, so a busy inbox keeps only the newest.
-pub const RELAY_INBOX_MAX_BYTES: usize = 16 * 1024 * 1024;
+/// Maximum encoded bytes of one payload element in a DHT storage entry.
+///
+/// The bound is per element so that filtering by it is a lattice morphism; with
+/// [`ENTRY_DATA_MAX_LEN`] it bounds every carrier at `ENTRY_DATA_MAX_LEN * ENTRY_PAYLOAD_MAX_BYTES`.
+pub const ENTRY_PAYLOAD_MAX_BYTES: usize = 64 * 1024;

--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -1,11 +1,23 @@
 //! Constant variables.
+
+use std::num::NonZeroU32;
+
+/// Default time-to-live in milliseconds, shared by message signatures and DHT entries.
 ///
-/// Default DHT entry time-to-live in milliseconds.
+/// A message proof is live for this long after its timestamp; a DHT entry stamped at the
+/// operation boundary is retained for this long after it was issued.
 pub const DEFAULT_TTL_MS: u64 = 600 * 1000;
-/// Maximum accepted DHT entry time-to-live in milliseconds.
+/// Maximum accepted time-to-live in milliseconds for message signatures and DHT entries.
 pub const MAX_TTL_MS: u64 = DEFAULT_TTL_MS * 10;
 /// Accepted timestamp drift in milliseconds.
 pub const TS_OFFSET_TOLERANCE_MS: u128 = 3000;
+/// Maximum number of fetched entries the local DHT cache retains before evicting the
+/// least recently written one.
+pub const LOCAL_CACHE_CAPACITY: NonZeroU32 = match NonZeroU32::new(1024) {
+    Some(capacity) => capacity,
+    // Evaluated at compile time; the literal is non-zero.
+    None => unreachable!(),
+};
 /// Default session time-to-live in milliseconds.
 pub const DEFAULT_SESSION_TTL_MS: u64 = 30 * 24 * 3600 * 1000;
 /// 60k

--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -9,6 +9,14 @@ use std::num::NonZeroU32;
 pub const DEFAULT_TTL_MS: u64 = 600 * 1000;
 /// Maximum accepted time-to-live in milliseconds for message signatures and DHT entries.
 pub const MAX_TTL_MS: u64 = DEFAULT_TTL_MS * 10;
+/// Default retention in milliseconds of a relay inbox, the messages held for an offline peer.
+///
+/// A peer that returns within this window after the last message held for it still receives the
+/// whole inbox. The policy is safe only because every inbox element carries a witness the
+/// storage owner verifies itself (see `dht::entry::inbox`).
+pub const DEFAULT_RELAY_INBOX_TTL_MS: u64 = 24 * 3600 * 1000;
+/// Maximum accepted retention in milliseconds of a relay inbox.
+pub const MAX_RELAY_INBOX_TTL_MS: u64 = DEFAULT_RELAY_INBOX_TTL_MS * 7;
 /// Accepted timestamp drift in milliseconds.
 pub const TS_OFFSET_TOLERANCE_MS: u128 = 3000;
 /// Maximum number of fetched entries the local DHT cache retains before evicting the

--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -21,7 +21,10 @@ pub const MAX_RELAY_INBOX_TTL_MS: u64 = DEFAULT_RELAY_INBOX_TTL_MS * 7;
 pub const TS_OFFSET_TOLERANCE_MS: u128 = 3000;
 /// Maximum number of fetched entries the local DHT cache retains before evicting the
 /// least recently written one.
-pub const LOCAL_CACHE_CAPACITY: NonZeroU32 = NonZeroU32::MIN.saturating_add(1023);
+pub const LOCAL_CACHE_CAPACITY: NonZeroU32 = match NonZeroU32::new(1024) {
+    Some(capacity) => capacity,
+    None => unreachable!(),
+};
 /// Default session time-to-live in milliseconds.
 pub const DEFAULT_SESSION_TTL_MS: u64 = 30 * 24 * 3600 * 1000;
 /// 60k
@@ -46,10 +49,20 @@ pub const MAX_CHUNK_ENVELOPE_OVERHEAD: usize = 4096;
 /// message into a huge number of near-empty chunks. This bounds the chunk count for any payload:
 /// at most `TRANSPORT_MAX_SIZE / MIN_CHUNK_DATA` chunks.
 pub const MIN_CHUNK_DATA: usize = 1024;
-/// Maximum number of encoded payloads kept in a single DHT storage entry.
+/// Maximum number of encoded payloads kept in a data topic.
 pub const ENTRY_DATA_MAX_LEN: usize = 1024;
+/// Maximum number of held messages kept in a relay inbox.
+pub const RELAY_INBOX_MAX_LEN: usize = 64;
 /// Maximum encoded bytes of one payload element in a DHT storage entry.
 ///
 /// The bound is per element so that filtering by it is a lattice morphism; with
 /// [`ENTRY_DATA_MAX_LEN`] it bounds every carrier at `ENTRY_DATA_MAX_LEN * ENTRY_PAYLOAD_MAX_BYTES`.
-pub const ENTRY_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
+pub const ENTRY_PAYLOAD_MAX_BYTES: usize = 32 * 1024;
+/// Carrier law: a full carrier must still be one transport message, since a hand-off, a
+/// republish, and a lookup answer each carry a whole carrier. Elements are already in their
+/// wire encoding; the carrier's wire form adds only codec framing, dots, and the message
+/// envelope, for which a quarter of [`TRANSPORT_MAX_SIZE`] is reserved.
+const _: () = assert!(
+    ENTRY_DATA_MAX_LEN * ENTRY_PAYLOAD_MAX_BYTES <= TRANSPORT_MAX_SIZE / 4 * 3,
+    "a full carrier must fit one transport message with room for its envelope"
+);

--- a/crates/core/src/consts.rs
+++ b/crates/core/src/consts.rs
@@ -9,6 +9,14 @@ use std::num::NonZeroU32;
 pub const DEFAULT_TTL_MS: u64 = 600 * 1000;
 /// Maximum accepted time-to-live in milliseconds for message signatures and DHT entries.
 pub const MAX_TTL_MS: u64 = DEFAULT_TTL_MS * 10;
+/// Default retention in milliseconds of a relayed message held for an offline destination.
+///
+/// Relay entries are the destination's inbox while it is offline, so they outlive data entries
+/// by design: a peer that returns within this window after the last relayed message still
+/// receives the whole inbox.
+pub const DEFAULT_RELAY_ENTRY_TTL_MS: u64 = 24 * 3600 * 1000;
+/// Maximum accepted retention in milliseconds of a relayed message.
+pub const MAX_RELAY_ENTRY_TTL_MS: u64 = DEFAULT_RELAY_ENTRY_TTL_MS * 7;
 /// Accepted timestamp drift in milliseconds.
 pub const TS_OFFSET_TOLERANCE_MS: u128 = 3000;
 /// Maximum number of fetched entries the local DHT cache retains before evicting the
@@ -44,3 +52,8 @@ pub const MAX_CHUNK_ENVELOPE_OVERHEAD: usize = 4096;
 pub const MIN_CHUNK_DATA: usize = 1024;
 /// Maximum number of encoded payloads kept in a single DHT storage entry.
 pub const ENTRY_DATA_MAX_LEN: usize = 1024;
+/// Maximum encoded bytes kept in a single data entry; older payloads are dropped first.
+pub const ENTRY_DATA_MAX_BYTES: usize = 1024 * 1024;
+/// Maximum encoded bytes kept in one relay inbox (the relayed messages held for an offline
+/// destination); older messages are dropped first, so a busy inbox keeps only the newest.
+pub const RELAY_INBOX_MAX_BYTES: usize = 16 * 1024 * 1024;

--- a/crates/core/src/dht/chord/action.rs
+++ b/crates/core/src/dht/chord/action.rs
@@ -40,8 +40,9 @@ pub enum RemoteAction {
     FindSuccessor(Did),
     /// Ask the recipient to find one entry placement.
     FindEntry(EntryLookupKey),
-    /// Ask the recipient to find one placement for operating.
-    FindEntryForOperate(PlacedEntryOperation),
+    /// Ask the recipient to find one placement for operating. Boxed: the carried entry
+    /// dominates the size of every other variant.
+    FindEntryForOperate(Box<PlacedEntryOperation>),
     /// Send a predecessor notification to the recipient.
     Notify(Did),
     /// Copy placed entries to one storage sync destination.

--- a/crates/core/src/dht/chord/action.rs
+++ b/crates/core/src/dht/chord/action.rs
@@ -28,6 +28,9 @@ pub enum PeerRingAction {
     RemoteAction(Did, RemoteAction),
     /// Trigger multiple remote actions.
     MultiActions(Vec<PeerRingAction>),
+    /// The placement interval changed: a storage repair round is due. A local intent, carrying
+    /// nothing, because the pass reads the ring state when it runs.
+    StorageRepairDue,
 }
 
 /// Describes the remote continuation required by a peer-ring operation.
@@ -45,9 +48,6 @@ pub enum RemoteAction {
     FindEntryForOperate(Box<PlacedEntryOperation>),
     /// Send a predecessor notification to the recipient.
     Notify(Did),
-    /// The recipient became the successor head: request a storage repair round, which offers it
-    /// every local entry placed beyond it as an ownership hand-off.
-    HandOffStorage,
     /// Copy placed entries to one storage sync destination.
     SyncEntriesWithSuccessor {
         /// Sync transition kind.

--- a/crates/core/src/dht/chord/action.rs
+++ b/crates/core/src/dht/chord/action.rs
@@ -45,6 +45,9 @@ pub enum RemoteAction {
     FindEntryForOperate(Box<PlacedEntryOperation>),
     /// Send a predecessor notification to the recipient.
     Notify(Did),
+    /// The recipient became the successor head: request a storage repair round, which offers it
+    /// every local entry placed beyond it as an ownership hand-off.
+    HandOffStorage,
     /// Copy placed entries to one storage sync destination.
     SyncEntriesWithSuccessor {
         /// Sync transition kind.

--- a/crates/core/src/dht/chord/mod.rs
+++ b/crates/core/src/dht/chord/mod.rs
@@ -9,6 +9,7 @@ pub use action::RemoteAction;
 pub use action::TopoInfo;
 pub use peer_ring::EntryStorage;
 pub use peer_ring::PeerRing;
+pub(crate) use storage::StorageKey;
 
 #[cfg(all(not(all(feature = "wasm", target_family = "wasm")), test))]
 mod tests;

--- a/crates/core/src/dht/chord/peer_ring.rs
+++ b/crates/core/src/dht/chord/peer_ring.rs
@@ -216,6 +216,22 @@ impl PeerRing {
         self.storage_virtual_node_config
     }
 
+    /// The overlay this ring belongs to; every stored value is admitted inside it.
+    pub const fn network_id(&self) -> u32 {
+        self.storage_virtual_node_config.network_id()
+    }
+
+    /// Whether this node is the Chord successor of the position `did`, i.e.
+    /// `did ∈ (predecessor, self]`; with no known predecessor the node is responsible for the
+    /// whole ring. A message addressed to an unconnected `did` in this interval has reached the
+    /// node that must hold it.
+    pub(crate) fn is_responsible_for(&self, did: Did) -> Result<bool> {
+        let state = self.topology_state()?;
+        Ok(state.predecessor.is_none_or(|predecessor| {
+            topology::dist(predecessor, did) <= topology::dist(predecessor, self.did)
+        }))
+    }
+
     fn transition_topology(&self, event: TopologyEvent) -> Result<TopologyStep> {
         self.transition_topology_with_observer(event, |_| {})
     }

--- a/crates/core/src/dht/chord/peer_ring.rs
+++ b/crates/core/src/dht/chord/peer_ring.rs
@@ -116,11 +116,11 @@ impl PeerRing {
     }
 
     fn lock_finger_state(&self) -> Result<MutexGuard<'_, FingerTable>> {
-        self.finger.lock().map_err(|_| Error::DHTSyncLockError)
+        self.finger.lock().map_err(|_| Error::LockPoisoned)
     }
 
     fn lock_predecessor_state(&self) -> Result<MutexGuard<'_, Option<Did>>> {
-        self.predecessor.lock().map_err(|_| Error::DHTSyncLockError)
+        self.predecessor.lock().map_err(|_| Error::LockPoisoned)
     }
 
     #[cfg(all(test, not(all(feature = "wasm", target_family = "wasm"))))]
@@ -133,7 +133,7 @@ impl PeerRing {
         let _transition = self
             .topology_transition
             .lock()
-            .map_err(|_| Error::DHTSyncLockError)?;
+            .map_err(|_| Error::LockPoisoned)?;
         let mut observed = self.lock_finger_state()?;
         for (index, did) in fingers {
             if *index >= observed.slot_count() {
@@ -197,7 +197,7 @@ impl PeerRing {
         let _transition = self
             .topology_transition
             .lock()
-            .map_err(|_| Error::DHTSyncLockError)?;
+            .map_err(|_| Error::LockPoisoned)?;
         let state = self.topology_state_unlocked()?;
         Ok(observe(&state))
     }
@@ -262,7 +262,7 @@ impl PeerRing {
         let _transition = self
             .topology_transition
             .lock()
-            .map_err(|_| Error::DHTSyncLockError)?;
+            .map_err(|_| Error::LockPoisoned)?;
         let current = self.topology_state_unlocked()?;
         observe_snapshot(&current);
         let next = topology::step(&current, event, self.successor_seq.capacity());

--- a/crates/core/src/dht/chord/peer_ring.rs
+++ b/crates/core/src/dht/chord/peer_ring.rs
@@ -225,14 +225,29 @@ impl PeerRing {
     }
 
     /// Whether this node is the Chord successor of the position `did`, i.e.
-    /// `did ∈ (predecessor, self]`; with no known predecessor the node is responsible for the
-    /// whole ring. A message addressed to an unconnected `did` in this interval has reached the
-    /// node that must hold it.
+    /// `did ∈ (predecessor, self]`. With no known predecessor the node is responsible only when
+    /// it stands alone: a node that has successors but has not yet learned its predecessor is
+    /// merely uninformed, not responsible for the whole ring. A message addressed to an
+    /// unreachable `did` in this interval has reached the node that must hold it.
     pub(crate) fn is_responsible_for(&self, did: Did) -> Result<bool> {
         let state = self.topology_state()?;
-        Ok(state.predecessor.is_none_or(|predecessor| {
-            topology::dist(predecessor, did) <= topology::dist(predecessor, self.did)
-        }))
+        Ok(match state.predecessor {
+            Some(predecessor) => {
+                did != predecessor
+                    && topology::dist(predecessor, did) <= topology::dist(predecessor, self.did)
+            }
+            None => topology::successor_head(&state).is_none(),
+        })
+    }
+
+    /// The node this owner routes the position `destination` to, when its own view answers:
+    /// the only node whose holds for `destination` this owner admits (see the `inbox` module).
+    pub(crate) fn inbox_hold_authority(&self, destination: Did) -> Result<Option<Did>> {
+        let state = self.topology_state()?;
+        Ok(match topology::find_successor(&state, destination) {
+            FindSuccessorStep::Local(responsible) => Some(responsible),
+            FindSuccessorStep::Remote { .. } => None,
+        })
     }
 
     fn transition_topology(&self, event: TopologyEvent) -> Result<TopologyStep> {
@@ -278,9 +293,8 @@ impl PeerRing {
             TopologyAction::Notify(did) => {
                 PeerRingAction::RemoteAction(did, RemoteAction::Notify(self.did))
             }
-            TopologyAction::SuccessorHeadChanged(head) => {
-                PeerRingAction::RemoteAction(head, RemoteAction::HandOffStorage)
-            }
+            // The pass reads the current head when it runs, so the head is not carried.
+            TopologyAction::SuccessorHeadChanged(_) => PeerRingAction::StorageRepairDue,
         }
     }
 

--- a/crates/core/src/dht/chord/peer_ring.rs
+++ b/crates/core/src/dht/chord/peer_ring.rs
@@ -230,14 +230,7 @@ impl PeerRing {
     /// merely uninformed, not responsible for the whole ring. A message addressed to an
     /// unreachable `did` in this interval has reached the node that must hold it.
     pub(crate) fn is_responsible_for(&self, did: Did) -> Result<bool> {
-        let state = self.topology_state()?;
-        Ok(match state.predecessor {
-            Some(predecessor) => {
-                did != predecessor
-                    && topology::dist(predecessor, did) <= topology::dist(predecessor, self.did)
-            }
-            None => topology::successor_head(&state).is_none(),
-        })
+        self.with_topology_state(|state| topology::is_responsible_for(state, did))
     }
 
     /// The node this owner routes the position `destination` to, when its own view answers:

--- a/crates/core/src/dht/chord/peer_ring.rs
+++ b/crates/core/src/dht/chord/peer_ring.rs
@@ -170,6 +170,9 @@ impl PeerRing {
         self.remove_with_successor_evidence(did, SuccessorRemoval::ReplaceWith(replacements))
     }
 
+    /// Post: the emitted actions are dropped. A removal only widens `(self, head]` (a closer
+    /// connected peer would already be the head), so its head change moves no placement out of
+    /// this node; the caller requests the storage repair round for the widened interval itself.
     fn remove_with_successor_evidence(&self, did: Did, successor: SuccessorRemoval) -> Result<()> {
         self.transition_topology(TopologyEvent::Remove {
             peer: did,
@@ -274,6 +277,9 @@ impl PeerRing {
             }
             TopologyAction::Notify(did) => {
                 PeerRingAction::RemoteAction(did, RemoteAction::Notify(self.did))
+            }
+            TopologyAction::SuccessorHeadChanged(head) => {
+                PeerRingAction::RemoteAction(head, RemoteAction::HandOffStorage)
             }
         }
     }

--- a/crates/core/src/dht/chord/peer_ring.rs
+++ b/crates/core/src/dht/chord/peer_ring.rs
@@ -3,6 +3,7 @@ use std::sync::Mutex;
 use std::sync::MutexGuard;
 
 use async_trait::async_trait;
+use futures::lock::Mutex as FuturesMutex;
 
 use super::PeerRingAction;
 use super::RemoteAction;
@@ -52,6 +53,8 @@ pub struct PeerRing {
     pub cache: EntryStorage,
     storage_virtual_node_config: VirtualNodeConfig,
     topology_transition: Mutex<()>,
+    /// Serializes every read-modify-write of a storage slot (see `chord::storage`).
+    pub(super) storage_transition: FuturesMutex<()>,
 }
 
 impl PeerRing {
@@ -100,6 +103,7 @@ impl PeerRing {
             cache: Box::new(MemStorage::bounded(LOCAL_CACHE_CAPACITY)),
             storage_virtual_node_config: virtual_nodes,
             topology_transition: Mutex::new(()),
+            storage_transition: FuturesMutex::new(()),
             did,
         }
     }

--- a/crates/core/src/dht/chord/peer_ring.rs
+++ b/crates/core/src/dht/chord/peer_ring.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use super::PeerRingAction;
 use super::RemoteAction;
 use super::TopoInfo;
+use crate::consts::LOCAL_CACHE_CAPACITY;
 use crate::dht::did::BiasId;
 use crate::dht::entry::Entry;
 use crate::dht::finger::DEFAULT_FINGER_TABLE_SIZE;
@@ -47,7 +48,7 @@ pub struct PeerRing {
     predecessor: Arc<Mutex<Option<Did>>>,
     /// Persistent replicated-entry storage.
     pub storage: EntryStorage,
-    /// Local fetched-entry cache.
+    /// Local fetched-entry cache, bounded at [`LOCAL_CACHE_CAPACITY`] entries.
     pub cache: EntryStorage,
     storage_virtual_node_config: VirtualNodeConfig,
     topology_transition: Mutex<()>,
@@ -96,7 +97,7 @@ impl PeerRing {
             predecessor: Arc::new(Mutex::new(None)),
             finger: Arc::new(Mutex::new(FingerTable::new(did, finger_table_size))),
             storage,
-            cache: Box::new(MemStorage::new()),
+            cache: Box::new(MemStorage::bounded(LOCAL_CACHE_CAPACITY)),
             storage_virtual_node_config: virtual_nodes,
             topology_transition: Mutex::new(()),
             did,

--- a/crates/core/src/dht/chord/storage.rs
+++ b/crates/core/src/dht/chord/storage.rs
@@ -55,15 +55,19 @@ impl PeerRing {
         Ok(live)
     }
 
-    /// Join an incoming replicated entry delta into local storage.
+    /// Join a peer-supplied replicated value into local storage at time `now_ms`.
     ///
-    /// Pre: `incoming` satisfies [`Entry::validate_admissible_at`] for the local clock; the
-    /// check is enforced here so every write path shares one admission rule.
+    /// Pre: `incoming` is the value a peer supplied, not a local join result; it is admitted
+    /// by [`Entry::validate_admissible_at`] here so every replication path shares one rule.
     /// Post: the stored value is the least upper bound of the previous live local
     /// value and `incoming` when a previous value exists; otherwise it is
     /// `incoming` normalized for storage.
-    pub(crate) async fn join_storage_entry(&self, key: Did, incoming: Entry) -> Result<Entry> {
-        let now_ms = get_epoch_ms();
+    pub(crate) async fn join_storage_entry(
+        &self,
+        now_ms: u128,
+        key: Did,
+        incoming: Entry,
+    ) -> Result<Entry> {
         incoming.validate_admissible_at(now_ms)?;
         let incoming = incoming.try_into_storage_entry()?;
         let stored = if let Some(local) = self.live_storage_entry(key, now_ms).await? {
@@ -74,6 +78,30 @@ impl PeerRing {
         .try_into_storage_entry()?;
         self.storage.put(&key.to_string(), &stored).await?;
         Ok(stored)
+    }
+
+    /// Apply a stamped operation to the value stored at `placement` at time `now_ms`.
+    ///
+    /// Pre: `op` is stamped. Admission is checked on the delta `op` carries, never on the join
+    /// result, so a locally derived version (a compaction floor bumped by one step) is never
+    /// mistaken for a peer clock running ahead.
+    /// Post: the stored value is `local.operate(op)` normalized for storage, where `local` is
+    /// the live stored value or the operation's default carrier.
+    pub(crate) async fn operate_storage_entry(
+        &self,
+        now_ms: u128,
+        placement: Did,
+        op: EntryOperation,
+    ) -> Result<()> {
+        op.validate_admissible_at(now_ms)?;
+        let local = match self.live_storage_entry(placement, now_ms).await? {
+            Some(local) => local,
+            None => op.clone().gen_default_entry()?,
+        };
+        let stored = local
+            .operate(now_ms, op, self.did)?
+            .try_into_storage_entry()?;
+        self.storage.put(&placement.to_string(), &stored).await
     }
 
     fn storage_fetch_fallback_successor(&self) -> Result<Option<Did>> {
@@ -181,18 +209,14 @@ impl<const REDUNDANT: u16> ChordStorage<PeerRingAction, REDUNDANT> for PeerRing 
 
     async fn entry_operate(&self, op: EntryOperation) -> Result<PeerRingAction> {
         let now_ms = get_epoch_ms();
-        let op = op.stamped_at(now_ms, self.did)?;
+        let op = op.stamped(now_ms, self.did)?;
         let entry_key = op.did()?;
         let mut ret = vec![];
         for entry_key in entry_key.rotate_affine(REDUNDANT)? {
             let act = match self.find_storage_owner(entry_key) {
                 Ok(PeerRingAction::Some(_)) => {
-                    let this = match self.live_storage_entry(entry_key, now_ms).await? {
-                        Some(this) => this,
-                        None => op.clone().gen_default_entry()?,
-                    };
-                    let entry = this.operate_at(now_ms, op.clone(), self.did)?;
-                    self.join_storage_entry(entry_key, entry).await?;
+                    self.operate_storage_entry(now_ms, entry_key, op.clone())
+                        .await?;
                     Ok(PeerRingAction::None)
                 }
                 Ok(PeerRingAction::RemoteAction(next, RemoteAction::FindSuccessor(_))) => {

--- a/crates/core/src/dht/chord/storage.rs
+++ b/crates/core/src/dht/chord/storage.rs
@@ -12,18 +12,61 @@ use crate::dht::entry::PlacementMiss;
 use crate::dht::types::ChordStorage;
 use crate::dht::types::ChordStorageCache;
 use crate::dht::Did;
+use crate::dht::EntryStorage;
 use crate::error::Error;
 use crate::error::Result;
+use crate::utils::get_epoch_ms;
+
+/// Read `key` from `store`, retiring a value that is no longer live.
+///
+/// Post: `Ok(Some(entry))` implies `entry.is_live_at(now_ms)`. A stored value whose
+/// retention bound has elapsed (or that predates retention bounds) is removed and reported
+/// absent, so expiry is enforced lazily on every read path instead of by a sweeper.
+async fn live_entry(store: &EntryStorage, key: &str, now_ms: u128) -> Result<Option<Entry>> {
+    match store.get(key).await? {
+        Some(entry) if entry.is_live_at(now_ms) => Ok(Some(entry)),
+        Some(_) => {
+            store.remove(key).await?;
+            Ok(None)
+        }
+        None => Ok(None),
+    }
+}
 
 impl PeerRing {
+    /// Read the live replicated entry stored at `key`.
+    pub(crate) async fn live_storage_entry(&self, key: Did, now_ms: u128) -> Result<Option<Entry>> {
+        live_entry(&self.storage, &key.to_string(), now_ms).await
+    }
+
+    /// Every live replicated entry with its placement key, retiring the rest.
+    ///
+    /// Post: every returned entry satisfies `is_live_at(now_ms)`; every stored entry that does
+    /// not has been removed.
+    pub(crate) async fn live_storage_entries(&self, now_ms: u128) -> Result<Vec<(String, Entry)>> {
+        let mut live = Vec::new();
+        for (key, entry) in self.storage.get_all().await? {
+            if entry.is_live_at(now_ms) {
+                live.push((key, entry));
+            } else {
+                self.storage.remove(&key).await?;
+            }
+        }
+        Ok(live)
+    }
+
     /// Join an incoming replicated entry delta into local storage.
     ///
-    /// Post: the stored value is the least upper bound of the previous local
+    /// Pre: `incoming` satisfies [`Entry::validate_admissible_at`] for the local clock; the
+    /// check is enforced here so every write path shares one admission rule.
+    /// Post: the stored value is the least upper bound of the previous live local
     /// value and `incoming` when a previous value exists; otherwise it is
     /// `incoming` normalized for storage.
     pub(crate) async fn join_storage_entry(&self, key: Did, incoming: Entry) -> Result<Entry> {
+        let now_ms = get_epoch_ms();
+        incoming.validate_admissible_at(now_ms)?;
         let incoming = incoming.try_into_storage_entry()?;
-        let stored = if let Some(local) = self.storage.get(&key.to_string()).await? {
+        let stored = if let Some(local) = self.live_storage_entry(key, now_ms).await? {
             local.join(incoming)?
         } else {
             incoming
@@ -46,13 +89,14 @@ impl PeerRing {
         entry_key: Did,
         fallback_on_local_virtual_miss: bool,
     ) -> Result<PeerRingAction> {
+        let now_ms = get_epoch_ms();
         let mut ret = vec![];
         let mut misses = vec![];
         for placement_key in entry_key.rotate_affine(REDUNDANT)? {
             let query = EntryLookupKey::new(entry_key, placement_key);
             let act = match self.find_storage_owner(placement_key) {
                 Ok(PeerRingAction::Some(succ)) => {
-                    match self.storage.get(&placement_key.to_string()).await {
+                    match self.live_storage_entry(placement_key, now_ms).await {
                         Ok(Some(value)) => {
                             let observed_misses = std::mem::take(&mut misses);
                             Ok(PeerRingAction::SomeEntry(EntryLookupEvidence::new(
@@ -136,27 +180,28 @@ impl<const REDUNDANT: u16> ChordStorage<PeerRingAction, REDUNDANT> for PeerRing 
     }
 
     async fn entry_operate(&self, op: EntryOperation) -> Result<PeerRingAction> {
-        let op = op.stamped(self.did)?;
+        let now_ms = get_epoch_ms();
+        let op = op.stamped_at(now_ms, self.did)?;
         let entry_key = op.did()?;
         let mut ret = vec![];
         for entry_key in entry_key.rotate_affine(REDUNDANT)? {
             let act = match self.find_storage_owner(entry_key) {
                 Ok(PeerRingAction::Some(_)) => {
-                    let this = match self.storage.get(&entry_key.to_string()).await? {
+                    let this = match self.live_storage_entry(entry_key, now_ms).await? {
                         Some(this) => this,
                         None => op.clone().gen_default_entry()?,
                     };
-                    let entry = this.operate(op.clone(), self.did)?;
+                    let entry = this.operate_at(now_ms, op.clone(), self.did)?;
                     self.join_storage_entry(entry_key, entry).await?;
                     Ok(PeerRingAction::None)
                 }
                 Ok(PeerRingAction::RemoteAction(next, RemoteAction::FindSuccessor(_))) => {
                     Ok(PeerRingAction::RemoteAction(
                         next,
-                        RemoteAction::FindEntryForOperate(PlacedEntryOperation {
+                        RemoteAction::FindEntryForOperate(Box::new(PlacedEntryOperation {
                             placement: entry_key,
                             op: op.clone(),
-                        }),
+                        })),
                     ))
                 }
                 Ok(action) => Err(Error::unexpected_peer_ring_action(action)),
@@ -173,11 +218,16 @@ impl<const REDUNDANT: u16> ChordStorage<PeerRingAction, REDUNDANT> for PeerRing 
 #[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
 impl ChordStorageCache<PeerRingAction> for PeerRing {
+    /// Cache a fetched entry.
+    ///
+    /// Pre: `entry` satisfies the same admission law as a replicated write, so a peer cannot
+    /// pin a fetched value in the cache past the retention bound it could obtain in storage.
     async fn local_cache_put(&self, entry: Entry) -> Result<()> {
+        entry.validate_admissible_at(get_epoch_ms())?;
         self.cache.put(&entry.did.to_string(), &entry).await
     }
 
     async fn local_cache_get(&self, entry_key: Did) -> Result<Option<Entry>> {
-        self.cache.get(&entry_key.to_string()).await
+        live_entry(&self.cache, &entry_key.to_string(), get_epoch_ms()).await
     }
 }

--- a/crates/core/src/dht/chord/storage.rs
+++ b/crates/core/src/dht/chord/storage.rs
@@ -7,6 +7,7 @@ use super::PeerRing;
 use super::PeerRingAction;
 use super::RemoteAction;
 use crate::dht::entry::inbox::inbox_destination;
+use crate::dht::entry::inbox::inbox_key;
 use crate::dht::entry::Entry;
 use crate::dht::entry::EntryKind;
 use crate::dht::entry::EntryLookupEvidence;
@@ -44,6 +45,11 @@ impl StorageKey {
     /// The slot of a carrier of `kind` placed at `placement`.
     pub(crate) const fn new(kind: EntryKind, placement: Did) -> Self {
         Self { kind, placement }
+    }
+
+    /// The slot of the relay inbox kept for `destination`.
+    pub(crate) fn inbox_of(destination: Did) -> Self {
+        Self::new(EntryKind::RelayMessage, inbox_key(destination))
     }
 
     /// The placement of the carrier.
@@ -160,8 +166,10 @@ impl PeerRing {
     /// result, so a locally derived version (a compaction floor bumped by one step) is never
     /// mistaken for a peer clock running ahead; a relay inbox also passes the authority law
     /// under this node's own routing view.
-    /// Post: the stored value is `local.operate(op)` normalized for storage, where `local` is
-    /// the live stored value or the operation's default carrier.
+    /// Post: the slot holds `local.operate(op)` normalized for storage, where `local` is the
+    /// live stored value or the operation's default carrier, when that result is live; a result
+    /// with no retention (a removal against nothing held) leaves the slot empty, so a stored
+    /// value is always live when written.
     pub(crate) async fn operate_storage_entry(
         &self,
         now_ms: u128,
@@ -191,7 +199,11 @@ impl PeerRing {
         let stored = local
             .operate(now_ms, op, self.did)?
             .try_into_storage_entry()?;
-        self.storage.put(&key.to_string(), &stored).await
+        if stored.is_live_at(now_ms) {
+            self.storage.put(&key.to_string(), &stored).await
+        } else {
+            self.storage.remove(&key.to_string()).await
+        }
     }
 
     fn storage_fetch_fallback_successor(&self) -> Result<Option<Did>> {

--- a/crates/core/src/dht/chord/storage.rs
+++ b/crates/core/src/dht/chord/storage.rs
@@ -15,6 +15,7 @@ use crate::dht::entry::EntryLookupKey;
 use crate::dht::entry::EntryOperation;
 use crate::dht::entry::PlacedEntryOperation;
 use crate::dht::entry::PlacementMiss;
+use crate::dht::entry::SyncedEntryAck;
 use crate::dht::types::ChordStorage;
 use crate::dht::types::ChordStorageCache;
 use crate::dht::Did;
@@ -81,6 +82,7 @@ impl FromStr for StorageKey {
 
 /// Read `key` from `store`, retiring a value that is no longer live.
 ///
+/// Pre: the caller holds the ring's storage transition, since a retirement is a write.
 /// Post: `Ok(Some(entry))` implies `entry.is_live_at(now_ms)`. A stored value whose
 /// retention bound has elapsed (or that predates retention bounds) is removed and reported
 /// absent, so expiry is enforced lazily on every read path instead of by a sweeper.
@@ -105,6 +107,14 @@ async fn retire_unless_live(
     Ok(None)
 }
 
+/// Storage transition law: every read-modify-write of a slot (an operation, a join, an
+/// acknowledged removal, and the retirement a read performs) runs under the ring's storage
+/// transition, one at a time. The inbound actor and the stabilizer write the same slots
+/// concurrently (a hold arriving while the recipient drains its inbox, a hand-off joining while
+/// a repair pass reads), and the store itself only orders single puts, so without this
+/// serialization one of two interleaved read-modify-writes would overwrite the other and a held
+/// message could be lost. The transition is held across the store's own awaits and nothing
+/// else, so it never nests and never waits on the network.
 impl PeerRing {
     /// Read the live replicated entry stored at `key`.
     pub(crate) async fn live_storage_entry(
@@ -112,6 +122,7 @@ impl PeerRing {
         key: StorageKey,
         now_ms: u128,
     ) -> Result<Option<Entry>> {
+        let _transition = self.storage_transition.lock().await;
         live_entry(&self.storage, &key.to_string(), now_ms).await
     }
 
@@ -123,6 +134,7 @@ impl PeerRing {
         &self,
         now_ms: u128,
     ) -> Result<Vec<(StorageKey, Entry)>> {
+        let _transition = self.storage_transition.lock().await;
         let mut live = Vec::new();
         for (key, entry) in self.storage.get_all().await? {
             if let Some(entry) = retire_unless_live(&self.storage, &key, entry, now_ms).await? {
@@ -130,6 +142,28 @@ impl PeerRing {
             }
         }
         Ok(live)
+    }
+
+    /// Remove the value stored at `key` iff `ack` proves the receiver holds exactly that
+    /// value: the ack-gated local cleanup of an ownership hand-off.
+    ///
+    /// Post: a value written after the hand-off copy was taken differs from the acked one and
+    /// stays; the comparison and the removal are one storage transition, so a write landing
+    /// between them cannot be removed by an ack for an older value.
+    pub(crate) async fn remove_storage_entry_confirmed_by(
+        &self,
+        key: StorageKey,
+        now_ms: u128,
+        ack: &SyncedEntryAck,
+    ) -> Result<()> {
+        let _transition = self.storage_transition.lock().await;
+        let Some(local) = live_entry(&self.storage, &key.to_string(), now_ms).await? else {
+            return Ok(());
+        };
+        if ack.confirms_local_value(&local)? {
+            self.storage.remove(&key.to_string()).await?;
+        }
+        Ok(())
     }
 
     /// Join a peer-supplied replicated value into local storage at time `now_ms`.
@@ -146,15 +180,16 @@ impl PeerRing {
         incoming: Entry,
     ) -> Result<Entry> {
         incoming.validate_admissible_at(now_ms, self.network_id())?;
-        let key = StorageKey::new(incoming.kind, key);
+        let key = StorageKey::new(incoming.kind, key).to_string();
         let incoming = incoming.try_into_storage_entry()?;
-        let stored = if let Some(local) = self.live_storage_entry(key, now_ms).await? {
+        let _transition = self.storage_transition.lock().await;
+        let stored = if let Some(local) = live_entry(&self.storage, &key, now_ms).await? {
             local.join(incoming)?
         } else {
             incoming
         }
         .try_into_storage_entry()?;
-        self.storage.put(&key.to_string(), &stored).await?;
+        self.storage.put(&key, &stored).await?;
         Ok(stored)
     }
 
@@ -191,8 +226,9 @@ impl PeerRing {
                 op.validate_inbox_write(writer, responsible, now_ms, self.network_id())?;
             }
         }
-        let key = StorageKey::new(op.kind(), placement);
-        let local = match self.live_storage_entry(key, now_ms).await? {
+        let key = StorageKey::new(op.kind(), placement).to_string();
+        let _transition = self.storage_transition.lock().await;
+        let local = match live_entry(&self.storage, &key, now_ms).await? {
             Some(local) => local,
             None => op.gen_default_entry()?,
         };
@@ -200,9 +236,9 @@ impl PeerRing {
             .operate(now_ms, op, self.did)?
             .try_into_storage_entry()?;
         if stored.is_live_at(now_ms) {
-            self.storage.put(&key.to_string(), &stored).await
+            self.storage.put(&key, &stored).await
         } else {
-            self.storage.remove(&key.to_string()).await
+            self.storage.remove(&key).await
         }
     }
 

--- a/crates/core/src/dht/chord/storage.rs
+++ b/crates/core/src/dht/chord/storage.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+use std::str::FromStr;
+
 use async_trait::async_trait;
 
 use super::PeerRing;
@@ -18,6 +21,57 @@ use crate::dht::EntryStorage;
 use crate::error::Error;
 use crate::error::Result;
 use crate::utils::get_epoch_ms;
+
+/// The identity of a stored carrier: its kind and its placement.
+///
+/// Storage is partitioned by kind, so the two carriers one position can name (a data topic,
+/// which any node may place at any position through an overwrite, and the relay inbox of the
+/// peer just before that position) never contend for one slot: a topic parked at `d + 1` cannot
+/// shadow the inbox kept for `d`. The data namespace keeps the historical rendering of a bare
+/// placement, so values written by earlier builds stay addressable.
+///
+/// Law: `StorageKey::from_str(&key.to_string()) == Ok(key)`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct StorageKey {
+    kind: EntryKind,
+    placement: Did,
+}
+
+impl StorageKey {
+    /// The rendering prefix of the relay-inbox namespace; the data namespace has none.
+    const RELAY_INBOX_PREFIX: &'static str = "relay:";
+
+    /// The slot of a carrier of `kind` placed at `placement`.
+    pub(crate) const fn new(kind: EntryKind, placement: Did) -> Self {
+        Self { kind, placement }
+    }
+
+    /// The placement of the carrier.
+    pub(crate) const fn placement(self) -> Did {
+        self.placement
+    }
+}
+
+impl fmt::Display for StorageKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            EntryKind::Data => write!(f, "{}", self.placement),
+            EntryKind::RelayMessage => write!(f, "{}{}", Self::RELAY_INBOX_PREFIX, self.placement),
+        }
+    }
+}
+
+impl FromStr for StorageKey {
+    type Err = Error;
+
+    fn from_str(key: &str) -> Result<Self> {
+        let (kind, placement) = match key.strip_prefix(Self::RELAY_INBOX_PREFIX) {
+            Some(placement) => (EntryKind::RelayMessage, placement),
+            None => (EntryKind::Data, key),
+        };
+        Ok(Self::new(kind, Did::from_str(placement)?))
+    }
+}
 
 /// Read `key` from `store`, retiring a value that is no longer live.
 ///
@@ -47,19 +101,26 @@ async fn retire_unless_live(
 
 impl PeerRing {
     /// Read the live replicated entry stored at `key`.
-    pub(crate) async fn live_storage_entry(&self, key: Did, now_ms: u128) -> Result<Option<Entry>> {
+    pub(crate) async fn live_storage_entry(
+        &self,
+        key: StorageKey,
+        now_ms: u128,
+    ) -> Result<Option<Entry>> {
         live_entry(&self.storage, &key.to_string(), now_ms).await
     }
 
-    /// Every live replicated entry with its placement key, retiring the rest.
+    /// Every live replicated entry with its key, retiring the rest.
     ///
     /// Post: every returned entry satisfies `is_live_at(now_ms)`; every stored entry that does
     /// not has been removed.
-    pub(crate) async fn live_storage_entries(&self, now_ms: u128) -> Result<Vec<(String, Entry)>> {
+    pub(crate) async fn live_storage_entries(
+        &self,
+        now_ms: u128,
+    ) -> Result<Vec<(StorageKey, Entry)>> {
         let mut live = Vec::new();
         for (key, entry) in self.storage.get_all().await? {
             if let Some(entry) = retire_unless_live(&self.storage, &key, entry, now_ms).await? {
-                live.push((key, entry));
+                live.push((StorageKey::from_str(&key)?, entry));
             }
         }
         Ok(live)
@@ -79,6 +140,7 @@ impl PeerRing {
         incoming: Entry,
     ) -> Result<Entry> {
         incoming.validate_admissible_at(now_ms, self.network_id())?;
+        let key = StorageKey::new(incoming.kind, key);
         let incoming = incoming.try_into_storage_entry()?;
         let stored = if let Some(local) = self.live_storage_entry(key, now_ms).await? {
             local.join(incoming)?
@@ -121,14 +183,15 @@ impl PeerRing {
                 op.validate_inbox_write(writer, responsible, now_ms, self.network_id())?;
             }
         }
-        let local = match self.live_storage_entry(placement, now_ms).await? {
+        let key = StorageKey::new(op.kind(), placement);
+        let local = match self.live_storage_entry(key, now_ms).await? {
             Some(local) => local,
             None => op.gen_default_entry()?,
         };
         let stored = local
             .operate(now_ms, op, self.did)?
             .try_into_storage_entry()?;
-        self.storage.put(&placement.to_string(), &stored).await
+        self.storage.put(&key.to_string(), &stored).await
     }
 
     fn storage_fetch_fallback_successor(&self) -> Result<Option<Did>> {
@@ -150,9 +213,12 @@ impl PeerRing {
         let mut misses = vec![];
         for placement_key in entry_key.rotate_affine(redundancy)? {
             let query = EntryLookupKey::new(entry_key, placement_key);
+            // A lookup reads the data namespace: a relay inbox is never fetched, its recipient
+            // drains it from local storage, so a lookup at its position sees it as absent.
+            let key = StorageKey::new(EntryKind::Data, placement_key);
             let act = match self.find_storage_owner(placement_key) {
                 Ok(PeerRingAction::Some(succ)) => {
-                    match self.live_storage_entry(placement_key, now_ms).await {
+                    match self.live_storage_entry(key, now_ms).await {
                         Ok(Some(value)) => {
                             let observed_misses = std::mem::take(&mut misses);
                             Ok(PeerRingAction::SomeEntry(EntryLookupEvidence::new(

--- a/crates/core/src/dht/chord/storage.rs
+++ b/crates/core/src/dht/chord/storage.rs
@@ -3,7 +3,9 @@ use async_trait::async_trait;
 use super::PeerRing;
 use super::PeerRingAction;
 use super::RemoteAction;
+use crate::dht::entry::inbox::inbox_destination;
 use crate::dht::entry::Entry;
+use crate::dht::entry::EntryKind;
 use crate::dht::entry::EntryLookupEvidence;
 use crate::dht::entry::EntryLookupKey;
 use crate::dht::entry::EntryOperation;
@@ -87,13 +89,23 @@ impl PeerRing {
     /// mistaken for a peer clock running ahead.
     /// Post: the stored value is `local.operate(op)` normalized for storage, where `local` is
     /// the live stored value or the operation's default carrier.
+    /// Apply `op` to the carrier at `placement`, issued by `writer`.
+    ///
+    /// Pre: `writer` is the signer of the operation as the shell verified it (this node for a
+    /// local operation). Post: the delta passed admission and, for a relay inbox, the authority
+    /// law under this node's own routing view.
     pub(crate) async fn operate_storage_entry(
         &self,
         now_ms: u128,
         placement: Did,
         op: EntryOperation,
+        writer: Did,
     ) -> Result<()> {
         op.validate_admissible_at(now_ms, self.network_id())?;
+        if op.entry().kind == EntryKind::RelayMessage {
+            let responsible = self.inbox_hold_authority(inbox_destination(placement))?;
+            op.validate_inbox_authority(writer, responsible)?;
+        }
         let local = match self.live_storage_entry(placement, now_ms).await? {
             Some(local) => local,
             None => op.clone().gen_default_entry()?,
@@ -211,11 +223,17 @@ impl PeerRing {
         let now_ms = get_epoch_ms();
         let op = op.stamped(now_ms, self.did)?;
         let entry_key = op.did()?;
+        let kind = op.entry().kind;
+        // A relay inbox has one owner: it is never replicated.
+        let redundancy = match kind {
+            EntryKind::Data => redundancy,
+            EntryKind::RelayMessage => 1,
+        };
         let mut ret = vec![];
         for entry_key in entry_key.rotate_affine(redundancy)? {
-            let act = match self.find_storage_owner(entry_key) {
+            let act = match self.find_storage_owner_for(entry_key, kind) {
                 Ok(PeerRingAction::Some(_)) => {
-                    self.operate_storage_entry(now_ms, entry_key, op.clone())
+                    self.operate_storage_entry(now_ms, entry_key, op.clone(), self.did)
                         .await?;
                     Ok(PeerRingAction::None)
                 }
@@ -259,6 +277,9 @@ impl ChordStorageCache<PeerRingAction> for PeerRing {
     /// Pre: `entry` satisfies the same admission law as a replicated write, so a peer cannot
     /// pin a fetched value in the cache past the retention bound it could obtain in storage.
     async fn local_cache_put(&self, entry: Entry) -> Result<()> {
+        if entry.kind == EntryKind::RelayMessage {
+            return Err(Error::RelayInboxOperationNotAllowed);
+        }
         entry.validate_admissible_at(get_epoch_ms(), self.network_id())?;
         self.cache.put(&entry.did.to_string(), &entry).await
     }

--- a/crates/core/src/dht/chord/storage.rs
+++ b/crates/core/src/dht/chord/storage.rs
@@ -26,13 +26,23 @@ use crate::utils::get_epoch_ms;
 /// absent, so expiry is enforced lazily on every read path instead of by a sweeper.
 async fn live_entry(store: &EntryStorage, key: &str, now_ms: u128) -> Result<Option<Entry>> {
     match store.get(key).await? {
-        Some(entry) if entry.is_live_at(now_ms) => Ok(Some(entry)),
-        Some(_) => {
-            store.remove(key).await?;
-            Ok(None)
-        }
+        Some(entry) => retire_unless_live(store, key, entry, now_ms).await,
         None => Ok(None),
     }
+}
+
+/// Keep `entry`, read from `store` at `key`, iff it is live at `now_ms`; remove it otherwise.
+async fn retire_unless_live(
+    store: &EntryStorage,
+    key: &str,
+    entry: Entry,
+    now_ms: u128,
+) -> Result<Option<Entry>> {
+    if entry.is_live_at(now_ms) {
+        return Ok(Some(entry));
+    }
+    store.remove(key).await?;
+    Ok(None)
 }
 
 impl PeerRing {
@@ -48,10 +58,8 @@ impl PeerRing {
     pub(crate) async fn live_storage_entries(&self, now_ms: u128) -> Result<Vec<(String, Entry)>> {
         let mut live = Vec::new();
         for (key, entry) in self.storage.get_all().await? {
-            if entry.is_live_at(now_ms) {
+            if let Some(entry) = retire_unless_live(&self.storage, &key, entry, now_ms).await? {
                 live.push((key, entry));
-            } else {
-                self.storage.remove(&key).await?;
             }
         }
         Ok(live)
@@ -99,20 +107,23 @@ impl PeerRing {
         op: EntryOperation,
         writer: Did,
     ) -> Result<()> {
-        op.validate_admissible_at(now_ms, self.network_id())?;
-        if op.entry().kind == EntryKind::RelayMessage {
-            // Only a hold needs to know who is responsible for the recipient.
-            let responsible = match op {
-                EntryOperation::Extend(_) => {
-                    self.inbox_hold_authority(inbox_destination(placement))?
-                }
-                _ => None,
-            };
-            op.validate_inbox_authority(writer, responsible)?;
+        match op.entry().kind {
+            EntryKind::Data => op.validate_admissible_at(now_ms, self.network_id())?,
+            EntryKind::RelayMessage => {
+                op.entry().validate_bounds_at(now_ms)?;
+                // Only a hold needs to know who is responsible for the recipient.
+                let responsible = match op {
+                    EntryOperation::Extend(_) => {
+                        self.inbox_hold_authority(inbox_destination(placement))?
+                    }
+                    _ => None,
+                };
+                op.validate_inbox_write(writer, responsible, now_ms, self.network_id())?;
+            }
         }
         let local = match self.live_storage_entry(placement, now_ms).await? {
             Some(local) => local,
-            None => op.clone().gen_default_entry()?,
+            None => op.gen_default_entry()?,
         };
         let stored = local
             .operate(now_ms, op, self.did)?
@@ -228,11 +239,7 @@ impl PeerRing {
         let op = op.stamped(now_ms, self.did)?;
         let entry_key = op.did()?;
         let kind = op.entry().kind;
-        // A relay inbox has one owner: it is never replicated.
-        let redundancy = match kind {
-            EntryKind::Data => redundancy,
-            EntryKind::RelayMessage => 1,
-        };
+        let redundancy = kind.replication(redundancy);
         let mut ret = vec![];
         for entry_key in entry_key.rotate_affine(redundancy)? {
             let act = match self.find_storage_owner_for(entry_key, kind) {
@@ -281,7 +288,7 @@ impl ChordStorageCache<PeerRingAction> for PeerRing {
     /// Pre: `entry` satisfies the same admission law as a replicated write, so a peer cannot
     /// pin a fetched value in the cache past the retention bound it could obtain in storage.
     async fn local_cache_put(&self, entry: Entry) -> Result<()> {
-        if entry.kind == EntryKind::RelayMessage {
+        if entry.kind.is_relay_inbox() {
             return Err(Error::RelayInboxOperationNotAllowed);
         }
         entry.validate_admissible_at(get_epoch_ms(), self.network_id())?;

--- a/crates/core/src/dht/chord/storage.rs
+++ b/crates/core/src/dht/chord/storage.rs
@@ -68,7 +68,7 @@ impl PeerRing {
         key: Did,
         incoming: Entry,
     ) -> Result<Entry> {
-        incoming.validate_admissible_at(now_ms)?;
+        incoming.validate_admissible_at(now_ms, self.network_id())?;
         let incoming = incoming.try_into_storage_entry()?;
         let stored = if let Some(local) = self.live_storage_entry(key, now_ms).await? {
             local.join(incoming)?
@@ -93,7 +93,7 @@ impl PeerRing {
         placement: Did,
         op: EntryOperation,
     ) -> Result<()> {
-        op.validate_admissible_at(now_ms)?;
+        op.validate_admissible_at(now_ms, self.network_id())?;
         let local = match self.live_storage_entry(placement, now_ms).await? {
             Some(local) => local,
             None => op.clone().gen_default_entry()?,
@@ -112,15 +112,16 @@ impl PeerRing {
             .find(|successor| *successor != self.did))
     }
 
-    async fn entry_lookup_inner<const REDUNDANT: u16>(
+    async fn entry_lookup_inner(
         &self,
         entry_key: Did,
         fallback_on_local_virtual_miss: bool,
+        redundancy: u16,
     ) -> Result<PeerRingAction> {
         let now_ms = get_epoch_ms();
         let mut ret = vec![];
         let mut misses = vec![];
-        for placement_key in entry_key.rotate_affine(REDUNDANT)? {
+        for placement_key in entry_key.rotate_affine(redundancy)? {
             let query = EntryLookupKey::new(entry_key, placement_key);
             let act = match self.find_storage_owner(placement_key) {
                 Ok(PeerRingAction::Some(succ)) => {
@@ -192,27 +193,26 @@ impl PeerRing {
     /// read repair can converge instead of treating the fresh local miss as
     /// authoritative. Remote `SearchEntry` handling uses [`ChordStorage`] and
     /// intentionally does not enable this fallback.
-    pub(crate) async fn entry_lookup_for_fetch<const REDUNDANT: u16>(
+    pub(crate) async fn entry_lookup_for_fetch(
         &self,
         entry_key: Did,
+        redundancy: u16,
     ) -> Result<PeerRingAction> {
-        self.entry_lookup_inner::<REDUNDANT>(entry_key, true).await
-    }
-}
-
-#[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
-#[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
-impl<const REDUNDANT: u16> ChordStorage<PeerRingAction, REDUNDANT> for PeerRing {
-    async fn entry_lookup(&self, entry_key: Did) -> Result<PeerRingAction> {
-        self.entry_lookup_inner::<REDUNDANT>(entry_key, false).await
+        self.entry_lookup_inner(entry_key, true, redundancy).await
     }
 
-    async fn entry_operate(&self, op: EntryOperation) -> Result<PeerRingAction> {
+    /// Apply `op` under a runtime `redundancy`: locally at every accepted placement, and as a
+    /// [`RemoteAction::FindEntryForOperate`] toward every remote one.
+    pub(crate) async fn entry_operate_with_redundancy(
+        &self,
+        op: EntryOperation,
+        redundancy: u16,
+    ) -> Result<PeerRingAction> {
         let now_ms = get_epoch_ms();
         let op = op.stamped(now_ms, self.did)?;
         let entry_key = op.did()?;
         let mut ret = vec![];
-        for entry_key in entry_key.rotate_affine(REDUNDANT)? {
+        for entry_key in entry_key.rotate_affine(redundancy)? {
             let act = match self.find_storage_owner(entry_key) {
                 Ok(PeerRingAction::Some(_)) => {
                     self.operate_storage_entry(now_ms, entry_key, op.clone())
@@ -241,13 +241,25 @@ impl<const REDUNDANT: u16> ChordStorage<PeerRingAction, REDUNDANT> for PeerRing 
 
 #[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
+impl<const REDUNDANT: u16> ChordStorage<PeerRingAction, REDUNDANT> for PeerRing {
+    async fn entry_lookup(&self, entry_key: Did) -> Result<PeerRingAction> {
+        self.entry_lookup_inner(entry_key, false, REDUNDANT).await
+    }
+
+    async fn entry_operate(&self, op: EntryOperation) -> Result<PeerRingAction> {
+        self.entry_operate_with_redundancy(op, REDUNDANT).await
+    }
+}
+
+#[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
+#[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
 impl ChordStorageCache<PeerRingAction> for PeerRing {
     /// Cache a fetched entry.
     ///
     /// Pre: `entry` satisfies the same admission law as a replicated write, so a peer cannot
     /// pin a fetched value in the cache past the retention bound it could obtain in storage.
     async fn local_cache_put(&self, entry: Entry) -> Result<()> {
-        entry.validate_admissible_at(get_epoch_ms())?;
+        entry.validate_admissible_at(get_epoch_ms(), self.network_id())?;
         self.cache.put(&entry.did.to_string(), &entry).await
     }
 

--- a/crates/core/src/dht/chord/storage.rs
+++ b/crates/core/src/dht/chord/storage.rs
@@ -82,18 +82,16 @@ impl PeerRing {
         Ok(stored)
     }
 
-    /// Apply a stamped operation to the value stored at `placement` at time `now_ms`.
+    /// Apply a stamped operation issued by `writer` to the value stored at `placement` at time
+    /// `now_ms`.
     ///
-    /// Pre: `op` is stamped. Admission is checked on the delta `op` carries, never on the join
+    /// Pre: `op` is stamped, and `writer` is its signer as the shell verified it (this node for
+    /// a local operation). Admission is checked on the delta `op` carries, never on the join
     /// result, so a locally derived version (a compaction floor bumped by one step) is never
-    /// mistaken for a peer clock running ahead.
+    /// mistaken for a peer clock running ahead; a relay inbox also passes the authority law
+    /// under this node's own routing view.
     /// Post: the stored value is `local.operate(op)` normalized for storage, where `local` is
     /// the live stored value or the operation's default carrier.
-    /// Apply `op` to the carrier at `placement`, issued by `writer`.
-    ///
-    /// Pre: `writer` is the signer of the operation as the shell verified it (this node for a
-    /// local operation). Post: the delta passed admission and, for a relay inbox, the authority
-    /// law under this node's own routing view.
     pub(crate) async fn operate_storage_entry(
         &self,
         now_ms: u128,
@@ -103,7 +101,13 @@ impl PeerRing {
     ) -> Result<()> {
         op.validate_admissible_at(now_ms, self.network_id())?;
         if op.entry().kind == EntryKind::RelayMessage {
-            let responsible = self.inbox_hold_authority(inbox_destination(placement))?;
+            // Only a hold needs to know who is responsible for the recipient.
+            let responsible = match op {
+                EntryOperation::Extend(_) => {
+                    self.inbox_hold_authority(inbox_destination(placement))?
+                }
+                _ => None,
+            };
             op.validate_inbox_authority(writer, responsible)?;
         }
         let local = match self.live_storage_entry(placement, now_ms).await? {

--- a/crates/core/src/dht/chord/tests/test_finger.rs
+++ b/crates/core/src/dht/chord/tests/test_finger.rs
@@ -9,7 +9,7 @@ use super::*;
 fn connect_and_hand_off(peer: Did, local: Did) -> PeerRingAction {
     PeerRingAction::MultiActions(vec![
         PeerRingAction::RemoteAction(peer, RemoteAction::FindSuccessorForConnect(local)),
-        PeerRingAction::RemoteAction(peer, RemoteAction::HandOffStorage),
+        PeerRingAction::StorageRepairDue,
     ])
 }
 

--- a/crates/core/src/dht/chord/tests/test_finger.rs
+++ b/crates/core/src/dht/chord/tests/test_finger.rs
@@ -4,6 +4,15 @@ use num_bigint::BigUint;
 
 use super::*;
 
+/// The actions of a join that makes `peer` the successor head: the connect lookup and, by the
+/// topology head law, the hand-off request toward the new head.
+fn connect_and_hand_off(peer: Did, local: Did) -> PeerRingAction {
+    PeerRingAction::MultiActions(vec![
+        PeerRingAction::RemoteAction(peer, RemoteAction::FindSuccessorForConnect(local)),
+        PeerRingAction::RemoteAction(peer, RemoteAction::HandOffStorage),
+    ])
+}
+
 #[tokio::test]
 async fn test_finger_table_tracks_clockwise_and_wrapped_joins() -> Result<()> {
     let a = Did::from_str("0x00E807fcc88dD319270493fB2e822e388Fe36ab0").unwrap();
@@ -23,10 +32,7 @@ async fn test_finger_table_tracks_clockwise_and_wrapped_joins() -> Result<()> {
     assert!(node_a.successors().is_empty()?);
     assert!(node_a.lock_finger()?.is_empty());
 
-    assert_eq!(
-        node_a.join(b)?,
-        PeerRingAction::RemoteAction(b, RemoteAction::FindSuccessorForConnect(a))
-    );
+    assert_eq!(node_a.join(b)?, connect_and_hand_off(b, a));
     assert!(BigUint::from(b) > BigUint::from(2u16).pow(156));
     assert!(BigUint::from(b) < BigUint::from(2u16).pow(157));
 
@@ -62,28 +68,19 @@ async fn test_finger_table_tracks_clockwise_and_wrapped_joins() -> Result<()> {
     );
 
     let node_a = PeerRing::new_with_storage(a, 3, Box::new(MemStorage::new()));
-    assert_eq!(
-        node_a.join(c)?,
-        PeerRingAction::RemoteAction(c, RemoteAction::FindSuccessorForConnect(a))
-    );
+    assert_eq!(node_a.join(c)?, connect_and_hand_off(c, a));
     let expected = std::iter::repeat_n(Some(c), 160).collect::<Vec<_>>();
     assert_eq!(node_a.lock_finger()?.list(), &expected);
     assert_eq!(node_a.successors().list()?, vec![c]);
 
-    assert_eq!(
-        node_a.join(b)?,
-        PeerRingAction::RemoteAction(b, RemoteAction::FindSuccessorForConnect(a))
-    );
+    assert_eq!(node_a.join(b)?, connect_and_hand_off(b, a));
     let mut expected = std::iter::repeat_n(Some(b), 157).collect::<Vec<_>>();
     expected.extend(std::iter::repeat_n(Some(c), 3));
     assert_eq!(node_a.lock_finger()?.list(), &expected);
     assert_eq!(node_a.successors().list()?, vec![b, c]);
 
     let node_d = PeerRing::new_with_storage(d, 1, Box::new(MemStorage::new()));
-    assert_eq!(
-        node_d.join(a)?,
-        PeerRingAction::RemoteAction(a, RemoteAction::FindSuccessorForConnect(d))
-    );
+    assert_eq!(node_d.join(a)?, connect_and_hand_off(a, d));
     assert!(d + Did::from(BigUint::from(2u16).pow(151)) < a);
     assert!(d + Did::from(BigUint::from(2u16).pow(152)) > a);
 

--- a/crates/core/src/dht/chord/tests/test_stabilization.rs
+++ b/crates/core/src/dht/chord/tests/test_stabilization.rs
@@ -68,10 +68,12 @@ async fn test_correct_chord_maintains_expected_successors() -> Result<()> {
         panic!("wrong action");
     };
     for action in actions {
-        let PeerRingAction::RemoteAction(target, _) = action else {
-            panic!("expected remote action");
-        };
-        assert_eq!(target, n1.did);
+        match action {
+            PeerRingAction::RemoteAction(target, _) => assert_eq!(target, n1.did),
+            // Admitting the first successor moves the head, which makes a repair round due.
+            PeerRingAction::StorageRepairDue => {}
+            action => panic!("expected a remote action or a repair request, got {action:?}"),
+        }
     }
     Ok(())
 }

--- a/crates/core/src/dht/entry.rs
+++ b/crates/core/src/dht/entry.rs
@@ -862,11 +862,13 @@ impl Entry {
     ///
     /// Pre: `self` and `other` are the same data or relay-message carrier.
     /// Post: every removed payload is represented by an add-dot tombstone, so
-    /// future joins with stale add replicas cannot resurrect it.
+    /// future joins with stale add replicas cannot resurrect it. The carrier keeps
+    /// its own retention bound: retention is refreshed by what is held, never by
+    /// a removal, so a drained carrier expires when its last hold would have.
     pub fn tombstone(&self, other: Self) -> Result<Self> {
         self.validate_same_carrier(&other)?;
 
-        let expires_at_ms = self.joined_lifetime(&other);
+        let expires_at_ms = self.expires_at_ms;
         let target_values = other.data.into_iter().collect::<BTreeSet<_>>();
         let target_dots = other.crdt.dots.into_iter().collect::<BTreeSet<_>>();
         let has_dot_witness = !target_dots.is_empty();

--- a/crates/core/src/dht/entry.rs
+++ b/crates/core/src/dht/entry.rs
@@ -14,10 +14,9 @@ use crate::error::Error;
 use crate::error::Result;
 use crate::message::Encoded;
 use crate::message::Encoder;
-use crate::message::MessagePayload;
-use crate::message::MessageVerificationExt;
 
 mod crdt;
+pub mod inbox;
 mod retention;
 
 pub use crdt::DataTopicBuffer;
@@ -69,7 +68,7 @@ struct OperationDigest<'a> {
 pub enum EntryOperation {
     /// Create or update an [`Entry`].
     Overwrite(Entry),
-    /// Extend data to a Data kind [`Entry`].
+    /// Add payloads to a data topic or a relay inbox.
     /// This operation will create an [`Entry`] if it does not exist.
     Extend(Entry),
     /// Extend data to a Data kind [`Entry`] uniquely.
@@ -384,17 +383,6 @@ impl EntryOperation {
     /// Generate a target Entry when it is not existed.
     pub fn gen_default_entry(self) -> Result<Entry> {
         Ok(Entry::new(self.did()?, vec![], self.kind()))
-    }
-}
-
-impl TryFrom<MessagePayload> for Entry {
-    type Error = Error;
-    fn try_from(msg: MessagePayload) -> Result<Self> {
-        // Relay entries target the signer's successor on R = Z / 2^160, so the
-        // `+ 1` intentionally wraps in the fixed-width DID ring.
-        let did = msg.signer() + Did::from(1u32);
-        let data = msg.encode()?;
-        Ok(Self::new(did, vec![data], EntryKind::RelayMessage))
     }
 }
 
@@ -791,12 +779,10 @@ impl Entry {
         )?)
     }
 
-    /// This method is used to extend data to a Data kind [`Entry`].
+    /// Add `other`'s payloads to this carrier: the element-set join for a data topic and for
+    /// a relay inbox alike, so holding a message for an offline peer is one ordinary write.
     /// The handler of [EntryOperation::Extend].
     pub fn extend(&self, now_ms: u128, other: Self, actor: Did) -> Result<Self> {
-        if !self.is_data_entry() {
-            return Err(Error::EntryNotAppendable);
-        }
         self.join(other.ensure_stamp_after(
             now_ms,
             actor,
@@ -859,20 +845,15 @@ impl Entry {
         }
     }
 
-    /// Compact a Data kind entry using the receiver's current visible payloads.
+    /// Compact a carrier using the receiver's current visible payloads.
     ///
-    /// Pre: `removals` names the same Data carrier as `self`.
+    /// Pre: `removals` names the same carrier as `self`.
     /// Post: every current visible payload not listed in `removals` is preserved
     /// under the greatest observed register floor, and older tombstone metadata
-    /// is pruned by that floor.
+    /// is pruned by that floor. For a relay inbox this is how the recipient
+    /// retires the messages it has delivered without leaving their tombstones
+    /// behind.
     pub fn compact_data(&self, now_ms: u128, removals: Self, actor: Did) -> Result<Self> {
-        match self.is_data_entry() {
-            true => self.compact_data_entry(now_ms, removals, actor),
-            false => Err(Error::EntryNotOverwritable),
-        }
-    }
-
-    fn compact_data_entry(&self, now_ms: u128, removals: Self, actor: Did) -> Result<Self> {
         let removals =
             removals.ensure_overwrite_stamp_after(now_ms, actor, self.max_observed_version())?;
         self.validate_same_carrier(&removals)?;
@@ -881,17 +862,26 @@ impl Entry {
             Error::InvalidMessage("compact data operation has no register floor".to_string())
         })?;
         let removal_values = removals.data.into_iter().collect::<BTreeSet<_>>();
-        let buffer = self.topic_buffer()?;
-        let output_floor = Self::compact_data_output_floor(self.crdt.register, floor);
+        let (register, values, removes) = match self.kind {
+            EntryKind::Data => {
+                let buffer = self.topic_buffer()?;
+                (buffer.register, buffer.values, buffer.removes)
+            }
+            EntryKind::RelayMessage => {
+                let set = self.relay_set()?;
+                (set.adds.register, set.adds.values, set.removes)
+            }
+        };
+        let output_floor = Self::compact_data_output_floor(register, floor);
         let elements = Self::compact_data_elements(
             floor,
             &removal_values,
-            Self::data_compaction_candidates(&self.data, buffer.values),
+            Self::data_compaction_candidates(&self.data, values),
         )?;
-        let tombstones = Self::compact_data_tombstones(output_floor, buffer.removes);
+        let tombstones = Self::compact_data_tombstones(output_floor, removes);
         Ok(Self::materialize_elements(
             self.did,
-            EntryKind::Data,
+            self.kind,
             Some(output_floor),
             elements,
             tombstones,
@@ -902,3 +892,5 @@ impl Entry {
 
 #[cfg(test)]
 mod test_entry;
+#[cfg(test)]
+mod test_inbox;

--- a/crates/core/src/dht/entry.rs
+++ b/crates/core/src/dht/entry.rs
@@ -7,9 +7,13 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::algebra::JoinSemilattice;
+use crate::consts::DEFAULT_RELAY_ENTRY_TTL_MS;
 use crate::consts::DEFAULT_TTL_MS;
+use crate::consts::ENTRY_DATA_MAX_BYTES;
 use crate::consts::ENTRY_DATA_MAX_LEN;
+use crate::consts::MAX_RELAY_ENTRY_TTL_MS;
 use crate::consts::MAX_TTL_MS;
+use crate::consts::RELAY_INBOX_MAX_BYTES;
 use crate::consts::TS_OFFSET_TOLERANCE_MS;
 use crate::dht::Did;
 use crate::ecc::HashStr;
@@ -37,6 +41,58 @@ pub enum EntryKind {
     /// A relayed but unreached message, which should be stored on
     /// the successor of the destination Did.
     RelayMessage,
+}
+
+impl EntryKind {
+    /// Retention stamped at the operation boundary when the origin left it absent.
+    ///
+    /// Relay entries are an offline destination's inbox and outlive data entries.
+    pub const fn default_lifetime_ms(self) -> u64 {
+        match self {
+            EntryKind::Data => DEFAULT_TTL_MS,
+            EntryKind::RelayMessage => DEFAULT_RELAY_ENTRY_TTL_MS,
+        }
+    }
+
+    /// The longest retention a receiver admits for this kind.
+    pub const fn max_lifetime_ms(self) -> u64 {
+        match self {
+            EntryKind::Data => MAX_TTL_MS,
+            EntryKind::RelayMessage => MAX_RELAY_ENTRY_TTL_MS,
+        }
+    }
+
+    /// Encoded bytes one carrier of this kind retains; the oldest payloads are dropped first.
+    pub const fn max_data_bytes(self) -> usize {
+        match self {
+            EntryKind::Data => ENTRY_DATA_MAX_BYTES,
+            EntryKind::RelayMessage => RELAY_INBOX_MAX_BYTES,
+        }
+    }
+}
+
+/// Index of the first element of `visible` (ordered oldest to newest) that is retained under
+/// the kind's count and byte budgets.
+///
+/// Law: the retained suffix is the longest suffix whose length is at most
+/// [`ENTRY_DATA_MAX_LEN`] and whose encoded bytes sum to at most
+/// [`EntryKind::max_data_bytes`]. Newer payloads are always preferred, so a payload that alone
+/// exceeds the byte budget is dropped rather than retained over the budget.
+fn retained_suffix_start(visible: &[(Encoded, EntryDot)], kind: EntryKind) -> usize {
+    let max_bytes = kind.max_data_bytes();
+    let mut retained_bytes = 0usize;
+    let mut retained = 0usize;
+    for (value, _) in visible.iter().rev().take(ENTRY_DATA_MAX_LEN) {
+        let Some(next_bytes) = retained_bytes.checked_add(value.value().len()) else {
+            break;
+        };
+        if next_bytes > max_bytes {
+            break;
+        }
+        retained_bytes = next_bytes;
+        retained += 1;
+    }
+    visible.len().saturating_sub(retained)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -141,8 +197,9 @@ fn placement_belongs_to_entry_key(entry_key: Did, placement: Did, redundancy: u1
 ///   thus while destination node going online, it will sync message from its successor.
 ///
 /// Retention: every entry accepted into storage carries a retention bound
-/// `expires_at_ms`, stamped by the origin at the operation boundary and bounded by the
-/// receiver at admission (see [`Entry::validate_admissible_at`]). The bound joins by `max`, so
+/// `expires_at_ms`, stamped by the origin at the operation boundary with the kind's
+/// [`EntryKind::default_lifetime_ms`] and bounded by the receiver at admission by the kind's
+/// [`EntryKind::max_lifetime_ms`] (see [`Entry::validate_admissible_at`]). The bound joins by `max`, so
 /// every accepted write extends the carrier's life to at least its own bound, and an entry whose
 /// bound has elapsed is dropped on the next read instead of being served or replicated.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -320,7 +377,7 @@ impl EntryOperation {
     /// [`Self::stamped`] at an explicit operation-boundary time.
     ///
     /// Post: every carried entry has `expires_at_ms = Some(_)`; an absent bound becomes
-    /// `now_ms + DEFAULT_TTL_MS`.
+    /// `now_ms + kind.default_lifetime_ms()`.
     pub(crate) fn stamped_at(self, now_ms: u128, actor: Did) -> Result<Self> {
         Ok(match self {
             EntryOperation::Overwrite(entry) => {
@@ -525,7 +582,8 @@ impl Entry {
     /// Stamp the retention bound when the origin left it absent.
     fn ensure_lifetime_from(mut self, now_ms: u128) -> Self {
         if self.expires_at_ms.is_none() {
-            self.expires_at_ms = Some(now_ms.saturating_add(u128::from(DEFAULT_TTL_MS)));
+            self.expires_at_ms =
+                Some(now_ms.saturating_add(u128::from(self.kind.default_lifetime_ms())));
         }
         self
     }
@@ -548,7 +606,7 @@ impl Entry {
     ///
     /// Pre: `now_ms` is the receiver's clock.
     /// Post: `Ok` implies the entry is live, its bound is at most
-    /// `now_ms + MAX_TTL_MS + TS_OFFSET_TOLERANCE_MS`, and every version it carries has a
+    /// `now_ms + kind.max_lifetime_ms() + TS_OFFSET_TOLERANCE_MS`, and every version it carries has a
     /// logical time at most `now_ms + TS_OFFSET_TOLERANCE_MS`. The version bound keeps a
     /// peer-supplied hybrid clock from pinning a key: an accepted floor can exceed the
     /// receiver's clock only by the message skew tolerance, so honest writers issued after
@@ -558,7 +616,7 @@ impl Entry {
             return Err(Error::EntryNotLive);
         };
         let lifetime_bound = now_ms
-            .saturating_add(u128::from(MAX_TTL_MS))
+            .saturating_add(u128::from(self.kind.max_lifetime_ms()))
             .saturating_add(TS_OFFSET_TOLERANCE_MS);
         if expires_at_ms > lifetime_bound {
             return Err(Error::EntryLifetimeExceedsMax);
@@ -635,7 +693,7 @@ impl Entry {
                 .cmp(right_dot)
                 .then_with(|| left_value.cmp(right_value))
         });
-        let skip_count = visible.len().saturating_sub(ENTRY_DATA_MAX_LEN);
+        let skip_count = retained_suffix_start(&visible, kind);
         let visible = visible.into_iter().skip(skip_count).collect::<Vec<_>>();
         let (data, dots): (Vec<_>, Vec<_>) = visible.into_iter().unzip();
 
@@ -803,7 +861,9 @@ impl Entry {
     ///
     /// Post: normalization uses the same carrier materialization as
     /// [`Self::join`]; there is no second cap strategy outside the CRDT.
-    /// Post: `result.data.len() <= ENTRY_DATA_MAX_LEN`.
+    /// Post: `result.data.len() <= ENTRY_DATA_MAX_LEN` and the encoded bytes of `result.data`
+    /// sum to at most `kind.max_data_bytes()`; when either budget binds, the oldest payloads
+    /// are the ones dropped.
     /// Post: `result.data.len() == result.crdt.dots.len()` for Data and
     /// RelayMessage entries.
     pub fn try_into_storage_entry(self) -> Result<Self> {

--- a/crates/core/src/dht/entry.rs
+++ b/crates/core/src/dht/entry.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 
 use crate::algebra::JoinSemilattice;
 use crate::consts::ENTRY_DATA_MAX_LEN;
+use crate::consts::RELAY_INBOX_MAX_LEN;
 use crate::dht::Did;
 use crate::ecc::HashStr;
 use crate::error::Error;
@@ -16,7 +17,7 @@ use crate::message::Encoded;
 use crate::message::Encoder;
 
 mod crdt;
-pub mod inbox;
+pub(crate) mod inbox;
 mod retention;
 
 pub use crdt::DataTopicBuffer;
@@ -30,9 +31,30 @@ pub use crdt::RelayMessageSet;
 pub enum EntryKind {
     /// Encoded data stored in DHT
     Data,
-    /// A relayed but unreached message, which should be stored on
-    /// the successor of the destination Did.
+    /// A relay inbox: messages held for an offline peer (see the `inbox` module).
     RelayMessage,
+}
+
+impl EntryKind {
+    /// The greatest number of visible elements a carrier of this kind keeps; when the cap binds,
+    /// the oldest elements are the ones dropped.
+    pub const fn max_data_len(self) -> usize {
+        match self {
+            EntryKind::Data => ENTRY_DATA_MAX_LEN,
+            EntryKind::RelayMessage => RELAY_INBOX_MAX_LEN,
+        }
+    }
+
+    /// The greatest number of tombstones a carrier of this kind keeps. A data topic keeps every
+    /// tombstone below its reset floor's pruning; a relay inbox has one owner and one
+    /// ack-gated relocation at a time, so a stale copy can only be transient and the newest
+    /// [`RELAY_INBOX_MAX_LEN`] removals suffice to shadow it.
+    pub const fn max_tombstones(self) -> Option<usize> {
+        match self {
+            EntryKind::Data => None,
+            EntryKind::RelayMessage => Some(RELAY_INBOX_MAX_LEN),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -323,7 +345,7 @@ impl EntryOperation {
     /// routing hop.
     ///
     /// Post: every carried entry has `expires_at_ms = Some(_)`; an absent bound becomes
-    /// `now_ms + DEFAULT_TTL_MS`.
+    /// `now_ms + kind.default_lifetime_ms()`.
     pub fn stamped(self, now_ms: u128, actor: Did) -> Result<Self> {
         let witness = self.witness();
         self.try_map_entry(|entry| {
@@ -561,9 +583,12 @@ impl Entry {
                 .cmp(right_dot)
                 .then_with(|| left_value.cmp(right_value))
         });
-        let skip_count = visible.len().saturating_sub(ENTRY_DATA_MAX_LEN);
+        let skip_count = visible.len().saturating_sub(kind.max_data_len());
         let visible = visible.into_iter().skip(skip_count).collect::<Vec<_>>();
         let (data, dots): (Vec<_>, Vec<_>) = visible.into_iter().unzip();
+        let tombstone_skip = kind
+            .max_tombstones()
+            .map_or(0, |cap| tombstones.len().saturating_sub(cap));
 
         Self {
             did,
@@ -572,7 +597,7 @@ impl Entry {
             crdt: EntryCrdt {
                 register,
                 dots,
-                tombstones: tombstones.into_iter().collect(),
+                tombstones: tombstones.into_iter().skip(tombstone_skip).collect(),
             },
             expires_at_ms,
         }
@@ -729,7 +754,7 @@ impl Entry {
     ///
     /// Post: normalization uses the same carrier materialization as
     /// [`Self::join`]; there is no second cap strategy outside the CRDT.
-    /// Post: `result.data.len() <= ENTRY_DATA_MAX_LEN`; when the cap binds, the oldest payloads
+    /// Post: `result.data.len() <= kind.max_data_len()`; when the cap binds, the oldest payloads
     /// are the ones dropped.
     /// Post: `result.data.len() == result.crdt.dots.len()` for Data and
     /// RelayMessage entries.
@@ -845,15 +870,17 @@ impl Entry {
         }
     }
 
-    /// Compact a carrier using the receiver's current visible payloads.
+    /// Compact a data topic using the receiver's current visible payloads.
     ///
-    /// Pre: `removals` names the same carrier as `self`.
+    /// Pre: `removals` names the same data topic as `self`; a relay inbox is never compacted
+    /// by a reset floor, its removals are per-dot tombstones issued by its recipient.
     /// Post: every current visible payload not listed in `removals` is preserved
     /// under the greatest observed register floor, and older tombstone metadata
-    /// is pruned by that floor. For a relay inbox this is how the recipient
-    /// retires the messages it has delivered without leaving their tombstones
-    /// behind.
+    /// is pruned by that floor.
     pub fn compact_data(&self, now_ms: u128, removals: Self, actor: Did) -> Result<Self> {
+        if !self.is_data_entry() {
+            return Err(Error::RelayInboxOperationNotAllowed);
+        }
         let removals =
             removals.ensure_overwrite_stamp_after(now_ms, actor, self.max_observed_version())?;
         self.validate_same_carrier(&removals)?;
@@ -862,16 +889,8 @@ impl Entry {
             Error::InvalidMessage("compact data operation has no register floor".to_string())
         })?;
         let removal_values = removals.data.into_iter().collect::<BTreeSet<_>>();
-        let (register, values, removes) = match self.kind {
-            EntryKind::Data => {
-                let buffer = self.topic_buffer()?;
-                (buffer.register, buffer.values, buffer.removes)
-            }
-            EntryKind::RelayMessage => {
-                let set = self.relay_set()?;
-                (set.adds.register, set.adds.values, set.removes)
-            }
-        };
+        let buffer = self.topic_buffer()?;
+        let (register, values, removes) = (buffer.register, buffer.values, buffer.removes);
         let output_floor = Self::compact_data_output_floor(register, floor);
         let elements = Self::compact_data_elements(
             floor,

--- a/crates/core/src/dht/entry.rs
+++ b/crates/core/src/dht/entry.rs
@@ -7,14 +7,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::algebra::JoinSemilattice;
-use crate::consts::DEFAULT_RELAY_ENTRY_TTL_MS;
-use crate::consts::DEFAULT_TTL_MS;
-use crate::consts::ENTRY_DATA_MAX_BYTES;
 use crate::consts::ENTRY_DATA_MAX_LEN;
-use crate::consts::MAX_RELAY_ENTRY_TTL_MS;
-use crate::consts::MAX_TTL_MS;
-use crate::consts::RELAY_INBOX_MAX_BYTES;
-use crate::consts::TS_OFFSET_TOLERANCE_MS;
 use crate::dht::Did;
 use crate::ecc::HashStr;
 use crate::error::Error;
@@ -23,9 +16,9 @@ use crate::message::Encoded;
 use crate::message::Encoder;
 use crate::message::MessagePayload;
 use crate::message::MessageVerificationExt;
-use crate::utils::get_epoch_ms;
 
 mod crdt;
+mod retention;
 
 pub use crdt::DataTopicBuffer;
 pub use crdt::EntryCrdt;
@@ -43,62 +36,21 @@ pub enum EntryKind {
     RelayMessage,
 }
 
-impl EntryKind {
-    /// Retention stamped at the operation boundary when the origin left it absent.
-    ///
-    /// Relay entries are an offline destination's inbox and outlive data entries.
-    pub const fn default_lifetime_ms(self) -> u64 {
-        match self {
-            EntryKind::Data => DEFAULT_TTL_MS,
-            EntryKind::RelayMessage => DEFAULT_RELAY_ENTRY_TTL_MS,
-        }
-    }
-
-    /// The longest retention a receiver admits for this kind.
-    pub const fn max_lifetime_ms(self) -> u64 {
-        match self {
-            EntryKind::Data => MAX_TTL_MS,
-            EntryKind::RelayMessage => MAX_RELAY_ENTRY_TTL_MS,
-        }
-    }
-
-    /// Encoded bytes one carrier of this kind retains; the oldest payloads are dropped first.
-    pub const fn max_data_bytes(self) -> usize {
-        match self {
-            EntryKind::Data => ENTRY_DATA_MAX_BYTES,
-            EntryKind::RelayMessage => RELAY_INBOX_MAX_BYTES,
-        }
-    }
-}
-
-/// Index of the first element of `visible` (ordered oldest to newest) that is retained under
-/// the kind's count and byte budgets.
-///
-/// Law: the retained suffix is the longest suffix whose length is at most
-/// [`ENTRY_DATA_MAX_LEN`] and whose encoded bytes sum to at most
-/// [`EntryKind::max_data_bytes`]. Newer payloads are always preferred, so a payload that alone
-/// exceeds the byte budget is dropped rather than retained over the budget.
-fn retained_suffix_start(visible: &[(Encoded, EntryDot)], kind: EntryKind) -> usize {
-    let max_bytes = kind.max_data_bytes();
-    let mut retained_bytes = 0usize;
-    let mut retained = 0usize;
-    for (value, _) in visible.iter().rev().take(ENTRY_DATA_MAX_LEN) {
-        let Some(next_bytes) = retained_bytes.checked_add(value.value().len()) else {
-            break;
-        };
-        if next_bytes > max_bytes {
-            break;
-        }
-        retained_bytes = next_bytes;
-        retained += 1;
-    }
-    visible.len().saturating_sub(retained)
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum EntryStampKind {
     Overwrite,
     Delta,
+}
+
+/// The write witness an [`EntryOperation`] must carry after stamping.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EntryWitness {
+    /// Per-element dots, plus a reset register for overwrites.
+    Elements(EntryStampKind),
+    /// A register floor only.
+    Register,
+    /// No witness: the operation names existing dots or values.
+    None,
 }
 
 // Canonical stamp input for EntryVersion.operation.
@@ -196,12 +148,12 @@ fn placement_belongs_to_entry_key(entry_key: Did, placement: Did, redundancy: u1
 ///   message plus 1 (to ensure that the message is sent to the successor of destination),
 ///   thus while destination node going online, it will sync message from its successor.
 ///
-/// Retention: every entry accepted into storage carries a retention bound
-/// `expires_at_ms`, stamped by the origin at the operation boundary with the kind's
-/// [`EntryKind::default_lifetime_ms`] and bounded by the receiver at admission by the kind's
-/// [`EntryKind::max_lifetime_ms`] (see [`Entry::validate_admissible_at`]). The bound joins by `max`, so
-/// every accepted write extends the carrier's life to at least its own bound, and an entry whose
-/// bound has elapsed is dropped on the next read instead of being served or replicated.
+/// Retention: every entry accepted into storage carries a retention bound `expires_at_ms`,
+/// stamped by the origin at the operation boundary and bounded by the receiver at admission
+/// (see the `retention` module and [`Entry::validate_admissible_at`]). The bound joins by
+/// `max`, so every accepted write extends the carrier's life to at least its own bound, and an
+/// entry whose bound has elapsed is dropped on the next read instead of being served or
+/// replicated.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Entry {
     /// The ring key of this entry. It has the same representation as a node DID, but a
@@ -365,76 +317,68 @@ impl Entry {
 
 impl EntryOperation {
     /// Return this operation with CRDT versions and the retention bound assigned at the
-    /// operation boundary, read from the local clock.
+    /// operation boundary `now_ms`.
     ///
     /// Existing CRDT witnesses and an existing retention bound are preserved so forwarded
     /// operations keep the origin's dot/version and lifetime instead of being reissued by every
     /// routing hop.
-    pub fn stamped(self, actor: Did) -> Result<Self> {
-        self.stamped_at(get_epoch_ms(), actor)
-    }
-
-    /// [`Self::stamped`] at an explicit operation-boundary time.
     ///
     /// Post: every carried entry has `expires_at_ms = Some(_)`; an absent bound becomes
-    /// `now_ms + kind.default_lifetime_ms()`.
-    pub(crate) fn stamped_at(self, now_ms: u128, actor: Did) -> Result<Self> {
+    /// `now_ms + DEFAULT_TTL_MS`.
+    pub fn stamped(self, now_ms: u128, actor: Did) -> Result<Self> {
+        let witness = self.witness();
+        self.try_map_entry(|entry| {
+            let entry = entry.ensure_lifetime_from(now_ms);
+            match witness {
+                EntryWitness::Elements(kind) => entry.ensure_stamp_after(now_ms, actor, None, kind),
+                EntryWitness::Register => entry.ensure_overwrite_stamp_after(now_ms, actor, None),
+                EntryWitness::None => Ok(entry),
+            }
+        })
+    }
+
+    /// The write witness each operation kind must carry.
+    const fn witness(&self) -> EntryWitness {
+        match self {
+            EntryOperation::Overwrite(_) => EntryWitness::Elements(EntryStampKind::Overwrite),
+            EntryOperation::Extend(_) | EntryOperation::Touch(_) => {
+                EntryWitness::Elements(EntryStampKind::Delta)
+            }
+            EntryOperation::Tombstone(_) => EntryWitness::None,
+            EntryOperation::CompactData(_) => EntryWitness::Register,
+        }
+    }
+
+    /// The entry this operation carries.
+    pub fn entry(&self) -> &Entry {
+        match self {
+            EntryOperation::Overwrite(entry)
+            | EntryOperation::Extend(entry)
+            | EntryOperation::Touch(entry)
+            | EntryOperation::Tombstone(entry)
+            | EntryOperation::CompactData(entry) => entry,
+        }
+    }
+
+    /// Apply `f` to the carried entry, keeping the operation kind.
+    fn try_map_entry(self, f: impl FnOnce(Entry) -> Result<Entry>) -> Result<Self> {
         Ok(match self {
-            EntryOperation::Overwrite(entry) => {
-                EntryOperation::Overwrite(entry.ensure_lifetime_from(now_ms).ensure_stamp_after(
-                    now_ms,
-                    actor,
-                    None,
-                    EntryStampKind::Overwrite,
-                )?)
-            }
-            EntryOperation::Extend(entry) => {
-                EntryOperation::Extend(entry.ensure_lifetime_from(now_ms).ensure_stamp_after(
-                    now_ms,
-                    actor,
-                    None,
-                    EntryStampKind::Delta,
-                )?)
-            }
-            EntryOperation::Touch(entry) => {
-                EntryOperation::Touch(entry.ensure_lifetime_from(now_ms).ensure_stamp_after(
-                    now_ms,
-                    actor,
-                    None,
-                    EntryStampKind::Delta,
-                )?)
-            }
-            EntryOperation::Tombstone(entry) => {
-                EntryOperation::Tombstone(entry.ensure_lifetime_from(now_ms))
-            }
-            EntryOperation::CompactData(entry) => EntryOperation::CompactData(
-                entry
-                    .ensure_lifetime_from(now_ms)
-                    .ensure_overwrite_stamp_after(now_ms, actor, None)?,
-            ),
+            EntryOperation::Overwrite(entry) => EntryOperation::Overwrite(f(entry)?),
+            EntryOperation::Extend(entry) => EntryOperation::Extend(f(entry)?),
+            EntryOperation::Touch(entry) => EntryOperation::Touch(f(entry)?),
+            EntryOperation::Tombstone(entry) => EntryOperation::Tombstone(f(entry)?),
+            EntryOperation::CompactData(entry) => EntryOperation::CompactData(f(entry)?),
         })
     }
 
     /// Extract the did of target Entry.
     pub fn did(&self) -> Result<Did> {
-        Ok(match self {
-            EntryOperation::Overwrite(entry) => entry.did,
-            EntryOperation::Extend(entry) => entry.did,
-            EntryOperation::Touch(entry) => entry.did,
-            EntryOperation::Tombstone(entry) => entry.did,
-            EntryOperation::CompactData(entry) => entry.did,
-        })
+        Ok(self.entry().did)
     }
 
     /// Extract the kind of target Entry.
     pub fn kind(&self) -> EntryKind {
-        match self {
-            EntryOperation::Overwrite(entry) => entry.kind,
-            EntryOperation::Extend(entry) => entry.kind,
-            EntryOperation::Touch(entry) => entry.kind,
-            EntryOperation::Tombstone(entry) => entry.kind,
-            EntryOperation::CompactData(entry) => entry.kind,
-        }
+        self.entry().kind
     }
 
     /// Generate a target Entry when it is not existed.
@@ -450,26 +394,14 @@ impl TryFrom<MessagePayload> for Entry {
         // `+ 1` intentionally wraps in the fixed-width DID ring.
         let did = msg.signer() + Did::from(1u32);
         let data = msg.encode()?;
-        Ok(Self {
-            did,
-            data: vec![data],
-            kind: EntryKind::RelayMessage,
-            crdt: EntryCrdt::default(),
-            expires_at_ms: None,
-        })
+        Ok(Self::new(did, vec![data], EntryKind::RelayMessage))
     }
 }
 
 impl TryFrom<(String, Encoded)> for Entry {
     type Error = Error;
     fn try_from((topic, e): (String, Encoded)) -> Result<Self> {
-        Ok(Self {
-            did: Self::gen_did(&topic)?,
-            data: vec![e],
-            kind: EntryKind::Data,
-            crdt: EntryCrdt::default(),
-            expires_at_ms: None,
-        })
+        Ok(Self::new(Self::gen_did(&topic)?, vec![e], EntryKind::Data))
     }
 }
 
@@ -579,58 +511,6 @@ impl Entry {
         self.versions().max()
     }
 
-    /// Stamp the retention bound when the origin left it absent.
-    fn ensure_lifetime_from(mut self, now_ms: u128) -> Self {
-        if self.expires_at_ms.is_none() {
-            self.expires_at_ms =
-                Some(now_ms.saturating_add(u128::from(self.kind.default_lifetime_ms())));
-        }
-        self
-    }
-
-    /// The retention bound of a join: the later of the two bounds.
-    fn joined_lifetime(&self, other: &Self) -> Option<u128> {
-        self.expires_at_ms.max(other.expires_at_ms)
-    }
-
-    /// Whether this entry may still be served or replicated at `now_ms`.
-    ///
-    /// Post: `false` for an unstamped entry, so a legacy stored value without a bound is
-    /// retired on its next read.
-    pub fn is_live_at(&self, now_ms: u128) -> bool {
-        self.expires_at_ms
-            .is_some_and(|expires_at_ms| now_ms < expires_at_ms)
-    }
-
-    /// Admission law for an entry supplied by a peer or read back from storage.
-    ///
-    /// Pre: `now_ms` is the receiver's clock.
-    /// Post: `Ok` implies the entry is live, its bound is at most
-    /// `now_ms + kind.max_lifetime_ms() + TS_OFFSET_TOLERANCE_MS`, and every version it carries has a
-    /// logical time at most `now_ms + TS_OFFSET_TOLERANCE_MS`. The version bound keeps a
-    /// peer-supplied hybrid clock from pinning a key: an accepted floor can exceed the
-    /// receiver's clock only by the message skew tolerance, so honest writers issued after
-    /// that tolerance elapses dominate it again.
-    pub fn validate_admissible_at(&self, now_ms: u128) -> Result<()> {
-        let Some(expires_at_ms) = self.expires_at_ms.filter(|&bound| now_ms < bound) else {
-            return Err(Error::EntryNotLive);
-        };
-        let lifetime_bound = now_ms
-            .saturating_add(u128::from(self.kind.max_lifetime_ms()))
-            .saturating_add(TS_OFFSET_TOLERANCE_MS);
-        if expires_at_ms > lifetime_bound {
-            return Err(Error::EntryLifetimeExceedsMax);
-        }
-        let clock_bound = now_ms.saturating_add(TS_OFFSET_TOLERANCE_MS);
-        if self
-            .versions()
-            .any(|version| version.logical_time_ms > clock_bound)
-        {
-            return Err(Error::EntryVersionAheadOfClock);
-        }
-        Ok(())
-    }
-
     fn validate_same_carrier(&self, other: &Self) -> Result<()> {
         if !self.same_kind_as(other) {
             return Err(Error::EntryKindNotEqual);
@@ -693,7 +573,7 @@ impl Entry {
                 .cmp(right_dot)
                 .then_with(|| left_value.cmp(right_value))
         });
-        let skip_count = retained_suffix_start(&visible, kind);
+        let skip_count = visible.len().saturating_sub(ENTRY_DATA_MAX_LEN);
         let visible = visible.into_iter().skip(skip_count).collect::<Vec<_>>();
         let (data, dots): (Vec<_>, Vec<_>) = visible.into_iter().unzip();
 
@@ -861,8 +741,7 @@ impl Entry {
     ///
     /// Post: normalization uses the same carrier materialization as
     /// [`Self::join`]; there is no second cap strategy outside the CRDT.
-    /// Post: `result.data.len() <= ENTRY_DATA_MAX_LEN` and the encoded bytes of `result.data`
-    /// sum to at most `kind.max_data_bytes()`; when either budget binds, the oldest payloads
+    /// Post: `result.data.len() <= ENTRY_DATA_MAX_LEN`; when the cap binds, the oldest payloads
     /// are the ones dropped.
     /// Post: `result.data.len() == result.crdt.dots.len()` for Data and
     /// RelayMessage entries.
@@ -879,20 +758,16 @@ impl Entry {
         }
     }
 
-    /// The entry point of [EntryOperation], stamping any unstamped witness from the local
-    /// clock. Will dispatch to different operation handlers according to the variant.
-    pub fn operate(&self, op: EntryOperation, actor: Did) -> Result<Self> {
-        self.operate_at(get_epoch_ms(), op, actor)
-    }
-
-    /// [`Self::operate`] at an explicit operation-boundary time.
-    pub(crate) fn operate_at(&self, now_ms: u128, op: EntryOperation, actor: Did) -> Result<Self> {
+    /// The entry point of [EntryOperation] at the operation-boundary time `now_ms`, which
+    /// stamps any unstamped witness. Will dispatch to different operation handlers according to
+    /// the variant.
+    pub fn operate(&self, now_ms: u128, op: EntryOperation, actor: Did) -> Result<Self> {
         match op {
-            EntryOperation::Overwrite(entry) => self.overwrite_at(now_ms, entry, actor),
-            EntryOperation::Extend(entry) => self.extend_at(now_ms, entry, actor),
-            EntryOperation::Touch(entry) => self.touch_at(now_ms, entry, actor),
+            EntryOperation::Overwrite(entry) => self.overwrite(now_ms, entry, actor),
+            EntryOperation::Extend(entry) => self.extend(now_ms, entry, actor),
+            EntryOperation::Touch(entry) => self.touch(now_ms, entry, actor),
             EntryOperation::Tombstone(entry) => self.tombstone(entry),
-            EntryOperation::CompactData(entry) => self.compact_data_at(now_ms, entry, actor),
+            EntryOperation::CompactData(entry) => self.compact_data(now_ms, entry, actor),
         }
     }
 
@@ -904,11 +779,7 @@ impl Entry {
     /// non-monotone assignment.
     ///
     /// The handler of [EntryOperation::Overwrite].
-    pub fn overwrite(&self, other: Self, actor: Did) -> Result<Self> {
-        self.overwrite_at(get_epoch_ms(), other, actor)
-    }
-
-    fn overwrite_at(&self, now_ms: u128, other: Self, actor: Did) -> Result<Self> {
+    pub fn overwrite(&self, now_ms: u128, other: Self, actor: Did) -> Result<Self> {
         if !self.is_data_entry() {
             return Err(Error::EntryNotOverwritable);
         }
@@ -922,11 +793,7 @@ impl Entry {
 
     /// This method is used to extend data to a Data kind [`Entry`].
     /// The handler of [EntryOperation::Extend].
-    pub fn extend(&self, other: Self, actor: Did) -> Result<Self> {
-        self.extend_at(get_epoch_ms(), other, actor)
-    }
-
-    fn extend_at(&self, now_ms: u128, other: Self, actor: Did) -> Result<Self> {
+    pub fn extend(&self, now_ms: u128, other: Self, actor: Did) -> Result<Self> {
         if !self.is_data_entry() {
             return Err(Error::EntryNotAppendable);
         }
@@ -941,11 +808,7 @@ impl Entry {
     /// This method is used to extend data to a Data kind [`Entry`] uniquely.
     /// If any element is already existed, move it to the end of the data vector.
     /// The handler of [EntryOperation::Touch].
-    pub fn touch(&self, other: Self, actor: Did) -> Result<Self> {
-        self.touch_at(get_epoch_ms(), other, actor)
-    }
-
-    fn touch_at(&self, now_ms: u128, other: Self, actor: Did) -> Result<Self> {
+    pub fn touch(&self, now_ms: u128, other: Self, actor: Did) -> Result<Self> {
         if !self.is_data_entry() {
             return Err(Error::EntryNotAppendable);
         }
@@ -1002,11 +865,7 @@ impl Entry {
     /// Post: every current visible payload not listed in `removals` is preserved
     /// under the greatest observed register floor, and older tombstone metadata
     /// is pruned by that floor.
-    pub fn compact_data(&self, removals: Self, actor: Did) -> Result<Self> {
-        self.compact_data_at(get_epoch_ms(), removals, actor)
-    }
-
-    fn compact_data_at(&self, now_ms: u128, removals: Self, actor: Did) -> Result<Self> {
+    pub fn compact_data(&self, now_ms: u128, removals: Self, actor: Did) -> Result<Self> {
         match self.is_data_entry() {
             true => self.compact_data_entry(now_ms, removals, actor),
             false => Err(Error::EntryNotOverwritable),

--- a/crates/core/src/dht/entry.rs
+++ b/crates/core/src/dht/entry.rs
@@ -7,7 +7,10 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::algebra::JoinSemilattice;
+use crate::consts::DEFAULT_TTL_MS;
 use crate::consts::ENTRY_DATA_MAX_LEN;
+use crate::consts::MAX_TTL_MS;
+use crate::consts::TS_OFFSET_TOLERANCE_MS;
 use crate::dht::Did;
 use crate::ecc::HashStr;
 use crate::error::Error;
@@ -16,6 +19,7 @@ use crate::message::Encoded;
 use crate::message::Encoder;
 use crate::message::MessagePayload;
 use crate::message::MessageVerificationExt;
+use crate::utils::get_epoch_ms;
 
 mod crdt;
 
@@ -135,6 +139,12 @@ fn placement_belongs_to_entry_key(entry_key: Did, placement: Did, redundancy: u1
 /// * If kind value is [EntryKind::RelayMessage], it's the destination Did of
 ///   message plus 1 (to ensure that the message is sent to the successor of destination),
 ///   thus while destination node going online, it will sync message from its successor.
+///
+/// Retention: every entry accepted into storage carries a retention bound
+/// `expires_at_ms`, stamped by the origin at the operation boundary and bounded by the
+/// receiver at admission (see [`Entry::validate_admissible_at`]). The bound joins by `max`, so
+/// every accepted write extends the carrier's life to at least its own bound, and an entry whose
+/// bound has elapsed is dropped on the next read instead of being served or replicated.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Entry {
     /// The ring key of this entry. It has the same representation as a node DID, but a
@@ -147,6 +157,10 @@ pub struct Entry {
     /// CRDT metadata that makes replicated merge a join-semilattice operation.
     #[serde(default)]
     pub crdt: EntryCrdt,
+    /// Retention bound in milliseconds since the Unix epoch. `None` only before the operation
+    /// boundary stamps it; a stored value without a bound is treated as not live.
+    #[serde(default)]
+    pub expires_at_ms: Option<u128>,
 }
 
 /// An [`Entry`] paired with its Chord placement key.
@@ -279,6 +293,7 @@ impl Entry {
             data,
             kind,
             crdt: EntryCrdt::default(),
+            expires_at_ms: None,
         }
     }
 
@@ -292,29 +307,54 @@ impl Entry {
 }
 
 impl EntryOperation {
-    /// Return this operation with CRDT versions assigned at the operation boundary.
+    /// Return this operation with CRDT versions and the retention bound assigned at the
+    /// operation boundary, read from the local clock.
     ///
-    /// Existing CRDT witnesses are preserved so forwarded operations keep the
-    /// origin's dot/version instead of being reissued by every routing hop.
+    /// Existing CRDT witnesses and an existing retention bound are preserved so forwarded
+    /// operations keep the origin's dot/version and lifetime instead of being reissued by every
+    /// routing hop.
     pub fn stamped(self, actor: Did) -> Result<Self> {
+        self.stamped_at(get_epoch_ms(), actor)
+    }
+
+    /// [`Self::stamped`] at an explicit operation-boundary time.
+    ///
+    /// Post: every carried entry has `expires_at_ms = Some(_)`; an absent bound becomes
+    /// `now_ms + DEFAULT_TTL_MS`.
+    pub(crate) fn stamped_at(self, now_ms: u128, actor: Did) -> Result<Self> {
         Ok(match self {
-            EntryOperation::Overwrite(entry) => EntryOperation::Overwrite(
-                entry.ensure_stamp_after(actor, None, EntryStampKind::Overwrite)?,
-            ),
-            EntryOperation::Extend(entry) => EntryOperation::Extend(entry.ensure_stamp_after(
-                actor,
-                None,
-                EntryStampKind::Delta,
-            )?),
-            EntryOperation::Touch(entry) => EntryOperation::Touch(entry.ensure_stamp_after(
-                actor,
-                None,
-                EntryStampKind::Delta,
-            )?),
-            EntryOperation::Tombstone(entry) => EntryOperation::Tombstone(entry),
-            EntryOperation::CompactData(entry) => {
-                EntryOperation::CompactData(entry.ensure_overwrite_stamp_after(actor, None)?)
+            EntryOperation::Overwrite(entry) => {
+                EntryOperation::Overwrite(entry.ensure_lifetime_from(now_ms).ensure_stamp_after(
+                    now_ms,
+                    actor,
+                    None,
+                    EntryStampKind::Overwrite,
+                )?)
             }
+            EntryOperation::Extend(entry) => {
+                EntryOperation::Extend(entry.ensure_lifetime_from(now_ms).ensure_stamp_after(
+                    now_ms,
+                    actor,
+                    None,
+                    EntryStampKind::Delta,
+                )?)
+            }
+            EntryOperation::Touch(entry) => {
+                EntryOperation::Touch(entry.ensure_lifetime_from(now_ms).ensure_stamp_after(
+                    now_ms,
+                    actor,
+                    None,
+                    EntryStampKind::Delta,
+                )?)
+            }
+            EntryOperation::Tombstone(entry) => {
+                EntryOperation::Tombstone(entry.ensure_lifetime_from(now_ms))
+            }
+            EntryOperation::CompactData(entry) => EntryOperation::CompactData(
+                entry
+                    .ensure_lifetime_from(now_ms)
+                    .ensure_overwrite_stamp_after(now_ms, actor, None)?,
+            ),
         })
     }
 
@@ -358,6 +398,7 @@ impl TryFrom<MessagePayload> for Entry {
             data: vec![data],
             kind: EntryKind::RelayMessage,
             crdt: EntryCrdt::default(),
+            expires_at_ms: None,
         })
     }
 }
@@ -370,6 +411,7 @@ impl TryFrom<(String, Encoded)> for Entry {
             data: vec![e],
             kind: EntryKind::Data,
             crdt: EntryCrdt::default(),
+            expires_at_ms: None,
         })
     }
 }
@@ -426,12 +468,18 @@ impl Entry {
         Did::try_from(HashStr::from_bytes(&bytes))
     }
 
-    fn issue_version_after(&self, actor: Did, floor: Option<EntryVersion>) -> Result<EntryVersion> {
-        Ok(EntryVersion::issued_by(actor, self.operation_digest()?).after(floor))
+    fn issue_version_after(
+        &self,
+        now_ms: u128,
+        actor: Did,
+        floor: Option<EntryVersion>,
+    ) -> Result<EntryVersion> {
+        Ok(EntryVersion::new(now_ms, actor, self.operation_digest()?).after(floor))
     }
 
     fn ensure_stamp_after(
         self,
+        now_ms: u128,
         actor: Did,
         floor: Option<EntryVersion>,
         kind: EntryStampKind,
@@ -439,30 +487,90 @@ impl Entry {
         match self.crdt.has_write_witness() {
             true => Ok(self),
             false => {
-                let version = self.issue_version_after(actor, floor)?;
+                let version = self.issue_version_after(now_ms, actor, floor)?;
                 self.stamp(version, kind)
             }
         }
     }
 
-    fn ensure_overwrite_stamp_after(self, actor: Did, floor: Option<EntryVersion>) -> Result<Self> {
+    fn ensure_overwrite_stamp_after(
+        self,
+        now_ms: u128,
+        actor: Did,
+        floor: Option<EntryVersion>,
+    ) -> Result<Self> {
         match self.crdt.register.is_some() {
             true => Ok(self),
             false => {
-                let version = self.issue_version_after(actor, floor)?;
+                let version = self.issue_version_after(now_ms, actor, floor)?;
                 self.stamp_overwrite(version)
             }
         }
     }
 
-    fn max_observed_version(&self) -> Option<EntryVersion> {
+    /// Every version this entry carries: element dots, tombstones, and the reset floor.
+    fn versions(&self) -> impl Iterator<Item = EntryVersion> + '_ {
         self.crdt
             .dots
             .iter()
             .map(|dot| dot.version)
             .chain(self.crdt.tombstones.iter().map(|dot| dot.version))
             .chain(self.crdt.register)
-            .max()
+    }
+
+    fn max_observed_version(&self) -> Option<EntryVersion> {
+        self.versions().max()
+    }
+
+    /// Stamp the retention bound when the origin left it absent.
+    fn ensure_lifetime_from(mut self, now_ms: u128) -> Self {
+        if self.expires_at_ms.is_none() {
+            self.expires_at_ms = Some(now_ms.saturating_add(u128::from(DEFAULT_TTL_MS)));
+        }
+        self
+    }
+
+    /// The retention bound of a join: the later of the two bounds.
+    fn joined_lifetime(&self, other: &Self) -> Option<u128> {
+        self.expires_at_ms.max(other.expires_at_ms)
+    }
+
+    /// Whether this entry may still be served or replicated at `now_ms`.
+    ///
+    /// Post: `false` for an unstamped entry, so a legacy stored value without a bound is
+    /// retired on its next read.
+    pub fn is_live_at(&self, now_ms: u128) -> bool {
+        self.expires_at_ms
+            .is_some_and(|expires_at_ms| now_ms < expires_at_ms)
+    }
+
+    /// Admission law for an entry supplied by a peer or read back from storage.
+    ///
+    /// Pre: `now_ms` is the receiver's clock.
+    /// Post: `Ok` implies the entry is live, its bound is at most
+    /// `now_ms + MAX_TTL_MS + TS_OFFSET_TOLERANCE_MS`, and every version it carries has a
+    /// logical time at most `now_ms + TS_OFFSET_TOLERANCE_MS`. The version bound keeps a
+    /// peer-supplied hybrid clock from pinning a key: an accepted floor can exceed the
+    /// receiver's clock only by the message skew tolerance, so honest writers issued after
+    /// that tolerance elapses dominate it again.
+    pub fn validate_admissible_at(&self, now_ms: u128) -> Result<()> {
+        let Some(expires_at_ms) = self.expires_at_ms.filter(|&bound| now_ms < bound) else {
+            return Err(Error::EntryNotLive);
+        };
+        let lifetime_bound = now_ms
+            .saturating_add(u128::from(MAX_TTL_MS))
+            .saturating_add(TS_OFFSET_TOLERANCE_MS);
+        if expires_at_ms > lifetime_bound {
+            return Err(Error::EntryLifetimeExceedsMax);
+        }
+        let clock_bound = now_ms.saturating_add(TS_OFFSET_TOLERANCE_MS);
+        if self
+            .versions()
+            .any(|version| version.logical_time_ms > clock_bound)
+        {
+            return Err(Error::EntryVersionAheadOfClock);
+        }
+        Ok(())
     }
 
     fn validate_same_carrier(&self, other: &Self) -> Result<()> {
@@ -513,6 +621,7 @@ impl Entry {
         register: Option<EntryVersion>,
         elements: impl IntoIterator<Item = (Encoded, EntryDot)>,
         tombstones: BTreeSet<EntryDot>,
+        expires_at_ms: Option<u128>,
     ) -> Self {
         let mut visible = elements
             .into_iter()
@@ -539,26 +648,33 @@ impl Entry {
                 dots,
                 tombstones: tombstones.into_iter().collect(),
             },
+            expires_at_ms,
         }
     }
 
-    fn materialize_topic_buffer(&self, buffer: DataTopicBuffer) -> Self {
+    fn materialize_topic_buffer(
+        &self,
+        buffer: DataTopicBuffer,
+        expires_at_ms: Option<u128>,
+    ) -> Self {
         Self::materialize_elements(
             self.did,
             self.kind,
             buffer.register,
             buffer.values,
             buffer.removes,
+            expires_at_ms,
         )
     }
 
-    fn materialize_relay_set(&self, set: RelayMessageSet) -> Self {
+    fn materialize_relay_set(&self, set: RelayMessageSet, expires_at_ms: Option<u128>) -> Self {
         Self::materialize_elements(
             self.did,
             self.kind,
             set.adds.register,
             set.adds.values,
             set.removes,
+            expires_at_ms,
         )
     }
 
@@ -639,16 +755,18 @@ impl Entry {
     /// Law: for a fixed `(did, kind)` carrier, this is the state-based CRDT
     /// join. Data entries are bounded LWW element sets with an LWW overwrite
     /// register; relay entries are two-phase sets whose remove side is carried
-    /// by tombstones.
+    /// by tombstones. The retention bound joins by `max`, so the product of the
+    /// payload lattice and the bound lattice is again a join-semilattice.
     pub fn join(&self, other: Self) -> Result<Self> {
         self.validate_same_carrier(&other)?;
+        let expires_at_ms = self.joined_lifetime(&other);
         match self.kind {
-            EntryKind::Data => {
-                Ok(self.materialize_topic_buffer(self.topic_buffer()?.join(other.topic_buffer()?)))
-            }
-            EntryKind::RelayMessage => {
-                Ok(self.materialize_relay_set(self.relay_set()?.join(other.relay_set()?)))
-            }
+            EntryKind::Data => Ok(self.materialize_topic_buffer(
+                self.topic_buffer()?.join(other.topic_buffer()?),
+                expires_at_ms,
+            )),
+            EntryKind::RelayMessage => Ok(self
+                .materialize_relay_set(self.relay_set()?.join(other.relay_set()?), expires_at_ms)),
         }
     }
 
@@ -692,24 +810,29 @@ impl Entry {
         match self.kind {
             EntryKind::Data => {
                 let buffer = self.topic_buffer()?;
-                Ok(self.materialize_topic_buffer(buffer))
+                Ok(self.materialize_topic_buffer(buffer, self.expires_at_ms))
             }
             EntryKind::RelayMessage => {
                 let set = self.relay_set()?;
-                Ok(self.materialize_relay_set(set))
+                Ok(self.materialize_relay_set(set, self.expires_at_ms))
             }
         }
     }
 
-    /// The entry point of [EntryOperation].
-    /// Will dispatch to different operation handlers according to the variant.
+    /// The entry point of [EntryOperation], stamping any unstamped witness from the local
+    /// clock. Will dispatch to different operation handlers according to the variant.
     pub fn operate(&self, op: EntryOperation, actor: Did) -> Result<Self> {
+        self.operate_at(get_epoch_ms(), op, actor)
+    }
+
+    /// [`Self::operate`] at an explicit operation-boundary time.
+    pub(crate) fn operate_at(&self, now_ms: u128, op: EntryOperation, actor: Did) -> Result<Self> {
         match op {
-            EntryOperation::Overwrite(entry) => self.overwrite(entry, actor),
-            EntryOperation::Extend(entry) => self.extend(entry, actor),
-            EntryOperation::Touch(entry) => self.touch(entry, actor),
+            EntryOperation::Overwrite(entry) => self.overwrite_at(now_ms, entry, actor),
+            EntryOperation::Extend(entry) => self.extend_at(now_ms, entry, actor),
+            EntryOperation::Touch(entry) => self.touch_at(now_ms, entry, actor),
             EntryOperation::Tombstone(entry) => self.tombstone(entry),
-            EntryOperation::CompactData(entry) => self.compact_data(entry, actor),
+            EntryOperation::CompactData(entry) => self.compact_data_at(now_ms, entry, actor),
         }
     }
 
@@ -722,10 +845,15 @@ impl Entry {
     ///
     /// The handler of [EntryOperation::Overwrite].
     pub fn overwrite(&self, other: Self, actor: Did) -> Result<Self> {
+        self.overwrite_at(get_epoch_ms(), other, actor)
+    }
+
+    fn overwrite_at(&self, now_ms: u128, other: Self, actor: Did) -> Result<Self> {
         if !self.is_data_entry() {
             return Err(Error::EntryNotOverwritable);
         }
         self.join(other.ensure_stamp_after(
+            now_ms,
             actor,
             self.max_observed_version(),
             EntryStampKind::Overwrite,
@@ -735,10 +863,15 @@ impl Entry {
     /// This method is used to extend data to a Data kind [`Entry`].
     /// The handler of [EntryOperation::Extend].
     pub fn extend(&self, other: Self, actor: Did) -> Result<Self> {
+        self.extend_at(get_epoch_ms(), other, actor)
+    }
+
+    fn extend_at(&self, now_ms: u128, other: Self, actor: Did) -> Result<Self> {
         if !self.is_data_entry() {
             return Err(Error::EntryNotAppendable);
         }
         self.join(other.ensure_stamp_after(
+            now_ms,
             actor,
             self.max_observed_version(),
             EntryStampKind::Delta,
@@ -749,10 +882,15 @@ impl Entry {
     /// If any element is already existed, move it to the end of the data vector.
     /// The handler of [EntryOperation::Touch].
     pub fn touch(&self, other: Self, actor: Did) -> Result<Self> {
+        self.touch_at(get_epoch_ms(), other, actor)
+    }
+
+    fn touch_at(&self, now_ms: u128, other: Self, actor: Did) -> Result<Self> {
         if !self.is_data_entry() {
             return Err(Error::EntryNotAppendable);
         }
         self.join(other.ensure_stamp_after(
+            now_ms,
             actor,
             self.max_observed_version(),
             EntryStampKind::Delta,
@@ -767,6 +905,7 @@ impl Entry {
     pub fn tombstone(&self, other: Self) -> Result<Self> {
         self.validate_same_carrier(&other)?;
 
+        let expires_at_ms = self.joined_lifetime(&other);
         let target_values = other.data.into_iter().collect::<BTreeSet<_>>();
         let target_dots = other.crdt.dots.into_iter().collect::<BTreeSet<_>>();
         let has_dot_witness = !target_dots.is_empty();
@@ -781,7 +920,7 @@ impl Entry {
                         buffer.removes.insert(*dot);
                     }
                 }
-                Ok(self.materialize_topic_buffer(buffer))
+                Ok(self.materialize_topic_buffer(buffer, expires_at_ms))
             }
             EntryKind::RelayMessage => {
                 let mut set = self.relay_set()?;
@@ -792,7 +931,7 @@ impl Entry {
                         set.removes.insert(*dot);
                     }
                 }
-                Ok(self.materialize_relay_set(set))
+                Ok(self.materialize_relay_set(set, expires_at_ms))
             }
         }
     }
@@ -804,15 +943,21 @@ impl Entry {
     /// under the greatest observed register floor, and older tombstone metadata
     /// is pruned by that floor.
     pub fn compact_data(&self, removals: Self, actor: Did) -> Result<Self> {
+        self.compact_data_at(get_epoch_ms(), removals, actor)
+    }
+
+    fn compact_data_at(&self, now_ms: u128, removals: Self, actor: Did) -> Result<Self> {
         match self.is_data_entry() {
-            true => self.compact_data_entry(removals, actor),
+            true => self.compact_data_entry(now_ms, removals, actor),
             false => Err(Error::EntryNotOverwritable),
         }
     }
 
-    fn compact_data_entry(&self, removals: Self, actor: Did) -> Result<Self> {
-        let removals = removals.ensure_overwrite_stamp_after(actor, self.max_observed_version())?;
+    fn compact_data_entry(&self, now_ms: u128, removals: Self, actor: Did) -> Result<Self> {
+        let removals =
+            removals.ensure_overwrite_stamp_after(now_ms, actor, self.max_observed_version())?;
         self.validate_same_carrier(&removals)?;
+        let expires_at_ms = self.joined_lifetime(&removals);
         let floor = removals.crdt.register.ok_or_else(|| {
             Error::InvalidMessage("compact data operation has no register floor".to_string())
         })?;
@@ -831,6 +976,7 @@ impl Entry {
             Some(output_floor),
             elements,
             tombstones,
+            expires_at_ms,
         ))
     }
 }

--- a/crates/core/src/dht/entry.rs
+++ b/crates/core/src/dht/entry.rs
@@ -131,8 +131,9 @@ pub enum EntryOperation {
 /// A storage operation targeted at one concrete affine placement key.
 ///
 /// Invariant: `placement` must be one of the affine replica keys derived from
-/// the operation's entry DID under the receiver's configured storage
-/// redundancy. The sender may choose a replica from that set, but cannot choose
+/// the operation's entry DID under the replication its kind gets from the
+/// receiver's configured storage redundancy (a relay inbox has one placement,
+/// its DID). The sender may choose a replica from that set, but cannot choose
 /// where the replica set itself lives.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PlacedEntryOperation {
@@ -151,7 +152,7 @@ impl PlacedEntryOperation {
     /// Return whether `placement` is in this entry's affine replica set.
     pub fn placement_belongs_to_entry(&self, redundancy: u16) -> Result<bool> {
         let entry_key = self.entry_key()?;
-        placement_belongs_to_entry_key(entry_key, self.placement, redundancy)
+        placement_belongs_to_entry_key(entry_key, self.placement, self.op.kind(), redundancy)
     }
 
     /// Enforce that `placement` belongs to the operation's entry.
@@ -167,8 +168,17 @@ impl PlacedEntryOperation {
     }
 }
 
-fn placement_belongs_to_entry_key(entry_key: Did, placement: Did, redundancy: u16) -> Result<bool> {
-    Ok(entry_key.rotate_affine(redundancy)?.contains(&placement))
+/// Whether `placement` lies in the affine replica set of a carrier of `kind` identified by
+/// `entry_key`: the set has `kind.replication(redundancy)` keys, one for a relay inbox.
+fn placement_belongs_to_entry_key(
+    entry_key: Did,
+    placement: Did,
+    kind: EntryKind,
+    redundancy: u16,
+) -> Result<bool> {
+    Ok(entry_key
+        .rotate_affine(kind.replication(redundancy))?
+        .contains(&placement))
 }
 
 /// A DHT storage entry with an [`EntryKind`] and a ring key represented as [`Did`].
@@ -179,9 +189,12 @@ fn placement_belongs_to_entry_key(entry_key: Did, placement: Did, redundancy: u1
 ///
 /// The [`Did`] of an [`Entry`] is in the following format:
 /// * If kind value is [EntryKind::Data], it's sha1 of data topic.
-/// * If kind value is [EntryKind::RelayMessage], it's the destination Did of
-///   message plus 1 (to ensure that the message is sent to the successor of destination),
-///   thus while destination node going online, it will sync message from its successor.
+/// * If kind value is [EntryKind::RelayMessage], it's the destination Did of the held
+///   messages plus 1, the position just after the destination, which lies in the
+///   destination's own storage interval once it is online (see the `inbox` module).
+///
+/// The kind is part of the carrier's storage identity: a data topic and a relay inbox at the
+/// same position are distinct slots, so neither can shadow the other.
 ///
 /// Retention: every entry accepted into storage carries a retention bound `expires_at_ms`,
 /// stamped by the origin at the operation boundary and bounded by the receiver at admission
@@ -227,7 +240,7 @@ impl PlacedEntry {
 
     /// Return whether `key` is in `entry.did`'s affine replica set.
     pub fn placement_belongs_to_entry(&self, redundancy: u16) -> Result<bool> {
-        placement_belongs_to_entry_key(self.entry.did, self.key, redundancy)
+        placement_belongs_to_entry_key(self.entry.did, self.key, self.entry.kind, redundancy)
     }
 
     /// Enforce that `key` belongs to `entry.did`'s affine replica set.

--- a/crates/core/src/dht/entry.rs
+++ b/crates/core/src/dht/entry.rs
@@ -45,6 +45,20 @@ impl EntryKind {
         }
     }
 
+    /// Whether this kind is a relay inbox.
+    pub const fn is_relay_inbox(self) -> bool {
+        matches!(self, EntryKind::RelayMessage)
+    }
+
+    /// The replication a carrier of this kind actually gets when `requested` is configured: a
+    /// relay inbox has one owner and is never replicated.
+    pub const fn replication(self, requested: u16) -> u16 {
+        match self {
+            EntryKind::Data => requested,
+            EntryKind::RelayMessage => 1,
+        }
+    }
+
     /// The greatest number of tombstones a carrier of this kind keeps. A data topic keeps every
     /// tombstone below its reset floor's pruning; a relay inbox has one owner and one
     /// ack-gated relocation at a time, so a stale copy can only be transient and the newest
@@ -70,8 +84,8 @@ enum EntryWitness {
     Elements(EntryStampKind),
     /// A register floor only.
     Register,
-    /// No witness: the operation names existing dots or values.
-    None,
+    /// A reference witness: the operation names existing dots or values and issues none.
+    Reference,
 }
 
 // Canonical stamp input for EntryVersion.operation.
@@ -353,7 +367,7 @@ impl EntryOperation {
             match witness {
                 EntryWitness::Elements(kind) => entry.ensure_stamp_after(now_ms, actor, None, kind),
                 EntryWitness::Register => entry.ensure_overwrite_stamp_after(now_ms, actor, None),
-                EntryWitness::None => Ok(entry),
+                EntryWitness::Reference => Ok(entry),
             }
         })
     }
@@ -365,7 +379,7 @@ impl EntryOperation {
             EntryOperation::Extend(_) | EntryOperation::Touch(_) => {
                 EntryWitness::Elements(EntryStampKind::Delta)
             }
-            EntryOperation::Tombstone(_) => EntryWitness::None,
+            EntryOperation::Tombstone(_) => EntryWitness::Reference,
             EntryOperation::CompactData(_) => EntryWitness::Register,
         }
     }
@@ -403,7 +417,7 @@ impl EntryOperation {
     }
 
     /// Generate a target Entry when it is not existed.
-    pub fn gen_default_entry(self) -> Result<Entry> {
+    pub fn gen_default_entry(&self) -> Result<Entry> {
         Ok(Entry::new(self.did()?, vec![], self.kind()))
     }
 }
@@ -739,7 +753,7 @@ impl Entry {
     }
 
     fn is_data_entry(&self) -> bool {
-        self.kind == EntryKind::Data
+        !self.kind.is_relay_inbox()
     }
 
     fn same_kind_as(&self, other: &Self) -> bool {

--- a/crates/core/src/dht/entry/crdt.rs
+++ b/crates/core/src/dht/entry/crdt.rs
@@ -59,11 +59,6 @@ impl EntryVersion {
         }
     }
 
-    /// Construct a version at the current operation boundary.
-    pub fn issued_by(actor: Did, operation: Did) -> Self {
-        Self::new(crate::utils::get_epoch_ms(), actor, operation)
-    }
-
     pub(super) fn after(self, floor: Option<Self>) -> Self {
         let Some(floor) = floor else {
             return self;

--- a/crates/core/src/dht/entry/inbox.rs
+++ b/crates/core/src/dht/entry/inbox.rs
@@ -26,16 +26,24 @@
 //! bounds replay: a holder can only hold a message inside its sender's own proof lifetime.
 //!
 //! Authority (checked by the shell, which knows who is writing): a fresh hold is admitted only
-//! from the node the owner itself routes `d` to (`find_successor(d)` answered locally), a
-//! relocation of the carrier only from the owner's predecessor as an ownership hand-off, and a
-//! removal only from `d`; a relay carrier is never fetched, cached, or replicated. Removal is
-//! per element by its add dot (an observed-remove), never by a reset floor, so a message the
-//! recipient has not seen is never dropped by a compaction it did not issue.
+//! from the node the owner itself routes `d` to (`find_successor(d)` answered locally), only
+//! while the held message's sender proof is still live by the owner's clock (so the hold instant
+//! a holder signs cannot lie about the past), a relocation of the carrier only from the owner's
+//! authenticated predecessor as an ownership hand-off, and a removal only from `d`; a relay
+//! carrier is never fetched, cached, or replicated. Removal is per element by its add dot (an
+//! observed-remove), never by a reset floor, so a message the recipient has not seen is never
+//! dropped by a compaction it did not issue.
+//!
+//! Both "responsible for `d`" (the holder's `(pred, self]`) and "routes `d` to" (the owner's
+//! successor list) are projections of failure detection: while an owner still lists the departed
+//! `d` as its head, it routes `d` to `d` and refuses the hold, and the message is lost as it was
+//! before the inbox existed. The window closes when the owner retires `d`.
 
 use serde::Deserialize;
 use serde::Serialize;
 
 use super::Entry;
+use super::EntryDot;
 use super::EntryKind;
 use super::EntryOperation;
 use crate::consts::TS_OFFSET_TOLERANCE_MS;
@@ -108,11 +116,15 @@ impl Decoder for HeldMessage {
 }
 
 impl HeldMessage {
-    /// Hold `payload` under `holder`'s authority, stamped with the current instant.
-    pub(crate) fn hold(payload: MessagePayload, holder: MessageSigner<&SessionSk>) -> Result<Self> {
+    /// Hold `payload` under `holder`'s authority at the instant `held_at_ms`.
+    pub(crate) fn hold(
+        payload: MessagePayload,
+        holder: MessageSigner<&SessionSk>,
+        held_at_ms: u128,
+    ) -> Result<Self> {
         let data = rings_codec::serialize(&payload).map_err(Error::CodecSerialize)?;
         Ok(Self {
-            holder: holder.sign(HELD_MESSAGE_DOMAIN_TAG, &data)?,
+            holder: holder.sign_at(HELD_MESSAGE_DOMAIN_TAG, &data, held_at_ms)?,
             payload,
         })
     }
@@ -130,7 +142,8 @@ impl HeldMessage {
     /// The element witness (see the module documentation).
     ///
     /// Pre: `now_ms` is the receiver's clock and `network_id` its overlay.
-    /// Post: `Ok(())` implies the payload is a `CustomMessage` addressed to `destination`, the
+    /// Post: `Ok(())` implies the payload is a `CustomMessage` whose transaction and relay are
+    /// both addressed to `destination` (so its recipient has nothing to forward), the
     /// hold instant is at most `now_ms + TS_OFFSET_TOLERANCE_MS`, the holder signature verifies
     /// inside `network_id` as of the hold instant, and the payload's transaction and hop
     /// signatures verify inside `network_id` as of the hold instant.
@@ -140,7 +153,9 @@ impl HeldMessage {
         now_ms: u128,
         network_id: u32,
     ) -> Result<()> {
-        if self.payload.transaction.destination != destination {
+        if self.payload.transaction.destination != destination
+            || self.payload.relay.destination != destination
+        {
             return Err(Error::RelayMessageNotAddressedToInbox);
         }
         if !matches!(
@@ -190,93 +205,131 @@ impl Entry {
         ))
     }
 
-    /// The element witness over every element of a relay carrier, and the carrier shape a relay
-    /// carrier must keep: no reset floor, because removal is by dot only.
+    /// Every element of this relay carrier, decoded and witnessed, in carrier order; and the
+    /// carrier shape a relay carrier must keep: no reset floor, because removal is by dot only,
+    /// and no more elements than the inbox keeps.
     ///
     /// Pre: `self.kind == EntryKind::RelayMessage`.
-    pub(super) fn validate_inbox_witness(&self, now_ms: u128, network_id: u32) -> Result<()> {
+    pub(crate) fn witnessed_inbox_elements(
+        &self,
+        now_ms: u128,
+        network_id: u32,
+    ) -> Result<Vec<HeldMessage>> {
         if self.crdt.register.is_some() {
             return Err(Error::RelayInboxRegisterNotAllowed);
         }
+        // Every element costs signature verifications; a delta the inbox could not keep is
+        // refused before the first one. (A data topic caps at materialization instead: its
+        // elements cost nothing to admit.)
+        if self.data.len() > self.kind.max_data_len() {
+            return Err(Error::RelayInboxDeltaExceedsCapacity);
+        }
         let destination = inbox_destination(self.did);
-        self.data.iter().try_for_each(|element| {
-            verified_element(element, destination, now_ms, network_id).map(drop)
-        })
+        self.data
+            .iter()
+            .map(|element| verified_element(element, destination, now_ms, network_id))
+            .collect()
     }
 
-    /// Whether every element of this relay delta was held by `holder`.
-    ///
-    /// Pre: `self` passed [`Self::validate_inbox_witness`], so every element decodes.
-    pub(crate) fn every_element_held_by(&self, holder: Did) -> bool {
-        self.data.iter().all(|element| {
-            HeldMessage::from_encoded(element).is_ok_and(|held| held.holder() == holder)
-        })
+    /// The element witness over every element of a relay carrier.
+    pub(super) fn validate_inbox_witness(&self, now_ms: u128, network_id: u32) -> Result<()> {
+        self.witnessed_inbox_elements(now_ms, network_id).map(drop)
     }
 
-    /// Partition this inbox into the messages its recipient may deliver and the dots of every
-    /// element it must retire: the delivered ones and the ones that fail the witness under the
-    /// recipient's overlay (junk a misbehaving owner relocated).
+    /// Partition this stored inbox into the elements its recipient may deliver, each with the
+    /// add dot that retires it, and the removal delta of every element that fails the witness
+    /// under the recipient's overlay (junk a misbehaving owner relocated).
     ///
-    /// Post: `deliverable` is in carrier order; `retired` names every element of the carrier.
-    pub(crate) fn drain_inbox(&self, now_ms: u128, network_id: u32) -> InboxDrain {
+    /// Pre: `self` is the materialized stored carrier, so `data` and `crdt.dots` align.
+    /// Post: `deliverable` is in carrier order; `deliverable` dots and `rejected` dots together
+    /// are every dot of the carrier.
+    pub(crate) fn partition_inbox(&self, now_ms: u128, network_id: u32) -> InboxDrain {
         let destination = inbox_destination(self.did);
         let mut deliverable = Vec::new();
-        let mut rejected = 0usize;
-        for element in &self.data {
+        let mut rejected = Vec::new();
+        for (element, dot) in self.data.iter().zip(self.crdt.dots.iter().copied()) {
             match verified_element(element, destination, now_ms, network_id) {
-                Ok(held) => deliverable.push(held.payload),
-                Err(_) => rejected = rejected.saturating_add(1),
+                Ok(held) => deliverable.push(InboxElement {
+                    dot,
+                    payload: held.payload,
+                }),
+                Err(_) => rejected.push(dot),
             }
         }
         InboxDrain {
             deliverable,
-            rejected,
-            retired: self.tombstone_delta(),
+            rejected: self.removal_of(rejected),
         }
     }
 
-    /// The removal delta naming every element of this carrier by its add dot.
-    fn tombstone_delta(&self) -> Entry {
+    /// The removal delta of this carrier naming `dots`.
+    pub(crate) fn removal_of(&self, dots: impl IntoIterator<Item = EntryDot>) -> Entry {
         let mut removal = Self::new(self.did, Vec::new(), EntryKind::RelayMessage);
-        removal.crdt.dots = self.crdt.dots.clone();
+        removal.crdt.dots = dots.into_iter().collect();
         removal
     }
 }
 
-/// The outcome of draining an inbox: what to deliver and what to retire.
+/// One deliverable inbox element: the payload and the add dot that retires it once delivered.
+#[derive(Debug)]
+pub(crate) struct InboxElement {
+    /// The add dot of the element in the stored carrier.
+    pub(crate) dot: EntryDot,
+    /// The held application payload.
+    pub(crate) payload: MessagePayload,
+}
+
+/// The outcome of partitioning an inbox: what to deliver and what to retire unread.
 #[derive(Debug)]
 pub(crate) struct InboxDrain {
-    /// Messages that pass the witness, in carrier order.
-    pub(crate) deliverable: Vec<MessagePayload>,
-    /// Elements that failed the witness under the recipient's overlay.
-    pub(crate) rejected: usize,
-    /// The tombstone delta retiring every element of the drained carrier.
-    pub(crate) retired: Entry,
+    /// Elements that pass the witness, in carrier order.
+    pub(crate) deliverable: Vec<InboxElement>,
+    /// The removal delta of the elements that failed the witness; empty when none did.
+    pub(crate) rejected: Entry,
 }
 
 impl EntryOperation {
-    /// The authority law of a relay-carrier operation: a hold (`Extend`) only from the node the
-    /// owner routes the destination to (`responsible`, `None` when that route is not local), a
-    /// removal (`Tombstone`) only from the recipient, and no other operation.
+    /// The write law of a relay-carrier operation issued by `writer` at the owner's clock
+    /// `now_ms`: a hold (`Extend`) only from the node the owner routes the destination to
+    /// (`responsible`, `None` when that route is not local), every element held by that node,
+    /// and held while its sender's proof is still live by the owner's own clock; a removal
+    /// (`Tombstone`) only from the recipient; no other operation.
     ///
-    /// Pre: the carried entry passed the element witness.
-    pub(crate) fn validate_inbox_authority(
+    /// The freshness bound is what makes the hold instant honest: the holder signs it, so the
+    /// witness alone would let a holder judge an old message at a time of its choosing. Judged
+    /// once here at the write, it bounds replay by the sender's proof lifetime; relocation and
+    /// delivery then judge as of the recorded instant, which keeps them monotone in time.
+    ///
+    /// Post: `Ok(())` implies the carried entry passed the element witness; authority is judged
+    /// before any signature is verified, so a stranger costs the owner no verification.
+    pub(crate) fn validate_inbox_write(
         &self,
         writer: Did,
         responsible: Option<Did>,
+        now_ms: u128,
+        network_id: u32,
     ) -> Result<()> {
-        let entry = self.entry();
         match self {
-            EntryOperation::Extend(_) => {
-                let holds = responsible
-                    .is_some_and(|node| writer == node && entry.every_element_held_by(node));
-                holds
-                    .then_some(())
-                    .ok_or(Error::RelayMessageHolderNotResponsible)
+            EntryOperation::Extend(entry) => {
+                if responsible != Some(writer) {
+                    return Err(Error::RelayMessageHolderNotResponsible);
+                }
+                for held in entry.witnessed_inbox_elements(now_ms, network_id)? {
+                    if held.holder() != writer {
+                        return Err(Error::RelayMessageHolderNotResponsible);
+                    }
+                    if !held.payload.transaction.verification.is_live_at(now_ms) {
+                        return Err(Error::RelayMessageHoldStale);
+                    }
+                }
+                Ok(())
             }
-            EntryOperation::Tombstone(_) => (writer == inbox_destination(entry.did))
-                .then_some(())
-                .ok_or(Error::RelayInboxWriterNotRecipient),
+            EntryOperation::Tombstone(entry) => {
+                if writer != inbox_destination(entry.did) {
+                    return Err(Error::RelayInboxWriterNotRecipient);
+                }
+                entry.validate_inbox_witness(now_ms, network_id)
+            }
             EntryOperation::Overwrite(_)
             | EntryOperation::Touch(_)
             | EntryOperation::CompactData(_) => Err(Error::RelayInboxOperationNotAllowed),
@@ -286,8 +339,10 @@ impl EntryOperation {
 
 /// The authority law of a relay-carrier relocation: an ownership hand-off is accepted only from
 /// the receiver's predecessor, the owner whose interval the carrier is leaving.
-pub(crate) fn validate_inbox_relocation(origin: Did, predecessor: Option<Did>) -> Result<()> {
-    (predecessor == Some(origin))
+///
+/// Pre: `sender` is the authenticated signer of the hand-off, not its peer-declared relay path.
+pub(crate) fn validate_inbox_relocation(sender: Did, predecessor: Option<Did>) -> Result<()> {
+    (predecessor == Some(sender))
         .then_some(())
         .ok_or(Error::RelayInboxNotRelocatable)
 }

--- a/crates/core/src/dht/entry/inbox.rs
+++ b/crates/core/src/dht/entry/inbox.rs
@@ -1,0 +1,101 @@
+//! The relay inbox: messages held for a peer while it is offline.
+//!
+//! Model: a message addressed to `d` routes to `succ(d)`. When `d` is not connected, `succ(d)`
+//! is responsible for the position `d` occupies but cannot deliver, so it holds the message in
+//! the carrier `inbox(d) = d + 1` (arithmetic in `Z / 2^160`) through the ordinary storage write
+//! path. Storage places a key `k` at the node `n` with `k ∈ (n, succ(n)]`, so while `d` is offline
+//! the carrier lives at `d`'s predecessor, and once `d` returns `d + 1 ∈ (d, succ(d)]` makes `d`
+//! itself the owner: ownership hand-off moves the carrier to `d`, which drains it from its own
+//! storage, delivers the messages to its application, and compacts the carrier.
+//!
+//! Witness: the kind of an entry is a peer-declared wire field, so the inbox policy (longer
+//! retention than a data topic) is safe only because every element is verifiable by the
+//! storage owner without trusting the writer. An element is admitted iff it decodes as a
+//! [`MessagePayload`] whose transaction is addressed to `inbox_destination(entry.did)`, carries an
+//! application message, and whose transaction and hop signatures verify inside the owner's
+//! overlay. Signature liveness is deliberately not required: the inbox exists precisely to hold
+//! a message past its own proof lifetime, and the recipient re-verifies the same signatures when
+//! it drains the inbox.
+
+use super::Entry;
+use super::EntryKind;
+use crate::dht::Did;
+use crate::error::Error;
+use crate::error::Result;
+use crate::message::Decoder;
+use crate::message::Encoded;
+use crate::message::Encoder;
+use crate::message::Message;
+use crate::message::MessageClass;
+use crate::message::MessagePayload;
+use crate::message::MessageVerificationExt;
+
+/// The relay-inbox carrier of `destination`: the ring position just after it.
+pub fn inbox_key(destination: Did) -> Did {
+    destination + Did::from(1u32)
+}
+
+/// The peer an inbox carrier is kept for; the inverse of [`inbox_key`].
+pub fn inbox_destination(inbox: Did) -> Did {
+    inbox - Did::from(1u32)
+}
+
+/// Decode one inbox element and check the witness under `network_id`.
+///
+/// Post: `Ok(payload)` implies the payload is addressed to `destination`, carries an application
+/// message, and both its signatures verify inside `network_id` regardless of proof liveness.
+pub fn verified_inbox_message(
+    element: &Encoded,
+    destination: Did,
+    network_id: u32,
+) -> Result<MessagePayload> {
+    let payload = MessagePayload::from_encoded(element)?;
+    if payload.transaction.destination != destination {
+        return Err(Error::RelayMessageNotAddressedToInbox);
+    }
+    if payload.transaction.data::<Message>()?.kind().class() != MessageClass::Application {
+        return Err(Error::RelayMessageNotApplication);
+    }
+    if !(payload.transaction.verify_signature(network_id) && payload.verify_signature(network_id)) {
+        return Err(Error::RelayMessageUnverifiable);
+    }
+    Ok(payload)
+}
+
+impl Entry {
+    /// The inbox delta holding one undeliverable `payload` for its destination.
+    ///
+    /// Post: `result.did = inbox_key(payload.transaction.destination)` and the single element is
+    /// `payload` in wire encoding, so the storage owner can re-derive the witness.
+    pub fn inbox_delta(payload: &MessagePayload) -> Result<Self> {
+        Ok(Self::new(
+            inbox_key(payload.transaction.destination),
+            vec![payload.encode()?],
+            EntryKind::RelayMessage,
+        ))
+    }
+
+    /// The witness every element of a relay inbox must satisfy (see the module documentation).
+    ///
+    /// Pre: `self.kind == EntryKind::RelayMessage`.
+    pub(super) fn validate_inbox_witness(&self, network_id: u32) -> Result<()> {
+        let destination = inbox_destination(self.did);
+        self.data.iter().try_for_each(|element| {
+            verified_inbox_message(element, destination, network_id).map(drop)
+        })
+    }
+
+    /// The messages a recipient may deliver from its inbox: every element that satisfies the
+    /// witness under the recipient's overlay, in carrier order.
+    ///
+    /// Post: elements that fail the witness are skipped, never delivered; the carrier's own
+    /// admission makes them unreachable through an honest owner, so a failure here names a
+    /// misbehaving owner rather than a stale message.
+    pub fn deliverable_inbox_messages(&self, network_id: u32) -> Vec<MessagePayload> {
+        let destination = inbox_destination(self.did);
+        self.data
+            .iter()
+            .filter_map(|element| verified_inbox_message(element, destination, network_id).ok())
+            .collect()
+    }
+}

--- a/crates/core/src/dht/entry/inbox.rs
+++ b/crates/core/src/dht/entry/inbox.rs
@@ -340,11 +340,11 @@ impl EntryOperation {
 }
 
 /// The authority law of a relay-carrier relocation: an ownership hand-off is accepted only from
-/// the receiver's predecessor, the owner whose interval the carrier is leaving.
+/// the receiver's predecessor, the owner whose interval the carrier is leaving. A hand-off from
+/// anyone else is not invalid, only not this receiver's to take yet, so the law is a predicate
+/// the batch skips on rather than an error it fails with.
 ///
 /// Pre: `sender` is the authenticated signer of the hand-off, not its peer-declared relay path.
-pub(crate) fn validate_inbox_relocation(sender: Did, predecessor: Option<Did>) -> Result<()> {
-    (predecessor == Some(sender))
-        .then_some(())
-        .ok_or(Error::RelayInboxNotRelocatable)
+pub(crate) fn relocates_from_predecessor(sender: Did, predecessor: Option<Did>) -> bool {
+    predecessor == Some(sender)
 }

--- a/crates/core/src/dht/entry/inbox.rs
+++ b/crates/core/src/dht/entry/inbox.rs
@@ -6,10 +6,12 @@
 //! signature and the hold instant, and writes it into the carrier `inbox(d) = d + 1`
 //! (arithmetic in `Z / 2^160`, kind [`EntryKind::RelayMessage`]) through the ordinary storage
 //! write path. Relay carriers are placed by the ring geometry alone, `k ∈ (n, succ(n)]`, in every
-//! storage mode, so while `d` is offline the carrier lives at `d`'s predecessor and once `d`
-//! returns `d + 1 ∈ (d, succ(d)]` makes `d` itself the owner: the storage repair pass of the
-//! predecessor hands the carrier to `d`, which delivers it through its inbound pipeline and
-//! tombstones the delivered elements.
+//! storage mode, at that one placement whatever the configured redundancy, and in their own
+//! storage namespace, so a data topic parked at `d + 1` (any node may name any position through
+//! an overwrite) never shadows the inbox kept for `d`. While `d` is offline the carrier lives at
+//! `d`'s predecessor and once `d` returns `d + 1 ∈ (d, succ(d)]` makes `d` itself the owner: the
+//! storage repair pass of the predecessor hands the carrier to `d`, which delivers it through its
+//! inbound pipeline and tombstones the delivered elements.
 //!
 //! Only [`Message::CustomMessage`] is held; every other message class (control, storage, E2E
 //! frames) is forwarded as before and lost at a dead end, which is the pre-existing behaviour.

--- a/crates/core/src/dht/entry/inbox.rs
+++ b/crates/core/src/dht/entry/inbox.rs
@@ -1,101 +1,293 @@
 //! The relay inbox: messages held for a peer while it is offline.
 //!
-//! Model: a message addressed to `d` routes to `succ(d)`. When `d` is not connected, `succ(d)`
-//! is responsible for the position `d` occupies but cannot deliver, so it holds the message in
-//! the carrier `inbox(d) = d + 1` (arithmetic in `Z / 2^160`) through the ordinary storage write
-//! path. Storage places a key `k` at the node `n` with `k ∈ (n, succ(n)]`, so while `d` is offline
-//! the carrier lives at `d`'s predecessor, and once `d` returns `d + 1 ∈ (d, succ(d)]` makes `d`
-//! itself the owner: ownership hand-off moves the carrier to `d`, which drains it from its own
-//! storage, delivers the messages to its application, and compacts the carrier.
+//! Model: an application message addressed to `d` routes to `succ(d)`. When `d` has no
+//! connection at all, `succ(d)` is responsible for the position `d` occupies but cannot deliver,
+//! so it *holds* the message: it wraps the payload in a [`HeldMessage`] carrying its own
+//! signature and the hold instant, and writes it into the carrier `inbox(d) = d + 1`
+//! (arithmetic in `Z / 2^160`, kind [`EntryKind::RelayMessage`]) through the ordinary storage
+//! write path. Relay carriers are placed by the ring geometry alone, `k ∈ (n, succ(n)]`, in every
+//! storage mode, so while `d` is offline the carrier lives at `d`'s predecessor and once `d`
+//! returns `d + 1 ∈ (d, succ(d)]` makes `d` itself the owner: the storage repair pass of the
+//! predecessor hands the carrier to `d`, which delivers it through its inbound pipeline and
+//! tombstones the delivered elements.
+//!
+//! Only [`Message::CustomMessage`] is held; every other message class (control, storage, E2E
+//! frames) is forwarded as before and lost at a dead end, which is the pre-existing behaviour.
 //!
 //! Witness: the kind of an entry is a peer-declared wire field, so the inbox policy (longer
-//! retention than a data topic) is safe only because every element is verifiable by the
-//! storage owner without trusting the writer. An element is admitted iff it decodes as a
-//! [`MessagePayload`] whose transaction is addressed to `inbox_destination(entry.did)`, carries an
-//! application message, and whose transaction and hop signatures verify inside the owner's
-//! overlay. Signature liveness is deliberately not required: the inbox exists precisely to hold
-//! a message past its own proof lifetime, and the recipient re-verifies the same signatures when
-//! it drains the inbox.
+//! retention than a data topic, a writer restricted to one node) is safe only because every
+//! element is verifiable by whoever stores it. An element is admissible iff, as an
+//! [`Entry`] element, it decodes as a [`HeldMessage`] whose payload is a `CustomMessage`
+//! addressed to `inbox_destination(entry.did)`, whose hold instant is not ahead of the
+//! receiver's clock, whose holder signature verifies inside the receiver's overlay, and whose
+//! payload verifies *as of the hold instant*: both inner proofs were live then and both inner
+//! sessions were authorized then. Judging the payload at the hold instant keeps admissibility
+//! monotone in time (a sender's session expiring later does not unverify a held message) and
+//! bounds replay: a holder can only hold a message inside its sender's own proof lifetime.
+//!
+//! Authority (checked by the shell, which knows who is writing): a fresh hold is admitted only
+//! from the node the owner itself routes `d` to (`find_successor(d)` answered locally), a
+//! relocation of the carrier only from the owner's predecessor as an ownership hand-off, and a
+//! removal only from `d`; a relay carrier is never fetched, cached, or replicated. Removal is
+//! per element by its add dot (an observed-remove), never by a reset floor, so a message the
+//! recipient has not seen is never dropped by a compaction it did not issue.
+
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::Entry;
 use super::EntryKind;
+use super::EntryOperation;
+use crate::consts::TS_OFFSET_TOLERANCE_MS;
 use crate::dht::Did;
 use crate::error::Error;
 use crate::error::Result;
 use crate::message::Decoder;
+use crate::message::DomainTag;
 use crate::message::Encoded;
 use crate::message::Encoder;
 use crate::message::Message;
-use crate::message::MessageClass;
 use crate::message::MessagePayload;
+use crate::message::MessageSigner;
+use crate::message::MessageVerification;
 use crate::message::MessageVerificationExt;
+use crate::session::SessionSk;
+
+/// The message family of a holder's signature over a held payload.
+pub(crate) const HELD_MESSAGE_DOMAIN_TAG: DomainTag =
+    crate::domain_tag!("rings-core:relay-inbox:held-message:v1");
 
 /// The relay-inbox carrier of `destination`: the ring position just after it.
-pub fn inbox_key(destination: Did) -> Did {
+pub(crate) fn inbox_key(destination: Did) -> Did {
     destination + Did::from(1u32)
 }
 
 /// The peer an inbox carrier is kept for; the inverse of [`inbox_key`].
-pub fn inbox_destination(inbox: Did) -> Did {
+pub(crate) fn inbox_destination(inbox: Did) -> Did {
     inbox - Did::from(1u32)
 }
 
-/// Decode one inbox element and check the witness under `network_id`.
+/// One element of a relay inbox: an application payload together with its holder's attestation.
 ///
-/// Post: `Ok(payload)` implies the payload is addressed to `destination`, carries an application
-/// message, and both its signatures verify inside `network_id` regardless of proof liveness.
-pub fn verified_inbox_message(
+/// Invariant (established by [`HeldMessage::hold`], re-derived by [`Entry`] admission): `holder`
+/// signs the canonical encoding of `payload` under [`HELD_MESSAGE_DOMAIN_TAG`]; its timestamp is
+/// the instant the holder received the payload.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct HeldMessage {
+    /// The application payload as it reached the holder.
+    pub(crate) payload: MessagePayload,
+    /// The holder's signature; `ts_ms` is the hold instant.
+    pub(crate) holder: MessageVerification,
+}
+
+impl MessageVerificationExt for HeldMessage {
+    const DOMAIN_TAG: DomainTag = HELD_MESSAGE_DOMAIN_TAG;
+
+    fn verification_data(&self) -> Result<Vec<u8>> {
+        rings_codec::serialize(&self.payload).map_err(Error::CodecSerialize)
+    }
+
+    fn verification(&self) -> &MessageVerification {
+        &self.holder
+    }
+}
+
+impl Encoder for HeldMessage {
+    fn encode(&self) -> Result<Encoded> {
+        rings_codec::serialize(self)
+            .map_err(Error::CodecSerialize)?
+            .encode()
+    }
+}
+
+impl Decoder for HeldMessage {
+    fn from_encoded(encoded: &Encoded) -> Result<Self> {
+        let wire: Vec<u8> = encoded.decode()?;
+        rings_codec::deserialize(&wire).map_err(Error::CodecDeserialize)
+    }
+}
+
+impl HeldMessage {
+    /// Hold `payload` under `holder`'s authority, stamped with the current instant.
+    pub(crate) fn hold(payload: MessagePayload, holder: MessageSigner<&SessionSk>) -> Result<Self> {
+        let data = rings_codec::serialize(&payload).map_err(Error::CodecSerialize)?;
+        Ok(Self {
+            holder: holder.sign(HELD_MESSAGE_DOMAIN_TAG, &data)?,
+            payload,
+        })
+    }
+
+    /// The node that held the payload.
+    pub(crate) fn holder(&self) -> Did {
+        self.signer()
+    }
+
+    /// The instant the holder received the payload.
+    pub(crate) const fn held_at_ms(&self) -> u128 {
+        self.holder.ts_ms
+    }
+
+    /// The element witness (see the module documentation).
+    ///
+    /// Pre: `now_ms` is the receiver's clock and `network_id` its overlay.
+    /// Post: `Ok(())` implies the payload is a `CustomMessage` addressed to `destination`, the
+    /// hold instant is at most `now_ms + TS_OFFSET_TOLERANCE_MS`, the holder signature verifies
+    /// inside `network_id` as of the hold instant, and the payload's transaction and hop
+    /// signatures verify inside `network_id` as of the hold instant.
+    pub(crate) fn validate_witness(
+        &self,
+        destination: Did,
+        now_ms: u128,
+        network_id: u32,
+    ) -> Result<()> {
+        if self.payload.transaction.destination != destination {
+            return Err(Error::RelayMessageNotAddressedToInbox);
+        }
+        if !matches!(
+            self.payload.transaction.data::<Message>()?,
+            Message::CustomMessage(_)
+        ) {
+            return Err(Error::RelayMessageNotCustom);
+        }
+        let held_at_ms = self.held_at_ms();
+        if held_at_ms > now_ms.saturating_add(TS_OFFSET_TOLERANCE_MS) {
+            return Err(Error::RelayMessageHeldAheadOfClock);
+        }
+        if !self.verify_at(network_id, held_at_ms) {
+            return Err(Error::RelayMessageUnverifiable);
+        }
+        if !(self.payload.transaction.verify_at(network_id, held_at_ms)
+            && self.payload.verify_at(network_id, held_at_ms))
+        {
+            return Err(Error::RelayMessageHeldOutsideSenderProof);
+        }
+        Ok(())
+    }
+}
+
+/// Decode one inbox element and check its witness.
+fn verified_element(
     element: &Encoded,
     destination: Did,
+    now_ms: u128,
     network_id: u32,
-) -> Result<MessagePayload> {
-    let payload = MessagePayload::from_encoded(element)?;
-    if payload.transaction.destination != destination {
-        return Err(Error::RelayMessageNotAddressedToInbox);
-    }
-    if payload.transaction.data::<Message>()?.kind().class() != MessageClass::Application {
-        return Err(Error::RelayMessageNotApplication);
-    }
-    if !(payload.transaction.verify_signature(network_id) && payload.verify_signature(network_id)) {
-        return Err(Error::RelayMessageUnverifiable);
-    }
-    Ok(payload)
+) -> Result<HeldMessage> {
+    let held = HeldMessage::from_encoded(element)?;
+    held.validate_witness(destination, now_ms, network_id)?;
+    Ok(held)
 }
 
 impl Entry {
-    /// The inbox delta holding one undeliverable `payload` for its destination.
+    /// The inbox delta holding one message for its destination.
     ///
-    /// Post: `result.did = inbox_key(payload.transaction.destination)` and the single element is
-    /// `payload` in wire encoding, so the storage owner can re-derive the witness.
-    pub fn inbox_delta(payload: &MessagePayload) -> Result<Self> {
+    /// Post: `result.did = inbox_key(destination)` and the single element is `held` in wire
+    /// encoding, so the storage owner re-derives the witness from the element alone.
+    pub(crate) fn inbox_delta(held: &HeldMessage) -> Result<Self> {
         Ok(Self::new(
-            inbox_key(payload.transaction.destination),
-            vec![payload.encode()?],
+            inbox_key(held.payload.transaction.destination),
+            vec![held.encode()?],
             EntryKind::RelayMessage,
         ))
     }
 
-    /// The witness every element of a relay inbox must satisfy (see the module documentation).
+    /// The element witness over every element of a relay carrier, and the carrier shape a relay
+    /// carrier must keep: no reset floor, because removal is by dot only.
     ///
     /// Pre: `self.kind == EntryKind::RelayMessage`.
-    pub(super) fn validate_inbox_witness(&self, network_id: u32) -> Result<()> {
+    pub(super) fn validate_inbox_witness(&self, now_ms: u128, network_id: u32) -> Result<()> {
+        if self.crdt.register.is_some() {
+            return Err(Error::RelayInboxRegisterNotAllowed);
+        }
         let destination = inbox_destination(self.did);
         self.data.iter().try_for_each(|element| {
-            verified_inbox_message(element, destination, network_id).map(drop)
+            verified_element(element, destination, now_ms, network_id).map(drop)
         })
     }
 
-    /// The messages a recipient may deliver from its inbox: every element that satisfies the
-    /// witness under the recipient's overlay, in carrier order.
+    /// Whether every element of this relay delta was held by `holder`.
     ///
-    /// Post: elements that fail the witness are skipped, never delivered; the carrier's own
-    /// admission makes them unreachable through an honest owner, so a failure here names a
-    /// misbehaving owner rather than a stale message.
-    pub fn deliverable_inbox_messages(&self, network_id: u32) -> Vec<MessagePayload> {
-        let destination = inbox_destination(self.did);
-        self.data
-            .iter()
-            .filter_map(|element| verified_inbox_message(element, destination, network_id).ok())
-            .collect()
+    /// Pre: `self` passed [`Self::validate_inbox_witness`], so every element decodes.
+    pub(crate) fn every_element_held_by(&self, holder: Did) -> bool {
+        self.data.iter().all(|element| {
+            HeldMessage::from_encoded(element).is_ok_and(|held| held.holder() == holder)
+        })
     }
+
+    /// Partition this inbox into the messages its recipient may deliver and the dots of every
+    /// element it must retire: the delivered ones and the ones that fail the witness under the
+    /// recipient's overlay (junk a misbehaving owner relocated).
+    ///
+    /// Post: `deliverable` is in carrier order; `retired` names every element of the carrier.
+    pub(crate) fn drain_inbox(&self, now_ms: u128, network_id: u32) -> InboxDrain {
+        let destination = inbox_destination(self.did);
+        let mut deliverable = Vec::new();
+        let mut rejected = 0usize;
+        for element in &self.data {
+            match verified_element(element, destination, now_ms, network_id) {
+                Ok(held) => deliverable.push(held.payload),
+                Err(_) => rejected = rejected.saturating_add(1),
+            }
+        }
+        InboxDrain {
+            deliverable,
+            rejected,
+            retired: self.tombstone_delta(),
+        }
+    }
+
+    /// The removal delta naming every element of this carrier by its add dot.
+    fn tombstone_delta(&self) -> Entry {
+        let mut removal = Self::new(self.did, Vec::new(), EntryKind::RelayMessage);
+        removal.crdt.dots = self.crdt.dots.clone();
+        removal
+    }
+}
+
+/// The outcome of draining an inbox: what to deliver and what to retire.
+#[derive(Debug)]
+pub(crate) struct InboxDrain {
+    /// Messages that pass the witness, in carrier order.
+    pub(crate) deliverable: Vec<MessagePayload>,
+    /// Elements that failed the witness under the recipient's overlay.
+    pub(crate) rejected: usize,
+    /// The tombstone delta retiring every element of the drained carrier.
+    pub(crate) retired: Entry,
+}
+
+impl EntryOperation {
+    /// The authority law of a relay-carrier operation: a hold (`Extend`) only from the node the
+    /// owner routes the destination to (`responsible`, `None` when that route is not local), a
+    /// removal (`Tombstone`) only from the recipient, and no other operation.
+    ///
+    /// Pre: the carried entry passed the element witness.
+    pub(crate) fn validate_inbox_authority(
+        &self,
+        writer: Did,
+        responsible: Option<Did>,
+    ) -> Result<()> {
+        let entry = self.entry();
+        match self {
+            EntryOperation::Extend(_) => {
+                let holds = responsible
+                    .is_some_and(|node| writer == node && entry.every_element_held_by(node));
+                holds
+                    .then_some(())
+                    .ok_or(Error::RelayMessageHolderNotResponsible)
+            }
+            EntryOperation::Tombstone(_) => (writer == inbox_destination(entry.did))
+                .then_some(())
+                .ok_or(Error::RelayInboxWriterNotRecipient),
+            EntryOperation::Overwrite(_)
+            | EntryOperation::Touch(_)
+            | EntryOperation::CompactData(_) => Err(Error::RelayInboxOperationNotAllowed),
+        }
+    }
+}
+
+/// The authority law of a relay-carrier relocation: an ownership hand-off is accepted only from
+/// the receiver's predecessor, the owner whose interval the carrier is leaving.
+pub(crate) fn validate_inbox_relocation(origin: Did, predecessor: Option<Did>) -> Result<()> {
+    (predecessor == Some(origin))
+        .then_some(())
+        .ok_or(Error::RelayInboxNotRelocatable)
 }

--- a/crates/core/src/dht/entry/retention.rs
+++ b/crates/core/src/dht/entry/retention.rs
@@ -1,0 +1,105 @@
+//! Retention and admission of DHT entries.
+//!
+//! State: every entry carries `expires_at_ms : Option<u128>`, the instant after which it must
+//! no longer be served or replicated. The origin stamps it at the operation boundary; every
+//! receiver bounds it at admission.
+//!
+//! Laws:
+//! - Stamping: `stamped(now)` maps an absent bound to `now + DEFAULT_TTL_MS` and preserves a
+//!   present one, so a forwarded operation keeps the origin's bound.
+//! - Join: the bound of a join is the `max` of the bounds, with `None < Some(_)`. `max` is
+//!   idempotent, commutative, and associative, so the product of the payload lattice and the
+//!   bound lattice is again a join-semilattice.
+//! - Liveness: `is_live_at(now) ⟺ expires_at_ms = Some(t) ∧ now < t`. An unstamped value is
+//!   not live, so a stored value that predates retention is retired on its next read.
+//! - Admission: a value is admissible at `now` iff it is live, its bound is at most
+//!   `now + MAX_TTL_MS + TS_OFFSET_TOLERANCE_MS`, every version it carries has a logical time at
+//!   most `now + TS_OFFSET_TOLERANCE_MS`, and every payload is at most
+//!   `ENTRY_PAYLOAD_MAX_BYTES`. Admission is a predicate on the peer-supplied delta, never on
+//!   the receiver's join result, so locally derived versions (a compaction floor bumped by one
+//!   step) are never mistaken for a peer clock running ahead.
+//!
+//! Size: the payload predicate is element-intrinsic, so filtering by it commutes with union
+//! and the carrier stays a lattice; together with the count cap `ENTRY_DATA_MAX_LEN` it bounds
+//! a carrier at `ENTRY_DATA_MAX_LEN × ENTRY_PAYLOAD_MAX_BYTES` encoded bytes. A byte budget
+//! over the whole carrier is deliberately not used: "the newest payloads that fit" depends on
+//! the sizes of payloads a replica may already have dropped, so it is not a lattice morphism
+//! and replicas would diverge.
+
+use super::Entry;
+use super::EntryOperation;
+use crate::consts::DEFAULT_TTL_MS;
+use crate::consts::ENTRY_PAYLOAD_MAX_BYTES;
+use crate::consts::MAX_TTL_MS;
+use crate::consts::TS_OFFSET_TOLERANCE_MS;
+use crate::error::Error;
+use crate::error::Result;
+use crate::message::Encoded;
+
+/// Whether one encoded payload is within the per-payload size bound.
+fn payload_within_bound(value: &Encoded) -> bool {
+    value.value().len() <= ENTRY_PAYLOAD_MAX_BYTES
+}
+
+impl Entry {
+    /// Stamp the retention bound when the origin left it absent.
+    pub(super) fn ensure_lifetime_from(mut self, now_ms: u128) -> Self {
+        if self.expires_at_ms.is_none() {
+            self.expires_at_ms = Some(now_ms.saturating_add(u128::from(DEFAULT_TTL_MS)));
+        }
+        self
+    }
+
+    /// The retention bound of a join: the later of the two bounds.
+    pub(super) fn joined_lifetime(&self, other: &Self) -> Option<u128> {
+        self.expires_at_ms.max(other.expires_at_ms)
+    }
+
+    /// Whether this entry may still be served or replicated at `now_ms`.
+    ///
+    /// Post: `false` for an unstamped entry, so a legacy stored value without a bound is
+    /// retired on its next read.
+    pub fn is_live_at(&self, now_ms: u128) -> bool {
+        self.expires_at_ms
+            .is_some_and(|expires_at_ms| now_ms < expires_at_ms)
+    }
+
+    /// Admission law for a delta supplied by a peer (see the module documentation).
+    ///
+    /// Pre: `now_ms` is the receiver's clock and `self` is the peer-supplied value, not a join
+    /// result.
+    /// Post: `Ok` implies the entry is live, its bound and every version it carries are within
+    /// the receiver's tolerance of `now_ms`, and every payload is within the size bound. The
+    /// version bound keeps a peer-supplied hybrid clock from pinning a key: an accepted floor
+    /// can exceed the receiver's clock only by the message skew tolerance, so honest writers
+    /// issued after that tolerance elapses dominate it again.
+    pub fn validate_admissible_at(&self, now_ms: u128) -> Result<()> {
+        if !self.is_live_at(now_ms) {
+            return Err(Error::EntryNotLive);
+        }
+        let lifetime_bound = now_ms
+            .saturating_add(u128::from(MAX_TTL_MS))
+            .saturating_add(TS_OFFSET_TOLERANCE_MS);
+        if self.expires_at_ms > Some(lifetime_bound) {
+            return Err(Error::EntryLifetimeExceedsMax);
+        }
+        let clock_bound = now_ms.saturating_add(TS_OFFSET_TOLERANCE_MS);
+        if self
+            .versions()
+            .any(|version| version.logical_time_ms > clock_bound)
+        {
+            return Err(Error::EntryVersionAheadOfClock);
+        }
+        if !self.data.iter().all(payload_within_bound) {
+            return Err(Error::EntryPayloadExceedsMax);
+        }
+        Ok(())
+    }
+}
+
+impl EntryOperation {
+    /// Admission law for the delta this operation carries.
+    pub fn validate_admissible_at(&self, now_ms: u128) -> Result<()> {
+        self.entry().validate_admissible_at(now_ms)
+    }
+}

--- a/crates/core/src/dht/entry/retention.rs
+++ b/crates/core/src/dht/entry/retention.rs
@@ -100,6 +100,16 @@ impl Entry {
     /// a key: an accepted floor can exceed the receiver's clock only by the message skew
     /// tolerance, so honest writers issued after that tolerance elapses dominate it again.
     pub fn validate_admissible_at(&self, now_ms: u128, network_id: u32) -> Result<()> {
+        self.validate_bounds_at(now_ms)?;
+        match self.kind {
+            EntryKind::Data => Ok(()),
+            EntryKind::RelayMessage => self.validate_inbox_witness(now_ms, network_id),
+        }
+    }
+
+    /// The kind-independent part of the admission law: liveness, retention bound, version
+    /// clocks, and payload sizes.
+    pub(crate) fn validate_bounds_at(&self, now_ms: u128) -> Result<()> {
         if !self.is_live_at(now_ms) {
             return Err(Error::EntryNotLive);
         }
@@ -119,10 +129,7 @@ impl Entry {
         if !self.data.iter().all(payload_within_bound) {
             return Err(Error::EntryPayloadExceedsMax);
         }
-        match self.kind {
-            EntryKind::Data => Ok(()),
-            EntryKind::RelayMessage => self.validate_inbox_witness(now_ms, network_id),
-        }
+        Ok(())
     }
 }
 

--- a/crates/core/src/dht/entry/retention.rs
+++ b/crates/core/src/dht/entry/retention.rs
@@ -12,6 +12,10 @@
 //! - Join: the bound of a join is the `max` of the bounds, with `None < Some(_)`. `max` is
 //!   idempotent, commutative, and associative, so the product of the payload lattice and the
 //!   bound lattice is again a join-semilattice.
+//! - Removal: a tombstone leaves the carrier's bound unchanged. Retention is refreshed by what
+//!   is held (adds, overwrites, compaction floors), never by a removal, so a carrier drained to
+//!   tombstones expires when its last hold would have instead of outliving it by the
+//!   removal's own bound.
 //! - Liveness: `is_live_at(now) ⟺ expires_at_ms = Some(t) ∧ now < t`. An unstamped value is
 //!   not live, so a stored value that predates retention is retired on its next read.
 //! - Admission: a value is admissible at `now` in overlay `n` iff it is live, its bound is at

--- a/crates/core/src/dht/entry/retention.rs
+++ b/crates/core/src/dht/entry/retention.rs
@@ -17,14 +17,15 @@
 //! - Admission: a value is admissible at `now` in overlay `n` iff it is live, its bound is at
 //!   most `now + kind.max_lifetime_ms() + TS_OFFSET_TOLERANCE_MS`, every version it carries has
 //!   a logical time at most `now + TS_OFFSET_TOLERANCE_MS`, every payload is at most
-//!   `ENTRY_PAYLOAD_MAX_BYTES`, and its kind's witness holds (a relay inbox admits only messages
-//!   addressed to its owner and signed inside `n`). Admission is a predicate on the
+//!   `ENTRY_PAYLOAD_MAX_BYTES`, and its kind's witness holds (a relay inbox admits only held
+//!   messages addressed to its recipient, attested by their holder and verified as of the hold
+//!   instant inside `n`; see the `inbox` module). Admission is a predicate on the
 //!   peer-supplied delta, never on the receiver's join result, so locally derived versions (a
 //!   compaction floor bumped by one step) are never mistaken for a peer clock running ahead.
 //!
 //! Size: the payload predicate is element-intrinsic, so filtering by it commutes with union
-//! and the carrier stays a lattice; together with the count cap `ENTRY_DATA_MAX_LEN` it bounds
-//! a carrier at `ENTRY_DATA_MAX_LEN × ENTRY_PAYLOAD_MAX_BYTES` encoded bytes. A byte budget
+//! and the carrier stays a lattice; together with the count cap `kind.max_data_len()` it bounds
+//! a carrier at `max_data_len × ENTRY_PAYLOAD_MAX_BYTES` encoded bytes. A byte budget
 //! over the whole carrier is deliberately not used: "the newest payloads that fit" depends on
 //! the sizes of payloads a replica may already have dropped, so it is not a lattice morphism
 //! and replicas would diverge.
@@ -120,7 +121,7 @@ impl Entry {
         }
         match self.kind {
             EntryKind::Data => Ok(()),
-            EntryKind::RelayMessage => self.validate_inbox_witness(network_id),
+            EntryKind::RelayMessage => self.validate_inbox_witness(now_ms, network_id),
         }
     }
 }

--- a/crates/core/src/dht/entry/retention.rs
+++ b/crates/core/src/dht/entry/retention.rs
@@ -2,22 +2,25 @@
 //!
 //! State: every entry carries `expires_at_ms : Option<u128>`, the instant after which it must
 //! no longer be served or replicated. The origin stamps it at the operation boundary; every
-//! receiver bounds it at admission.
+//! receiver bounds it at admission. Both bounds are a property of the entry kind: a data topic
+//! is refreshed by its publishers, while a relay inbox must outlive the absence of the peer it
+//! is kept for (see the `inbox` module).
 //!
 //! Laws:
-//! - Stamping: `stamped(now)` maps an absent bound to `now + DEFAULT_TTL_MS` and preserves a
-//!   present one, so a forwarded operation keeps the origin's bound.
+//! - Stamping: `stamped(now)` maps an absent bound to `now + kind.default_lifetime_ms()` and
+//!   preserves a present one, so a forwarded operation keeps the origin's bound.
 //! - Join: the bound of a join is the `max` of the bounds, with `None < Some(_)`. `max` is
 //!   idempotent, commutative, and associative, so the product of the payload lattice and the
 //!   bound lattice is again a join-semilattice.
 //! - Liveness: `is_live_at(now) ⟺ expires_at_ms = Some(t) ∧ now < t`. An unstamped value is
 //!   not live, so a stored value that predates retention is retired on its next read.
-//! - Admission: a value is admissible at `now` iff it is live, its bound is at most
-//!   `now + MAX_TTL_MS + TS_OFFSET_TOLERANCE_MS`, every version it carries has a logical time at
-//!   most `now + TS_OFFSET_TOLERANCE_MS`, and every payload is at most
-//!   `ENTRY_PAYLOAD_MAX_BYTES`. Admission is a predicate on the peer-supplied delta, never on
-//!   the receiver's join result, so locally derived versions (a compaction floor bumped by one
-//!   step) are never mistaken for a peer clock running ahead.
+//! - Admission: a value is admissible at `now` in overlay `n` iff it is live, its bound is at
+//!   most `now + kind.max_lifetime_ms() + TS_OFFSET_TOLERANCE_MS`, every version it carries has
+//!   a logical time at most `now + TS_OFFSET_TOLERANCE_MS`, every payload is at most
+//!   `ENTRY_PAYLOAD_MAX_BYTES`, and its kind's witness holds (a relay inbox admits only messages
+//!   addressed to its owner and signed inside `n`). Admission is a predicate on the
+//!   peer-supplied delta, never on the receiver's join result, so locally derived versions (a
+//!   compaction floor bumped by one step) are never mistaken for a peer clock running ahead.
 //!
 //! Size: the payload predicate is element-intrinsic, so filtering by it commutes with union
 //! and the carrier stays a lattice; together with the count cap `ENTRY_DATA_MAX_LEN` it bounds
@@ -27,14 +30,35 @@
 //! and replicas would diverge.
 
 use super::Entry;
+use super::EntryKind;
 use super::EntryOperation;
+use crate::consts::DEFAULT_RELAY_INBOX_TTL_MS;
 use crate::consts::DEFAULT_TTL_MS;
 use crate::consts::ENTRY_PAYLOAD_MAX_BYTES;
+use crate::consts::MAX_RELAY_INBOX_TTL_MS;
 use crate::consts::MAX_TTL_MS;
 use crate::consts::TS_OFFSET_TOLERANCE_MS;
 use crate::error::Error;
 use crate::error::Result;
 use crate::message::Encoded;
+
+impl EntryKind {
+    /// Retention stamped at the operation boundary when the origin left it absent.
+    pub const fn default_lifetime_ms(self) -> u64 {
+        match self {
+            EntryKind::Data => DEFAULT_TTL_MS,
+            EntryKind::RelayMessage => DEFAULT_RELAY_INBOX_TTL_MS,
+        }
+    }
+
+    /// The longest retention a receiver admits for this kind.
+    pub const fn max_lifetime_ms(self) -> u64 {
+        match self {
+            EntryKind::Data => MAX_TTL_MS,
+            EntryKind::RelayMessage => MAX_RELAY_INBOX_TTL_MS,
+        }
+    }
+}
 
 /// Whether one encoded payload is within the per-payload size bound.
 fn payload_within_bound(value: &Encoded) -> bool {
@@ -45,7 +69,8 @@ impl Entry {
     /// Stamp the retention bound when the origin left it absent.
     pub(super) fn ensure_lifetime_from(mut self, now_ms: u128) -> Self {
         if self.expires_at_ms.is_none() {
-            self.expires_at_ms = Some(now_ms.saturating_add(u128::from(DEFAULT_TTL_MS)));
+            self.expires_at_ms =
+                Some(now_ms.saturating_add(u128::from(self.kind.default_lifetime_ms())));
         }
         self
     }
@@ -66,19 +91,19 @@ impl Entry {
 
     /// Admission law for a delta supplied by a peer (see the module documentation).
     ///
-    /// Pre: `now_ms` is the receiver's clock and `self` is the peer-supplied value, not a join
-    /// result.
+    /// Pre: `now_ms` is the receiver's clock, `network_id` its overlay, and `self` is the
+    /// peer-supplied value, not a join result.
     /// Post: `Ok` implies the entry is live, its bound and every version it carries are within
-    /// the receiver's tolerance of `now_ms`, and every payload is within the size bound. The
-    /// version bound keeps a peer-supplied hybrid clock from pinning a key: an accepted floor
-    /// can exceed the receiver's clock only by the message skew tolerance, so honest writers
-    /// issued after that tolerance elapses dominate it again.
-    pub fn validate_admissible_at(&self, now_ms: u128) -> Result<()> {
+    /// the receiver's tolerance of `now_ms`, every payload is within the size bound, and the
+    /// kind's witness holds. The version bound keeps a peer-supplied hybrid clock from pinning
+    /// a key: an accepted floor can exceed the receiver's clock only by the message skew
+    /// tolerance, so honest writers issued after that tolerance elapses dominate it again.
+    pub fn validate_admissible_at(&self, now_ms: u128, network_id: u32) -> Result<()> {
         if !self.is_live_at(now_ms) {
             return Err(Error::EntryNotLive);
         }
         let lifetime_bound = now_ms
-            .saturating_add(u128::from(MAX_TTL_MS))
+            .saturating_add(u128::from(self.kind.max_lifetime_ms()))
             .saturating_add(TS_OFFSET_TOLERANCE_MS);
         if self.expires_at_ms > Some(lifetime_bound) {
             return Err(Error::EntryLifetimeExceedsMax);
@@ -93,13 +118,16 @@ impl Entry {
         if !self.data.iter().all(payload_within_bound) {
             return Err(Error::EntryPayloadExceedsMax);
         }
-        Ok(())
+        match self.kind {
+            EntryKind::Data => Ok(()),
+            EntryKind::RelayMessage => self.validate_inbox_witness(network_id),
+        }
     }
 }
 
 impl EntryOperation {
     /// Admission law for the delta this operation carries.
-    pub fn validate_admissible_at(&self, now_ms: u128) -> Result<()> {
-        self.entry().validate_admissible_at(now_ms)
+    pub fn validate_admissible_at(&self, now_ms: u128, network_id: u32) -> Result<()> {
+        self.entry().validate_admissible_at(now_ms, network_id)
     }
 }

--- a/crates/core/src/dht/entry/test_entry.rs
+++ b/crates/core/src/dht/entry/test_entry.rs
@@ -772,6 +772,84 @@ fn test_join_takes_the_later_retention_bound() -> Result<()> {
     Ok(())
 }
 
+/// Retention policy is a property of the kind: relay entries (an offline destination's
+/// inbox) are stamped with and admitted up to their own, longer, bounds.
+#[test]
+fn test_relay_entries_use_their_own_retention_policy() -> Result<()> {
+    let relay = relay_delta(Did::from(7u32), "m1", 1)?;
+    let stamped = EntryOperation::Extend(relay.clone())
+        .stamped_at(NOW_MS, actor())?
+        .into_entry();
+    assert_eq!(
+        stamped.expires_at_ms,
+        Some(NOW_MS + u128::from(DEFAULT_RELAY_ENTRY_TTL_MS))
+    );
+    assert!(u128::from(DEFAULT_RELAY_ENTRY_TTL_MS) > u128::from(MAX_TTL_MS));
+
+    let relay_limit = NOW_MS + u128::from(MAX_RELAY_ENTRY_TTL_MS) + TS_OFFSET_TOLERANCE_MS;
+    bounded(relay.clone(), relay_limit).validate_admissible_at(NOW_MS)?;
+    assert!(matches!(
+        bounded(relay, relay_limit + 1).validate_admissible_at(NOW_MS),
+        Err(Error::EntryLifetimeExceedsMax)
+    ));
+
+    let data_limit = NOW_MS + u128::from(MAX_TTL_MS) + TS_OFFSET_TOLERANCE_MS;
+    assert!(matches!(
+        bounded(data_delta("topic", "value", 1)?, data_limit + 1).validate_admissible_at(NOW_MS),
+        Err(Error::EntryLifetimeExceedsMax)
+    ));
+    Ok(())
+}
+
+/// Byte budget law: the retained suffix is the newest payloads that fit the kind's byte budget,
+/// so a busy relay inbox keeps only its most recent messages, and a payload that alone exceeds
+/// the budget is dropped rather than retained over it.
+#[test]
+fn test_byte_budget_keeps_newest_payloads() -> Result<()> {
+    let did = Did::from(7u32);
+    let unit = RELAY_INBOX_MAX_BYTES / 4;
+    let raw_message =
+        |counter: u32, filler: usize| Encoded::from(format!("{counter}:{}", "x".repeat(filler)));
+    let retained_bytes = |entry: &Entry| {
+        entry
+            .data
+            .iter()
+            .map(|value| value.value().len())
+            .sum::<usize>()
+    };
+    let prefixes = |entry: &Entry| {
+        entry
+            .data
+            .iter()
+            .filter_map(|value| value.value().split(':').next().map(str::to_owned))
+            .collect::<Vec<_>>()
+    };
+
+    let mut inbox = relay_entry();
+    for counter in 1..=5u32 {
+        let delta = Entry::new(
+            did,
+            vec![raw_message(counter, unit)],
+            EntryKind::RelayMessage,
+        )
+        .stamp_delta(version(counter))?;
+        inbox = inbox.join(delta)?;
+    }
+    assert!(retained_bytes(&inbox) <= RELAY_INBOX_MAX_BYTES);
+    assert_eq!(prefixes(&inbox), ["3", "4", "5"]);
+
+    let oversize = Entry::new(
+        did,
+        vec![raw_message(9, RELAY_INBOX_MAX_BYTES)],
+        EntryKind::RelayMessage,
+    )
+    .stamp_delta(version(9))?;
+    let joined = inbox.join(oversize)?;
+    assert!(retained_bytes(&joined) <= RELAY_INBOX_MAX_BYTES);
+    assert!(!prefixes(&joined).contains(&"9".to_owned()));
+    Ok(())
+}
+
 /// Law: an entry is live exactly when it carries a bound strictly after `now`.
 #[test]
 fn test_is_live_at_requires_a_bound_after_now() -> Result<()> {

--- a/crates/core/src/dht/entry/test_entry.rs
+++ b/crates/core/src/dht/entry/test_entry.rs
@@ -3,6 +3,10 @@ use num_bigint::BigUint;
 use super::*;
 use crate::algebra::assert_join_semilattice_laws;
 use crate::algebra::assert_strong_eventual_consistency;
+use crate::consts::DEFAULT_TTL_MS;
+use crate::consts::ENTRY_PAYLOAD_MAX_BYTES;
+use crate::consts::MAX_TTL_MS;
+use crate::consts::TS_OFFSET_TOLERANCE_MS;
 use crate::ecc::SecretKey;
 use crate::message::Message;
 use crate::message::MessageSigner;
@@ -330,7 +334,7 @@ fn test_forwarded_overwrite_witness_is_not_reissued_after_local_floor() -> Resul
     let current = overwrite_delta("topic", "current", 10)?;
     let stale_forwarded = overwrite_delta("topic", "stale", 1)?;
 
-    let updated = current.overwrite(stale_forwarded, actor())?;
+    let updated = current.overwrite(NOW_MS, stale_forwarded, actor())?;
 
     assert_eq!(decode_entry_data(&updated)?, vec![String::from("current")]);
     Ok(())
@@ -340,7 +344,7 @@ fn test_forwarded_overwrite_witness_is_not_reissued_after_local_floor() -> Resul
 fn test_overwrite_replaces_data_for_same_data_entry() -> Result<()> {
     let entry = data_entry("topic", "old")?;
     let other = data_entry("topic", "new")?;
-    let updated = entry.overwrite(other, actor())?;
+    let updated = entry.overwrite(NOW_MS, other, actor())?;
     assert_eq!(decode_entry_data(&updated)?, vec![String::from("new")]);
     Ok(())
 }
@@ -351,7 +355,7 @@ fn test_overwrite_rejects_non_data_entry() -> Result<()> {
     let other = entry.clone();
 
     assert!(matches!(
-        entry.overwrite(other, actor()),
+        entry.overwrite(NOW_MS, other, actor()),
         Err(Error::EntryNotOverwritable)
     ));
     Ok(())
@@ -364,7 +368,7 @@ fn test_overwrite_rejects_kind_mismatch() -> Result<()> {
     other.kind = EntryKind::RelayMessage;
 
     assert!(matches!(
-        entry.overwrite(other, actor()),
+        entry.overwrite(NOW_MS, other, actor()),
         Err(Error::EntryKindNotEqual)
     ));
     Ok(())
@@ -376,7 +380,7 @@ fn test_overwrite_rejects_key_mismatch() -> Result<()> {
     let other = data_entry("topic-b", "new")?;
 
     assert!(matches!(
-        entry.overwrite(other, actor()),
+        entry.overwrite(NOW_MS, other, actor()),
         Err(Error::EntryDidNotEqual)
     ));
     Ok(())
@@ -387,7 +391,7 @@ fn test_overwrite_caps_payloads_larger_than_max_len() -> Result<()> {
     let overflow = 3;
     let (incoming, incoming_count) = overflowing_data_entry("topic", overflow)?;
     let entry = data_entry("topic", "base")?;
-    let updated = entry.overwrite(incoming, actor())?;
+    let updated = entry.overwrite(NOW_MS, incoming, actor())?;
     assert_entry_keeps_recent_overflow(&updated, incoming_count, overflow)
 }
 
@@ -395,7 +399,7 @@ fn test_overwrite_caps_payloads_larger_than_max_len() -> Result<()> {
 fn test_extend_appends_data_for_same_entry() -> Result<()> {
     let entry = data_entry("topic", "first")?;
     let other = data_entry("topic", "second")?;
-    let updated = entry.extend(other, actor())?;
+    let updated = entry.extend(NOW_MS, other, actor())?;
     assert_eq!(decode_entry_data(&updated)?, vec![
         String::from("first"),
         String::from("second")
@@ -409,14 +413,14 @@ fn test_extend_trims_oldest_items_at_max_len() -> Result<()> {
     for i in 1..ENTRY_DATA_MAX_LEN {
         let data = format!("test{i}");
         let other = data_entry("topic", &data)?;
-        entry = entry.extend(other, actor())?;
+        entry = entry.extend(NOW_MS, other, actor())?;
         assert_eq!(entry.data.len(), i + 1);
     }
 
     for i in ENTRY_DATA_MAX_LEN..ENTRY_DATA_MAX_LEN + 10 {
         let data = format!("test{i}");
         let other = data_entry("topic", &data)?;
-        entry = entry.extend(other, actor())?;
+        entry = entry.extend(NOW_MS, other, actor())?;
         assert_eq!(entry.data.len(), ENTRY_DATA_MAX_LEN);
         let decoded = decode_entry_data(&entry)?;
         assert_eq!(
@@ -433,7 +437,7 @@ fn test_extend_caps_incoming_payloads_larger_than_max_len() -> Result<()> {
     let overflow = 3;
     let (incoming, incoming_count) = overflowing_data_entry("topic", overflow)?;
     let entry = data_entry("topic", "base")?;
-    let updated = entry.extend(incoming, actor())?;
+    let updated = entry.extend(NOW_MS, incoming, actor())?;
     assert_entry_keeps_recent_overflow(&updated, incoming_count, overflow)
 }
 
@@ -443,7 +447,7 @@ fn test_extend_rejects_non_data_entry() -> Result<()> {
     let other = entry.clone();
 
     assert!(matches!(
-        entry.extend(other, actor()),
+        entry.extend(NOW_MS, other, actor()),
         Err(Error::EntryNotAppendable)
     ));
     Ok(())
@@ -452,10 +456,10 @@ fn test_extend_rejects_non_data_entry() -> Result<()> {
 #[test]
 fn test_touch_moves_existing_items_to_end_once() -> Result<()> {
     let entry = data_entry("topic", "a")?
-        .extend(data_entry("topic", "b")?, actor())?
-        .extend(data_entry("topic", "c")?, actor())?;
+        .extend(NOW_MS, data_entry("topic", "b")?, actor())?
+        .extend(NOW_MS, data_entry("topic", "c")?, actor())?;
     let touched = data_entry("topic", "b")?;
-    let updated = entry.touch(touched, actor())?;
+    let updated = entry.touch(NOW_MS, touched, actor())?;
     assert_eq!(decode_entry_data(&updated)?, vec![
         String::from("a"),
         String::from("c"),
@@ -468,9 +472,9 @@ fn test_touch_moves_existing_items_to_end_once() -> Result<()> {
 fn test_touch_trims_oldest_non_touched_items_at_max_len() -> Result<()> {
     let mut entry = data_entry("topic", "test0")?;
     for i in 1..ENTRY_DATA_MAX_LEN {
-        entry = entry.extend(data_entry("topic", &format!("test{i}"))?, actor())?;
+        entry = entry.extend(NOW_MS, data_entry("topic", &format!("test{i}"))?, actor())?;
     }
-    let updated = entry.touch(data_entry("topic", "test0")?, actor())?;
+    let updated = entry.touch(NOW_MS, data_entry("topic", "test0")?, actor())?;
     assert_eq!(updated.data.len(), ENTRY_DATA_MAX_LEN);
     let decoded = decode_entry_data(&updated)?;
     assert_eq!(decoded.first(), Some(&String::from("test1")));
@@ -532,7 +536,7 @@ fn test_data_compaction_prunes_tombstones_and_preserves_current_live_payloads() 
     ]);
     assert!(!carrier.crdt.tombstones.is_empty());
 
-    let compacted = carrier.compact_data(data_entry("topic", "first")?, actor())?;
+    let compacted = carrier.compact_data(NOW_MS, data_entry("topic", "first")?, actor())?;
 
     assert_entry_data_set(&compacted, &["second", "concurrent"])?;
     assert!(compacted.crdt.register.is_some());
@@ -554,10 +558,10 @@ fn test_data_compaction_uses_one_shared_floor_for_divergent_replicas() -> Result
         .tombstone(first.clone())?;
     let left = tombstoned.clone().join(left_live)?;
     let right = tombstoned.join(right_live)?;
-    let op = EntryOperation::CompactData(data_entry("topic", "first")?).stamped(actor())?;
+    let op = EntryOperation::CompactData(data_entry("topic", "first")?).stamped(NOW_MS, actor())?;
 
-    let compacted_left = left.operate(op.clone(), Did::from(7u32))?;
-    let compacted_right = right.operate(op, Did::from(8u32))?;
+    let compacted_left = left.operate(NOW_MS, op.clone(), Did::from(7u32))?;
+    let compacted_right = right.operate(NOW_MS, op, Did::from(8u32))?;
 
     assert_eq!(compacted_left.crdt.register, compacted_right.crdt.register);
     let joined = compacted_left.join(compacted_right)?;
@@ -580,10 +584,10 @@ fn test_data_compaction_keeps_value_dots_stable_across_replica_positions() -> Re
         .tombstone(first.clone())?;
     let left = tombstoned.clone().join(left_live)?.join(shared.clone())?;
     let right = tombstoned.join(shared)?;
-    let op = EntryOperation::CompactData(data_entry("topic", "first")?).stamped(actor())?;
+    let op = EntryOperation::CompactData(data_entry("topic", "first")?).stamped(NOW_MS, actor())?;
 
-    let compacted_left = left.operate(op.clone(), Did::from(7u32))?;
-    let compacted_right = right.operate(op, Did::from(8u32))?;
+    let compacted_left = left.operate(NOW_MS, op.clone(), Did::from(7u32))?;
+    let compacted_right = right.operate(NOW_MS, op, Did::from(8u32))?;
     let joined = compacted_left.join(compacted_right.clone())?;
     assert_entry_data_set(&joined, &["left-live", "shared"])?;
 
@@ -602,7 +606,7 @@ fn test_delayed_data_compaction_preserves_post_floor_writes() -> Result<()> {
         .join(first.clone())?
         .join(second)?
         .tombstone(first.clone())?;
-    let op = EntryOperation::CompactData(data_entry("topic", "first")?).stamped(actor())?;
+    let op = EntryOperation::CompactData(data_entry("topic", "first")?).stamped(NOW_MS, actor())?;
     let floor = compact_operation_floor(&op)?;
     let readded_first = data_entry("topic", "first")?.stamp_delta(version_after(floor, 101)?)?;
     let late_live = data_entry("topic", "late-live")?.stamp_delta(version_after(floor, 102)?)?;
@@ -610,7 +614,7 @@ fn test_delayed_data_compaction_preserves_post_floor_writes() -> Result<()> {
     let late_live_dot = entry_dot_for_value(&late_live, "late-live")?;
     let with_post_floor_writes = tombstoned.join(readded_first)?.join(late_live)?;
 
-    let compacted = with_post_floor_writes.operate(op, Did::from(7u32))?;
+    let compacted = with_post_floor_writes.operate(NOW_MS, op, Did::from(7u32))?;
 
     assert_entry_data_set(&compacted, &["first", "second", "late-live"])?;
     assert_eq!(entry_dot_for_value(&compacted, "first")?, readded_first_dot);
@@ -622,7 +626,8 @@ fn test_delayed_data_compaction_preserves_post_floor_writes() -> Result<()> {
 
 #[test]
 fn test_delayed_data_compaction_preserves_newer_register_floor() -> Result<()> {
-    let op = EntryOperation::CompactData(data_entry("topic", "obsolete")?).stamped(actor())?;
+    let op =
+        EntryOperation::CompactData(data_entry("topic", "obsolete")?).stamped(NOW_MS, actor())?;
     let compact_floor = compact_operation_floor(&op)?;
     let stale_after_compact =
         data_entry("topic", "stale")?.stamp_delta(version_after(compact_floor, 1)?)?;
@@ -639,7 +644,7 @@ fn test_delayed_data_compaction_preserves_newer_register_floor() -> Result<()> {
     assert_entry_data_set(&state, &["reset"])?;
     assert_eq!(state.crdt.register, Some(reset_floor));
 
-    let compacted = state.operate(op, Did::from(7u32))?;
+    let compacted = state.operate(NOW_MS, op, Did::from(7u32))?;
 
     assert_entry_data_set(&compacted, &["reset"])?;
     assert_eq!(compacted.crdt.register, Some(reset_floor));
@@ -653,7 +658,7 @@ fn test_touch_caps_incoming_payloads_larger_than_max_len() -> Result<()> {
     let overflow = 3;
     let (incoming, incoming_count) = overflowing_data_entry("topic", overflow)?;
     let entry = data_entry("topic", "base")?;
-    let updated = entry.touch(incoming, actor())?;
+    let updated = entry.touch(NOW_MS, incoming, actor())?;
     assert_entry_keeps_recent_overflow(&updated, incoming_count, overflow)
 }
 
@@ -726,25 +731,13 @@ fn test_stamped_assigns_default_lifetime_and_preserves_existing() -> Result<()> 
         EntryOperation::CompactData(unstamped.clone()),
     ];
     for op in ops {
-        let stamped = op.stamped_at(NOW_MS, actor())?;
-        assert_eq!(stamped.into_entry().expires_at_ms, Some(expected));
+        let stamped = op.stamped(NOW_MS, actor())?;
+        assert_eq!(stamped.entry().expires_at_ms, Some(expected));
     }
 
-    let forwarded = EntryOperation::Extend(bounded(unstamped, 7)).stamped_at(NOW_MS, actor())?;
-    assert_eq!(forwarded.into_entry().expires_at_ms, Some(7));
+    let forwarded = EntryOperation::Extend(bounded(unstamped, 7)).stamped(NOW_MS, actor())?;
+    assert_eq!(forwarded.entry().expires_at_ms, Some(7));
     Ok(())
-}
-
-impl EntryOperation {
-    fn into_entry(self) -> Entry {
-        match self {
-            EntryOperation::Overwrite(entry)
-            | EntryOperation::Extend(entry)
-            | EntryOperation::Touch(entry)
-            | EntryOperation::Tombstone(entry)
-            | EntryOperation::CompactData(entry) => entry,
-        }
-    }
 }
 
 /// Law: the retention bound joins by `max`, commutatively, for data and relay carriers and for
@@ -764,7 +757,7 @@ fn test_join_takes_the_later_retention_bound() -> Result<()> {
     assert_eq!(tombstoned.expires_at_ms, Some(30));
 
     let compacted =
-        earlier.compact_data_at(NOW_MS, bounded(data_entry("topic", "a")?, 40), actor())?;
+        earlier.compact_data(NOW_MS, bounded(data_entry("topic", "a")?, 40), actor())?;
     assert_eq!(compacted.expires_at_ms, Some(40));
 
     let unbounded_join = data_delta("topic", "c", 3)?.join(earlier.clone())?;
@@ -772,81 +765,30 @@ fn test_join_takes_the_later_retention_bound() -> Result<()> {
     Ok(())
 }
 
-/// Retention policy is a property of the kind: relay entries (an offline destination's
-/// inbox) are stamped with and admitted up to their own, longer, bounds.
+/// Admission law: every payload is at most `ENTRY_PAYLOAD_MAX_BYTES` encoded bytes. The bound is
+/// per element, so the carrier stays a lattice and its size is bounded by the count cap.
 #[test]
-fn test_relay_entries_use_their_own_retention_policy() -> Result<()> {
-    let relay = relay_delta(Did::from(7u32), "m1", 1)?;
-    let stamped = EntryOperation::Extend(relay.clone())
-        .stamped_at(NOW_MS, actor())?
-        .into_entry();
-    assert_eq!(
-        stamped.expires_at_ms,
-        Some(NOW_MS + u128::from(DEFAULT_RELAY_ENTRY_TTL_MS))
+fn test_admission_bounds_every_payload_size() -> Result<()> {
+    let did = Entry::gen_did("topic")?;
+    let at_bound = Entry::new(
+        did,
+        vec![Encoded::from("x".repeat(ENTRY_PAYLOAD_MAX_BYTES))],
+        EntryKind::Data,
     );
-    assert!(u128::from(DEFAULT_RELAY_ENTRY_TTL_MS) > u128::from(MAX_TTL_MS));
-
-    let relay_limit = NOW_MS + u128::from(MAX_RELAY_ENTRY_TTL_MS) + TS_OFFSET_TOLERANCE_MS;
-    bounded(relay.clone(), relay_limit).validate_admissible_at(NOW_MS)?;
-    assert!(matches!(
-        bounded(relay, relay_limit + 1).validate_admissible_at(NOW_MS),
-        Err(Error::EntryLifetimeExceedsMax)
-    ));
-
-    let data_limit = NOW_MS + u128::from(MAX_TTL_MS) + TS_OFFSET_TOLERANCE_MS;
-    assert!(matches!(
-        bounded(data_delta("topic", "value", 1)?, data_limit + 1).validate_admissible_at(NOW_MS),
-        Err(Error::EntryLifetimeExceedsMax)
-    ));
-    Ok(())
-}
-
-/// Byte budget law: the retained suffix is the newest payloads that fit the kind's byte budget,
-/// so a busy relay inbox keeps only its most recent messages, and a payload that alone exceeds
-/// the budget is dropped rather than retained over it.
-#[test]
-fn test_byte_budget_keeps_newest_payloads() -> Result<()> {
-    let did = Did::from(7u32);
-    let unit = RELAY_INBOX_MAX_BYTES / 4;
-    let raw_message =
-        |counter: u32, filler: usize| Encoded::from(format!("{counter}:{}", "x".repeat(filler)));
-    let retained_bytes = |entry: &Entry| {
-        entry
-            .data
-            .iter()
-            .map(|value| value.value().len())
-            .sum::<usize>()
-    };
-    let prefixes = |entry: &Entry| {
-        entry
-            .data
-            .iter()
-            .filter_map(|value| value.value().split(':').next().map(str::to_owned))
-            .collect::<Vec<_>>()
-    };
-
-    let mut inbox = relay_entry();
-    for counter in 1..=5u32 {
-        let delta = Entry::new(
-            did,
-            vec![raw_message(counter, unit)],
-            EntryKind::RelayMessage,
-        )
-        .stamp_delta(version(counter))?;
-        inbox = inbox.join(delta)?;
-    }
-    assert!(retained_bytes(&inbox) <= RELAY_INBOX_MAX_BYTES);
-    assert_eq!(prefixes(&inbox), ["3", "4", "5"]);
+    bounded(at_bound, NOW_MS + 1_000).validate_admissible_at(NOW_MS)?;
 
     let oversize = Entry::new(
         did,
-        vec![raw_message(9, RELAY_INBOX_MAX_BYTES)],
-        EntryKind::RelayMessage,
-    )
-    .stamp_delta(version(9))?;
-    let joined = inbox.join(oversize)?;
-    assert!(retained_bytes(&joined) <= RELAY_INBOX_MAX_BYTES);
-    assert!(!prefixes(&joined).contains(&"9".to_owned()));
+        vec![
+            Encoded::from("small"),
+            Encoded::from("x".repeat(ENTRY_PAYLOAD_MAX_BYTES + 1)),
+        ],
+        EntryKind::Data,
+    );
+    assert!(matches!(
+        bounded(oversize, NOW_MS + 1_000).validate_admissible_at(NOW_MS),
+        Err(Error::EntryPayloadExceedsMax)
+    ));
     Ok(())
 }
 

--- a/crates/core/src/dht/entry/test_entry.rs
+++ b/crates/core/src/dht/entry/test_entry.rs
@@ -5,7 +5,10 @@ use crate::consts::DEFAULT_TTL_MS;
 use crate::consts::ENTRY_PAYLOAD_MAX_BYTES;
 use crate::consts::MAX_TTL_MS;
 use crate::consts::TS_OFFSET_TOLERANCE_MS;
+use crate::tests::with_retention;
 use crate::tests::TEST_NETWORK_ID;
+
+const NOW_MS: u128 = 1_700_000_000_000;
 
 fn encoded(value: &str) -> Result<Encoded> {
     value.to_string().encode()
@@ -682,15 +685,11 @@ fn test_affine_preserves_payload_and_kind_while_rotating_keys() -> Result<()> {
     Ok(())
 }
 
-const NOW_MS: u128 = 1_700_000_000_000;
-
-fn bounded(mut entry: Entry, expires_at_ms: u128) -> Entry {
-    entry.expires_at_ms = Some(expires_at_ms);
-    entry
-}
-
 fn admissible_delta(topic: &str, value: &str, counter: u32) -> Result<Entry> {
-    Ok(bounded(data_delta(topic, value, counter)?, NOW_MS + 1_000))
+    Ok(with_retention(
+        data_delta(topic, value, counter)?,
+        NOW_MS + 1_000,
+    ))
 }
 
 fn version_at(logical_time_ms: u128) -> EntryVersion {
@@ -715,7 +714,8 @@ fn test_stamped_assigns_default_lifetime_and_preserves_existing() -> Result<()> 
         assert_eq!(stamped.entry().expires_at_ms, Some(expected));
     }
 
-    let forwarded = EntryOperation::Extend(bounded(unstamped, 7)).stamped(NOW_MS, actor())?;
+    let forwarded =
+        EntryOperation::Extend(with_retention(unstamped, 7)).stamped(NOW_MS, actor())?;
     assert_eq!(forwarded.entry().expires_at_ms, Some(7));
     Ok(())
 }
@@ -724,20 +724,23 @@ fn test_stamped_assigns_default_lifetime_and_preserves_existing() -> Result<()> 
 /// every operation that materializes a join.
 #[test]
 fn test_join_takes_the_later_retention_bound() -> Result<()> {
-    let earlier = bounded(data_delta("topic", "a", 1)?, 10);
-    let later = bounded(data_delta("topic", "b", 2)?, 20);
+    let earlier = with_retention(data_delta("topic", "a", 1)?, 10);
+    let later = with_retention(data_delta("topic", "b", 2)?, 20);
     assert_eq!(earlier.join(later.clone())?.expires_at_ms, Some(20));
     assert_eq!(later.join(earlier.clone())?.expires_at_ms, Some(20));
 
-    let relay_earlier = bounded(relay_delta(Did::from(7u32), "m1", 1)?, 10);
-    let relay_later = bounded(relay_delta(Did::from(7u32), "m2", 2)?, 20);
+    let relay_earlier = with_retention(relay_delta(Did::from(7u32), "m1", 1)?, 10);
+    let relay_later = with_retention(relay_delta(Did::from(7u32), "m2", 2)?, 20);
     assert_eq!(relay_earlier.join(relay_later)?.expires_at_ms, Some(20));
 
-    let tombstoned = earlier.tombstone(bounded(data_entry("topic", "a")?, 30))?;
+    let tombstoned = earlier.tombstone(with_retention(data_entry("topic", "a")?, 30))?;
     assert_eq!(tombstoned.expires_at_ms, Some(30));
 
-    let compacted =
-        earlier.compact_data(NOW_MS, bounded(data_entry("topic", "a")?, 40), actor())?;
+    let compacted = earlier.compact_data(
+        NOW_MS,
+        with_retention(data_entry("topic", "a")?, 40),
+        actor(),
+    )?;
     assert_eq!(compacted.expires_at_ms, Some(40));
 
     let unbounded_join = data_delta("topic", "c", 3)?.join(earlier.clone())?;
@@ -755,7 +758,7 @@ fn test_admission_bounds_every_payload_size() -> Result<()> {
         vec![Encoded::from("x".repeat(ENTRY_PAYLOAD_MAX_BYTES))],
         EntryKind::Data,
     );
-    bounded(at_bound, NOW_MS + 1_000).validate_admissible_at(NOW_MS, TEST_NETWORK_ID)?;
+    with_retention(at_bound, NOW_MS + 1_000).validate_admissible_at(NOW_MS, TEST_NETWORK_ID)?;
 
     let oversize = Entry::new(
         did,
@@ -766,7 +769,7 @@ fn test_admission_bounds_every_payload_size() -> Result<()> {
         EntryKind::Data,
     );
     assert!(matches!(
-        bounded(oversize, NOW_MS + 1_000).validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
+        with_retention(oversize, NOW_MS + 1_000).validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
         Err(Error::EntryPayloadExceedsMax)
     ));
     Ok(())
@@ -777,7 +780,7 @@ fn test_admission_bounds_every_payload_size() -> Result<()> {
 fn test_is_live_at_requires_a_bound_after_now() -> Result<()> {
     let unstamped = data_entry("topic", "value")?;
     assert!(!unstamped.is_live_at(0));
-    let stamped = bounded(unstamped, 5);
+    let stamped = with_retention(unstamped, 5);
     assert!(stamped.is_live_at(4));
     assert!(!stamped.is_live_at(5));
     Ok(())
@@ -794,15 +797,15 @@ fn test_admission_bounds_the_retention_bound() -> Result<()> {
         Err(Error::EntryNotLive)
     ));
     assert!(matches!(
-        bounded(delta.clone(), NOW_MS).validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
+        with_retention(delta.clone(), NOW_MS).validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
         Err(Error::EntryNotLive)
     ));
     assert!(matches!(
-        bounded(delta.clone(), limit + 1).validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
+        with_retention(delta.clone(), limit + 1).validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
         Err(Error::EntryLifetimeExceedsMax)
     ));
-    bounded(delta.clone(), limit).validate_admissible_at(NOW_MS, TEST_NETWORK_ID)?;
-    bounded(delta, NOW_MS + 1).validate_admissible_at(NOW_MS, TEST_NETWORK_ID)?;
+    with_retention(delta.clone(), limit).validate_admissible_at(NOW_MS, TEST_NETWORK_ID)?;
+    with_retention(delta, NOW_MS + 1).validate_admissible_at(NOW_MS, TEST_NETWORK_ID)?;
     Ok(())
 }
 

--- a/crates/core/src/dht/entry/test_entry.rs
+++ b/crates/core/src/dht/entry/test_entry.rs
@@ -5,7 +5,9 @@ use crate::algebra::assert_join_semilattice_laws;
 use crate::algebra::assert_strong_eventual_consistency;
 use crate::ecc::SecretKey;
 use crate::message::Message;
+use crate::message::MessageSigner;
 use crate::session::SessionSk;
+use crate::tests::TEST_NETWORK_ID;
 
 fn encoded(value: &str) -> Result<Encoded> {
     value.to_string().encode()
@@ -670,7 +672,12 @@ fn test_message_payload_entry_key_targets_successor_of_signer() -> Result<()> {
     let key = SecretKey::random();
     let session = SessionSk::new_with_seckey(&key)?;
     let signer: Did = key.address().into();
-    let payload = MessagePayload::new_send(Message::custom(b"relay")?, &session, signer, signer)?;
+    let payload = MessagePayload::new_send(
+        Message::custom(b"relay")?,
+        MessageSigner::new(&session, TEST_NETWORK_ID),
+        signer,
+        signer,
+    )?;
     let entry = Entry::try_from(payload)?;
     let expected = BigUint::from(signer) + BigUint::from(1u16);
     assert_eq!(entry.did, expected.into());
@@ -687,5 +694,179 @@ fn test_affine_preserves_payload_and_kind_while_rotating_keys() -> Result<()> {
         assert_eq!(rotated.data, entry.data);
         assert_eq!(rotated.kind, entry.kind);
     }
+    Ok(())
+}
+
+const NOW_MS: u128 = 1_700_000_000_000;
+
+fn bounded(mut entry: Entry, expires_at_ms: u128) -> Entry {
+    entry.expires_at_ms = Some(expires_at_ms);
+    entry
+}
+
+fn admissible_delta(topic: &str, value: &str, counter: u32) -> Result<Entry> {
+    Ok(bounded(data_delta(topic, value, counter)?, NOW_MS + 1_000))
+}
+
+fn version_at(logical_time_ms: u128) -> EntryVersion {
+    EntryVersion::new(logical_time_ms, actor(), Did::from(1u32))
+}
+
+/// Law: the operation boundary stamps `now + DEFAULT_TTL_MS` on every variant that carries no
+/// bound and preserves a bound the origin already stamped.
+#[test]
+fn test_stamped_assigns_default_lifetime_and_preserves_existing() -> Result<()> {
+    let expected = NOW_MS + u128::from(DEFAULT_TTL_MS);
+    let unstamped = data_entry("topic", "value")?;
+    let ops = [
+        EntryOperation::Overwrite(unstamped.clone()),
+        EntryOperation::Extend(unstamped.clone()),
+        EntryOperation::Touch(unstamped.clone()),
+        EntryOperation::Tombstone(unstamped.clone()),
+        EntryOperation::CompactData(unstamped.clone()),
+    ];
+    for op in ops {
+        let stamped = op.stamped_at(NOW_MS, actor())?;
+        assert_eq!(stamped.into_entry().expires_at_ms, Some(expected));
+    }
+
+    let forwarded = EntryOperation::Extend(bounded(unstamped, 7)).stamped_at(NOW_MS, actor())?;
+    assert_eq!(forwarded.into_entry().expires_at_ms, Some(7));
+    Ok(())
+}
+
+impl EntryOperation {
+    fn into_entry(self) -> Entry {
+        match self {
+            EntryOperation::Overwrite(entry)
+            | EntryOperation::Extend(entry)
+            | EntryOperation::Touch(entry)
+            | EntryOperation::Tombstone(entry)
+            | EntryOperation::CompactData(entry) => entry,
+        }
+    }
+}
+
+/// Law: the retention bound joins by `max`, commutatively, for data and relay carriers and for
+/// every operation that materializes a join.
+#[test]
+fn test_join_takes_the_later_retention_bound() -> Result<()> {
+    let earlier = bounded(data_delta("topic", "a", 1)?, 10);
+    let later = bounded(data_delta("topic", "b", 2)?, 20);
+    assert_eq!(earlier.join(later.clone())?.expires_at_ms, Some(20));
+    assert_eq!(later.join(earlier.clone())?.expires_at_ms, Some(20));
+
+    let relay_earlier = bounded(relay_delta(Did::from(7u32), "m1", 1)?, 10);
+    let relay_later = bounded(relay_delta(Did::from(7u32), "m2", 2)?, 20);
+    assert_eq!(relay_earlier.join(relay_later)?.expires_at_ms, Some(20));
+
+    let tombstoned = earlier.tombstone(bounded(data_entry("topic", "a")?, 30))?;
+    assert_eq!(tombstoned.expires_at_ms, Some(30));
+
+    let compacted =
+        earlier.compact_data_at(NOW_MS, bounded(data_entry("topic", "a")?, 40), actor())?;
+    assert_eq!(compacted.expires_at_ms, Some(40));
+
+    let unbounded_join = data_delta("topic", "c", 3)?.join(earlier.clone())?;
+    assert_eq!(unbounded_join.expires_at_ms, Some(10));
+    Ok(())
+}
+
+/// Law: an entry is live exactly when it carries a bound strictly after `now`.
+#[test]
+fn test_is_live_at_requires_a_bound_after_now() -> Result<()> {
+    let unstamped = data_entry("topic", "value")?;
+    assert!(!unstamped.is_live_at(0));
+    let stamped = bounded(unstamped, 5);
+    assert!(stamped.is_live_at(4));
+    assert!(!stamped.is_live_at(5));
+    Ok(())
+}
+
+/// Admission law: the bound must be live and at most `now + MAX_TTL_MS + TS_OFFSET_TOLERANCE_MS`.
+#[test]
+fn test_admission_bounds_the_retention_bound() -> Result<()> {
+    let limit = NOW_MS + u128::from(MAX_TTL_MS) + TS_OFFSET_TOLERANCE_MS;
+    let delta = data_delta("topic", "value", 1)?;
+
+    assert!(matches!(
+        delta.validate_admissible_at(NOW_MS),
+        Err(Error::EntryNotLive)
+    ));
+    assert!(matches!(
+        bounded(delta.clone(), NOW_MS).validate_admissible_at(NOW_MS),
+        Err(Error::EntryNotLive)
+    ));
+    assert!(matches!(
+        bounded(delta.clone(), limit + 1).validate_admissible_at(NOW_MS),
+        Err(Error::EntryLifetimeExceedsMax)
+    ));
+    bounded(delta.clone(), limit).validate_admissible_at(NOW_MS)?;
+    bounded(delta, NOW_MS + 1).validate_admissible_at(NOW_MS)?;
+    Ok(())
+}
+
+/// Admission law: every carried version (dots, tombstones, register) has a logical time at most
+/// `now + TS_OFFSET_TOLERANCE_MS`, so a peer-supplied `u128::MAX` floor cannot pin a key.
+#[test]
+fn test_admission_bounds_every_version_logical_time() -> Result<()> {
+    let clock_bound = NOW_MS + TS_OFFSET_TOLERANCE_MS;
+    let base = admissible_delta("topic", "value", 1)?;
+
+    let mut ahead_dot = base.clone();
+    ahead_dot.crdt.dots = vec![EntryDot::for_index(version_at(clock_bound + 1), 0)?];
+    assert!(matches!(
+        ahead_dot.validate_admissible_at(NOW_MS),
+        Err(Error::EntryVersionAheadOfClock)
+    ));
+
+    let mut ahead_register = base.clone();
+    ahead_register.crdt.register = Some(version_at(u128::MAX));
+    assert!(matches!(
+        ahead_register.validate_admissible_at(NOW_MS),
+        Err(Error::EntryVersionAheadOfClock)
+    ));
+
+    let mut ahead_tombstone = base.clone();
+    ahead_tombstone.crdt.tombstones = vec![EntryDot::for_index(version_at(clock_bound + 1), 0)?];
+    assert!(matches!(
+        ahead_tombstone.validate_admissible_at(NOW_MS),
+        Err(Error::EntryVersionAheadOfClock)
+    ));
+
+    let mut at_bound = base;
+    at_bound.crdt.dots = vec![EntryDot::for_index(version_at(clock_bound), 0)?];
+    at_bound.crdt.register = Some(version_at(clock_bound));
+    at_bound.validate_admissible_at(NOW_MS)?;
+    Ok(())
+}
+
+/// Storage normalization and affine placement preserve the retention bound.
+#[test]
+fn test_normalization_and_affine_preserve_retention_bound() -> Result<()> {
+    let entry = admissible_delta("topic", "value", 1)?;
+    assert_eq!(
+        entry.clone().try_into_storage_entry()?.expires_at_ms,
+        entry.expires_at_ms
+    );
+    for replica in entry.affine(3)? {
+        assert_eq!(replica.expires_at_ms, entry.expires_at_ms);
+    }
+    Ok(())
+}
+
+/// A stored value written before retention bounds existed deserializes as unstamped and is
+/// therefore not live, so it is retired on its next read instead of being served forever.
+#[test]
+fn test_legacy_value_without_bound_is_not_live() -> Result<()> {
+    let mut legacy = serde_json::to_value(admissible_delta("topic", "value", 1)?)
+        .map_err(|_| Error::SerializeToString)?;
+    legacy
+        .as_object_mut()
+        .ok_or_else(|| Error::InvalidMessage("entry must serialize to an object".to_string()))?
+        .remove("expires_at_ms");
+    let entry: Entry = serde_json::from_value(legacy).map_err(Error::Deserialize)?;
+    assert_eq!(entry.expires_at_ms, None);
+    assert!(!entry.is_live_at(0));
     Ok(())
 }

--- a/crates/core/src/dht/entry/test_entry.rs
+++ b/crates/core/src/dht/entry/test_entry.rs
@@ -733,9 +733,6 @@ fn test_join_takes_the_later_retention_bound() -> Result<()> {
     let relay_later = with_retention(relay_delta(Did::from(7u32), "m2", 2)?, 20);
     assert_eq!(relay_earlier.join(relay_later)?.expires_at_ms, Some(20));
 
-    let tombstoned = earlier.tombstone(with_retention(data_entry("topic", "a")?, 30))?;
-    assert_eq!(tombstoned.expires_at_ms, Some(30));
-
     let compacted = earlier.compact_data(
         NOW_MS,
         with_retention(data_entry("topic", "a")?, 40),
@@ -745,6 +742,24 @@ fn test_join_takes_the_later_retention_bound() -> Result<()> {
 
     let unbounded_join = data_delta("topic", "c", 3)?.join(earlier.clone())?;
     assert_eq!(unbounded_join.expires_at_ms, Some(10));
+    Ok(())
+}
+
+/// Removal law: a tombstone leaves the carrier's retention bound unchanged, for a data topic
+/// and a relay inbox alike, however far ahead the removal's own bound lies.
+#[test]
+fn test_removal_leaves_the_retention_bound_unchanged() -> Result<()> {
+    let topic = with_retention(data_delta("topic", "a", 1)?, 10);
+    let removal = with_retention(data_entry("topic", "a")?, 30);
+    let drained = topic.tombstone(removal)?;
+    assert!(drained.data.is_empty());
+    assert_eq!(drained.expires_at_ms, Some(10));
+
+    let inbox = with_retention(relay_delta(Did::from(7u32), "m1", 1)?, 10);
+    let removal = with_retention(inbox.removal_of(inbox.crdt.dots.clone()), 30);
+    let drained = inbox.tombstone(removal)?;
+    assert!(drained.data.is_empty());
+    assert_eq!(drained.expires_at_ms, Some(10));
     Ok(())
 }
 

--- a/crates/core/src/dht/entry/test_entry.rs
+++ b/crates/core/src/dht/entry/test_entry.rs
@@ -1,5 +1,3 @@
-use num_bigint::BigUint;
-
 use super::*;
 use crate::algebra::assert_join_semilattice_laws;
 use crate::algebra::assert_strong_eventual_consistency;
@@ -7,10 +5,6 @@ use crate::consts::DEFAULT_TTL_MS;
 use crate::consts::ENTRY_PAYLOAD_MAX_BYTES;
 use crate::consts::MAX_TTL_MS;
 use crate::consts::TS_OFFSET_TOLERANCE_MS;
-use crate::ecc::SecretKey;
-use crate::message::Message;
-use crate::message::MessageSigner;
-use crate::session::SessionSk;
 use crate::tests::TEST_NETWORK_ID;
 
 fn encoded(value: &str) -> Result<Encoded> {
@@ -441,13 +435,17 @@ fn test_extend_caps_incoming_payloads_larger_than_max_len() -> Result<()> {
     assert_entry_keeps_recent_overflow(&updated, incoming_count, overflow)
 }
 
+/// Extend is the element-set join for both carriers, so a relay inbox grows by extension;
+/// touch remains a data-topic operation.
 #[test]
-fn test_extend_rejects_non_data_entry() -> Result<()> {
-    let entry = relay_entry();
-    let other = entry.clone();
+fn test_extend_grows_relay_inbox_but_touch_rejects_it() -> Result<()> {
+    let inbox = relay_entry();
+    let delta = relay_delta(inbox.did, "m1", 1)?;
 
+    let extended = inbox.extend(NOW_MS, delta.clone(), actor())?;
+    assert_eq!(extended.data, delta.data);
     assert!(matches!(
-        entry.extend(NOW_MS, other, actor()),
+        inbox.touch(NOW_MS, delta, actor()),
         Err(Error::EntryNotAppendable)
     ));
     Ok(())
@@ -673,24 +671,6 @@ fn test_operation_default_entry_matches_operation_kind() -> Result<()> {
 }
 
 #[test]
-fn test_message_payload_entry_key_targets_successor_of_signer() -> Result<()> {
-    let key = SecretKey::random();
-    let session = SessionSk::new_with_seckey(&key)?;
-    let signer: Did = key.address().into();
-    let payload = MessagePayload::new_send(
-        Message::custom(b"relay")?,
-        MessageSigner::new(&session, TEST_NETWORK_ID),
-        signer,
-        signer,
-    )?;
-    let entry = Entry::try_from(payload)?;
-    let expected = BigUint::from(signer) + BigUint::from(1u16);
-    assert_eq!(entry.did, expected.into());
-    assert_eq!(entry.kind, EntryKind::RelayMessage);
-    Ok(())
-}
-
-#[test]
 fn test_affine_preserves_payload_and_kind_while_rotating_keys() -> Result<()> {
     let entry = data_entry("topic", "value")?;
     let affined = entry.affine(3)?;
@@ -775,7 +755,7 @@ fn test_admission_bounds_every_payload_size() -> Result<()> {
         vec![Encoded::from("x".repeat(ENTRY_PAYLOAD_MAX_BYTES))],
         EntryKind::Data,
     );
-    bounded(at_bound, NOW_MS + 1_000).validate_admissible_at(NOW_MS)?;
+    bounded(at_bound, NOW_MS + 1_000).validate_admissible_at(NOW_MS, TEST_NETWORK_ID)?;
 
     let oversize = Entry::new(
         did,
@@ -786,7 +766,7 @@ fn test_admission_bounds_every_payload_size() -> Result<()> {
         EntryKind::Data,
     );
     assert!(matches!(
-        bounded(oversize, NOW_MS + 1_000).validate_admissible_at(NOW_MS),
+        bounded(oversize, NOW_MS + 1_000).validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
         Err(Error::EntryPayloadExceedsMax)
     ));
     Ok(())
@@ -810,19 +790,19 @@ fn test_admission_bounds_the_retention_bound() -> Result<()> {
     let delta = data_delta("topic", "value", 1)?;
 
     assert!(matches!(
-        delta.validate_admissible_at(NOW_MS),
+        delta.validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
         Err(Error::EntryNotLive)
     ));
     assert!(matches!(
-        bounded(delta.clone(), NOW_MS).validate_admissible_at(NOW_MS),
+        bounded(delta.clone(), NOW_MS).validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
         Err(Error::EntryNotLive)
     ));
     assert!(matches!(
-        bounded(delta.clone(), limit + 1).validate_admissible_at(NOW_MS),
+        bounded(delta.clone(), limit + 1).validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
         Err(Error::EntryLifetimeExceedsMax)
     ));
-    bounded(delta.clone(), limit).validate_admissible_at(NOW_MS)?;
-    bounded(delta, NOW_MS + 1).validate_admissible_at(NOW_MS)?;
+    bounded(delta.clone(), limit).validate_admissible_at(NOW_MS, TEST_NETWORK_ID)?;
+    bounded(delta, NOW_MS + 1).validate_admissible_at(NOW_MS, TEST_NETWORK_ID)?;
     Ok(())
 }
 
@@ -836,28 +816,28 @@ fn test_admission_bounds_every_version_logical_time() -> Result<()> {
     let mut ahead_dot = base.clone();
     ahead_dot.crdt.dots = vec![EntryDot::for_index(version_at(clock_bound + 1), 0)?];
     assert!(matches!(
-        ahead_dot.validate_admissible_at(NOW_MS),
+        ahead_dot.validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
         Err(Error::EntryVersionAheadOfClock)
     ));
 
     let mut ahead_register = base.clone();
     ahead_register.crdt.register = Some(version_at(u128::MAX));
     assert!(matches!(
-        ahead_register.validate_admissible_at(NOW_MS),
+        ahead_register.validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
         Err(Error::EntryVersionAheadOfClock)
     ));
 
     let mut ahead_tombstone = base.clone();
     ahead_tombstone.crdt.tombstones = vec![EntryDot::for_index(version_at(clock_bound + 1), 0)?];
     assert!(matches!(
-        ahead_tombstone.validate_admissible_at(NOW_MS),
+        ahead_tombstone.validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
         Err(Error::EntryVersionAheadOfClock)
     ));
 
     let mut at_bound = base;
     at_bound.crdt.dots = vec![EntryDot::for_index(version_at(clock_bound), 0)?];
     at_bound.crdt.register = Some(version_at(clock_bound));
-    at_bound.validate_admissible_at(NOW_MS)?;
+    at_bound.validate_admissible_at(NOW_MS, TEST_NETWORK_ID)?;
     Ok(())
 }
 

--- a/crates/core/src/dht/entry/test_inbox.rs
+++ b/crates/core/src/dht/entry/test_inbox.rs
@@ -1,0 +1,195 @@
+use super::inbox::inbox_destination;
+use super::inbox::inbox_key;
+use super::Entry;
+use super::EntryKind;
+use super::EntryOperation;
+use crate::consts::DEFAULT_RELAY_INBOX_TTL_MS;
+use crate::consts::MAX_RELAY_INBOX_TTL_MS;
+use crate::consts::MAX_TTL_MS;
+use crate::consts::TS_OFFSET_TOLERANCE_MS;
+use crate::dht::Did;
+use crate::ecc::SecretKey;
+use crate::error::Error;
+use crate::error::Result;
+use crate::message::Message;
+use crate::message::MessagePayload;
+use crate::message::MessageSigner;
+use crate::session::SessionSk;
+use crate::tests::TEST_NETWORK_ID;
+
+const NOW_MS: u128 = 1_700_000_000_000;
+
+fn session() -> Result<SessionSk> {
+    SessionSk::new_with_seckey(&SecretKey::random())
+}
+
+fn custom_to(destination: Did, network_id: u32) -> Result<MessagePayload> {
+    let session = session()?;
+    MessagePayload::new_send(
+        Message::custom(b"held")?,
+        MessageSigner::new(&session, network_id),
+        destination,
+        destination,
+    )
+}
+
+fn live(mut entry: Entry) -> Entry {
+    entry.expires_at_ms = Some(NOW_MS + 1_000);
+    entry
+}
+
+/// Law: `inbox_destination ∘ inbox_key = id`, and the inbox of `d` is the position after `d`.
+#[test]
+fn test_inbox_key_is_the_position_after_the_destination() {
+    let destination = Did::from(41u32);
+    assert_eq!(inbox_key(destination), Did::from(42u32));
+    assert_eq!(inbox_destination(inbox_key(destination)), destination);
+    assert_eq!(inbox_destination(Did::from(0u32)), -Did::from(1u32));
+}
+
+/// Witness: a held message is admissible iff it is addressed to the inbox owner, carries an
+/// application message, and both signatures verify inside the receiver's overlay.
+#[test]
+fn test_inbox_admits_only_messages_addressed_to_its_owner() -> Result<()> {
+    let destination: Did = SecretKey::random().address().into();
+    let held = live(Entry::inbox_delta(&custom_to(
+        destination,
+        TEST_NETWORK_ID,
+    )?)?);
+    assert_eq!(held.did, inbox_key(destination));
+    assert_eq!(held.kind, EntryKind::RelayMessage);
+    held.validate_admissible_at(NOW_MS, TEST_NETWORK_ID)?;
+    assert_eq!(
+        held.deliverable_inbox_messages(TEST_NETWORK_ID)
+            .into_iter()
+            .map(|payload| payload.transaction.destination)
+            .collect::<Vec<_>>(),
+        vec![destination]
+    );
+
+    let misfiled = live(Entry::new(
+        held.did,
+        Entry::inbox_delta(&custom_to(
+            SecretKey::random().address().into(),
+            TEST_NETWORK_ID,
+        )?)?
+        .data,
+        EntryKind::RelayMessage,
+    ));
+    assert!(matches!(
+        misfiled.validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
+        Err(Error::RelayMessageNotAddressedToInbox)
+    ));
+    assert!(misfiled
+        .deliverable_inbox_messages(TEST_NETWORK_ID)
+        .is_empty());
+    Ok(())
+}
+
+/// Witness: a message signed inside another overlay is not admitted, even when addressed
+/// correctly.
+#[test]
+fn test_inbox_rejects_messages_signed_in_another_overlay() -> Result<()> {
+    let destination: Did = SecretKey::random().address().into();
+    let foreign = live(Entry::inbox_delta(&custom_to(
+        destination,
+        TEST_NETWORK_ID + 1,
+    )?)?);
+    assert!(matches!(
+        foreign.validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
+        Err(Error::RelayMessageUnverifiable)
+    ));
+    Ok(())
+}
+
+/// Witness: only application messages may be held; a control message is refused.
+#[test]
+fn test_inbox_rejects_control_messages() -> Result<()> {
+    let destination: Did = SecretKey::random().address().into();
+    let session = session()?;
+    let control = MessagePayload::new_send(
+        Message::PeerLivenessProbe(crate::message::PeerLivenessProbe { sent_at_ms: 1 }),
+        MessageSigner::new(&session, TEST_NETWORK_ID),
+        destination,
+        destination,
+    )?;
+    let held = live(Entry::inbox_delta(&control)?);
+    assert!(matches!(
+        held.validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
+        Err(Error::RelayMessageNotApplication)
+    ));
+    Ok(())
+}
+
+/// Witness: an element that is not a payload at all is refused.
+#[test]
+fn test_inbox_rejects_undecodable_elements() {
+    let held = live(Entry::new(
+        inbox_key(Did::from(7u32)),
+        vec![crate::message::Encoded::from("not a payload")],
+        EntryKind::RelayMessage,
+    ));
+    assert!(held
+        .validate_admissible_at(NOW_MS, TEST_NETWORK_ID)
+        .is_err());
+}
+
+/// Retention policy is a property of the kind: a relay inbox is stamped with and admitted up to
+/// its own, longer, bounds, while a data topic keeps the message bounds.
+#[test]
+fn test_inbox_uses_its_own_retention_policy() -> Result<()> {
+    let destination: Did = SecretKey::random().address().into();
+    let delta = Entry::inbox_delta(&custom_to(destination, TEST_NETWORK_ID)?)?;
+    let stamped = EntryOperation::Extend(delta.clone()).stamped(NOW_MS, Did::from(1u32))?;
+    assert_eq!(
+        stamped.entry().expires_at_ms,
+        Some(NOW_MS + u128::from(DEFAULT_RELAY_INBOX_TTL_MS))
+    );
+    assert!(u128::from(DEFAULT_RELAY_INBOX_TTL_MS) > u128::from(MAX_TTL_MS));
+
+    let mut at_limit = delta.clone();
+    at_limit.expires_at_ms =
+        Some(NOW_MS + u128::from(MAX_RELAY_INBOX_TTL_MS) + TS_OFFSET_TOLERANCE_MS);
+    at_limit.validate_admissible_at(NOW_MS, TEST_NETWORK_ID)?;
+
+    let mut beyond = delta;
+    beyond.expires_at_ms =
+        Some(NOW_MS + u128::from(MAX_RELAY_INBOX_TTL_MS) + TS_OFFSET_TOLERANCE_MS + 1);
+    assert!(matches!(
+        beyond.validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
+        Err(Error::EntryLifetimeExceedsMax)
+    ));
+    Ok(())
+}
+
+/// Draining: compacting the delivered messages out of the inbox leaves a floor that excludes
+/// them from every later join, so a stale copy cannot redeliver.
+#[test]
+fn test_compaction_retires_delivered_messages_from_the_inbox() -> Result<()> {
+    let destination: Did = SecretKey::random().address().into();
+    let owner = Did::from(9u32);
+    let first = Entry::inbox_delta(&custom_to(destination, TEST_NETWORK_ID)?)?;
+    let second = Entry::inbox_delta(&custom_to(destination, TEST_NETWORK_ID)?)?;
+    let inbox = Entry::new(first.did, Vec::new(), EntryKind::RelayMessage)
+        .operate(
+            NOW_MS,
+            EntryOperation::Extend(first.clone()).stamped(NOW_MS, owner)?,
+            owner,
+        )?
+        .operate(
+            NOW_MS,
+            EntryOperation::Extend(second.clone()).stamped(NOW_MS, owner)?,
+            owner,
+        )?;
+    assert_eq!(inbox.data.len(), 2);
+
+    let delivered = Entry::new(first.did, first.data.clone(), EntryKind::RelayMessage);
+    let compaction = EntryOperation::CompactData(delivered).stamped(NOW_MS + 1, destination)?;
+    let compacted = inbox.operate(NOW_MS + 1, compaction, destination)?;
+    assert_eq!(compacted.data, second.data);
+    assert!(compacted.crdt.tombstones.is_empty());
+
+    let stale_copy = compacted.join(inbox)?;
+    assert_eq!(stale_copy.data, second.data);
+    Ok(())
+}

--- a/crates/core/src/dht/entry/test_inbox.rs
+++ b/crates/core/src/dht/entry/test_inbox.rs
@@ -2,7 +2,6 @@ use super::inbox::inbox_destination;
 use super::inbox::inbox_key;
 use super::inbox::validate_inbox_relocation;
 use super::inbox::HeldMessage;
-use super::inbox::HELD_MESSAGE_DOMAIN_TAG;
 use super::Entry;
 use super::EntryKind;
 use super::EntryOperation;
@@ -21,9 +20,7 @@ use crate::message::Encoder;
 use crate::message::Message;
 use crate::message::MessagePayload;
 use crate::message::MessageSigner;
-use crate::message::MessageVerification;
 use crate::message::NotifyPredecessorSend;
-use crate::message::SigningDomain;
 use crate::session::SessionSk;
 use crate::tests::with_retention;
 use crate::tests::TEST_NETWORK_ID;
@@ -47,34 +44,32 @@ fn custom_to(destination: Did, network_id: u32) -> Result<MessagePayload> {
     payload_to(Message::custom(b"held")?, destination, network_id)
 }
 
-/// A hold by `holder` of a fresh custom message to `destination`, inside `network_id`.
+/// A hold by `holder` of `payload` inside `network_id` at `held_at_ms`.
+fn hold_at(
+    holder: &SessionSk,
+    payload: MessagePayload,
+    network_id: u32,
+    held_at_ms: u128,
+) -> Result<HeldMessage> {
+    HeldMessage::hold(payload, MessageSigner::new(holder, network_id), held_at_ms)
+}
+
+/// A hold by `holder` of a fresh custom message to `destination`, inside `network_id`, now.
 fn held_by(holder: &SessionSk, destination: Did, network_id: u32) -> Result<HeldMessage> {
-    HeldMessage::hold(
+    hold_at(
+        holder,
         custom_to(destination, network_id)?,
-        MessageSigner::new(holder, network_id),
+        network_id,
+        get_epoch_ms(),
     )
 }
 
-/// A holder signature stamped at an arbitrary instant, for laws about the hold instant.
-fn holder_signature_at(
-    holder: &SessionSk,
-    payload: &MessagePayload,
-    ts_ms: u128,
-) -> Result<MessageVerification> {
-    let data = rings_codec::serialize(payload).map_err(Error::CodecSerialize)?;
-    let domain = SigningDomain::new(HELD_MESSAGE_DOMAIN_TAG, TEST_NETWORK_ID);
-    let msg = domain.transcript(&data, ts_ms, DEFAULT_TTL_MS);
-    Ok(MessageVerification {
-        session: holder.session(),
-        sig: holder.sign(&msg)?,
-        ttl_ms: DEFAULT_TTL_MS,
-        ts_ms,
-    })
-}
-
-/// The owner's carrier after admitting `delta` as a hold at `now_ms`.
-fn carrier_with(delta: Entry, now_ms: u128, actor: Did) -> Result<Entry> {
-    Entry::new(delta.did, Vec::new(), EntryKind::RelayMessage).extend(now_ms, delta, actor)
+/// The delta of one hold, stamped live at `now_ms` under the inbox policy.
+fn live_delta(held: &HeldMessage, now_ms: u128) -> Result<Entry> {
+    Ok(with_retention(
+        Entry::inbox_delta(held)?,
+        now_ms + u128::from(DEFAULT_RELAY_INBOX_TTL_MS),
+    ))
 }
 
 #[test]
@@ -90,10 +85,7 @@ fn test_witness_admits_a_held_custom_message_addressed_to_the_recipient() -> Res
     let holder = session()?;
     let destination: Did = SecretKey::random().address().into();
     let held = held_by(&holder, destination, TEST_NETWORK_ID)?;
-    let delta = with_retention(
-        Entry::inbox_delta(&held)?,
-        now_ms + u128::from(DEFAULT_RELAY_INBOX_TTL_MS),
-    );
+    let delta = live_delta(&held, now_ms)?;
 
     assert_eq!(delta.did, inbox_key(destination));
     delta.validate_admissible_at(now_ms, TEST_NETWORK_ID)?;
@@ -104,16 +96,22 @@ fn test_witness_admits_a_held_custom_message_addressed_to_the_recipient() -> Res
 #[test]
 fn test_witness_rejects_a_message_addressed_elsewhere() -> Result<()> {
     let now_ms = get_epoch_ms();
+    let holder = session()?;
     let destination: Did = SecretKey::random().address().into();
-    let held = held_by(&session()?, destination, TEST_NETWORK_ID)?;
-    let mut misfiled = with_retention(
-        Entry::inbox_delta(&held)?,
-        now_ms + u128::from(DEFAULT_RELAY_INBOX_TTL_MS),
-    );
+    let held = held_by(&holder, destination, TEST_NETWORK_ID)?;
+    let mut misfiled = live_delta(&held, now_ms)?;
     misfiled.did = inbox_key(SecretKey::random().address().into());
-
     assert!(matches!(
         misfiled.validate_admissible_at(now_ms, TEST_NETWORK_ID),
+        Err(Error::RelayMessageNotAddressedToInbox)
+    ));
+
+    // The relay destination is bound too: the recipient must have nothing to forward.
+    let mut forwarding = custom_to(destination, TEST_NETWORK_ID)?;
+    forwarding.relay.destination = SecretKey::random().address().into();
+    let held = hold_at(&holder, forwarding, TEST_NETWORK_ID, now_ms)?;
+    assert!(matches!(
+        held.validate_witness(destination, now_ms, TEST_NETWORK_ID),
         Err(Error::RelayMessageNotAddressedToInbox)
     ));
     Ok(())
@@ -129,7 +127,7 @@ fn test_witness_rejects_every_message_but_custom() -> Result<()> {
         destination,
         TEST_NETWORK_ID,
     )?;
-    let held = HeldMessage::hold(control, MessageSigner::new(&holder, TEST_NETWORK_ID))?;
+    let held = hold_at(&holder, control, TEST_NETWORK_ID, now_ms)?;
 
     assert!(matches!(
         held.validate_witness(destination, now_ms, TEST_NETWORK_ID),
@@ -144,18 +142,22 @@ fn test_witness_binds_holder_and_payload_to_the_overlay() -> Result<()> {
     let holder = session()?;
     let destination: Did = SecretKey::random().address().into();
 
-    let foreign_hold = HeldMessage::hold(
+    let foreign_hold = hold_at(
+        &holder,
         custom_to(destination, TEST_NETWORK_ID)?,
-        MessageSigner::new(&holder, TEST_NETWORK_ID + 1),
+        TEST_NETWORK_ID + 1,
+        now_ms,
     )?;
     assert!(matches!(
         foreign_hold.validate_witness(destination, now_ms, TEST_NETWORK_ID),
         Err(Error::RelayMessageUnverifiable)
     ));
 
-    let foreign_payload = HeldMessage::hold(
+    let foreign_payload = hold_at(
+        &holder,
         custom_to(destination, TEST_NETWORK_ID + 1)?,
-        MessageSigner::new(&holder, TEST_NETWORK_ID),
+        TEST_NETWORK_ID,
+        now_ms,
     )?;
     assert!(matches!(
         foreign_payload.validate_witness(destination, now_ms, TEST_NETWORK_ID),
@@ -165,14 +167,23 @@ fn test_witness_binds_holder_and_payload_to_the_overlay() -> Result<()> {
 }
 
 #[test]
-fn test_witness_rejects_a_hold_ahead_of_the_clock() -> Result<()> {
-    let now_ms = get_epoch_ms();
+fn test_witness_bounds_the_hold_instant_by_the_receiver_clock() -> Result<()> {
     let destination: Did = SecretKey::random().address().into();
     let held = held_by(&session()?, destination, TEST_NETWORK_ID)?;
+    let held_at = held.held_at_ms();
 
-    let behind = now_ms - TS_OFFSET_TOLERANCE_MS - 1;
+    // The boundary is admissible; one millisecond beyond the tolerance is not.
+    held.validate_witness(
+        destination,
+        held_at - TS_OFFSET_TOLERANCE_MS,
+        TEST_NETWORK_ID,
+    )?;
     assert!(matches!(
-        held.validate_witness(destination, behind, TEST_NETWORK_ID),
+        held.validate_witness(
+            destination,
+            held_at - TS_OFFSET_TOLERANCE_MS - 1,
+            TEST_NETWORK_ID
+        ),
         Err(Error::RelayMessageHeldAheadOfClock)
     ));
     Ok(())
@@ -186,10 +197,7 @@ fn test_witness_judges_the_payload_as_of_the_hold_instant() -> Result<()> {
 
     // A hold after the sender's proof lifetime is not a hold of a live message.
     let late = get_epoch_ms() + u128::from(DEFAULT_TTL_MS) + TS_OFFSET_TOLERANCE_MS + 1;
-    let held_late = HeldMessage {
-        holder: holder_signature_at(&holder, &payload, late)?,
-        payload: payload.clone(),
-    };
+    let held_late = hold_at(&holder, payload.clone(), TEST_NETWORK_ID, late)?;
     assert!(matches!(
         held_late.validate_witness(destination, late, TEST_NETWORK_ID),
         Err(Error::RelayMessageHeldOutsideSenderProof)
@@ -197,7 +205,7 @@ fn test_witness_judges_the_payload_as_of_the_hold_instant() -> Result<()> {
 
     // A hold inside it stays admissible however far the receiver's clock has moved on: the
     // witness is monotone in `now_ms`.
-    let held = HeldMessage::hold(payload, MessageSigner::new(&holder, TEST_NETWORK_ID))?;
+    let held = hold_at(&holder, payload, TEST_NETWORK_ID, get_epoch_ms())?;
     let far_future = get_epoch_ms() + u128::from(MAX_RELAY_INBOX_TTL_MS);
     held.validate_witness(destination, far_future, TEST_NETWORK_ID)?;
     Ok(())
@@ -216,10 +224,7 @@ fn test_witness_rejects_a_tampered_payload_and_a_reset_floor() -> Result<()> {
     ));
 
     let held = held_by(&holder, destination, TEST_NETWORK_ID)?;
-    let mut with_floor = with_retention(
-        Entry::inbox_delta(&held)?,
-        now_ms + u128::from(DEFAULT_RELAY_INBOX_TTL_MS),
-    );
+    let mut with_floor = live_delta(&held, now_ms)?;
     with_floor.crdt.register = Some(EntryVersion::new(
         now_ms,
         holder.account_did(),
@@ -245,13 +250,12 @@ fn test_inbox_uses_its_own_retention_policy() -> Result<()> {
         Some(now_ms + u128::from(DEFAULT_RELAY_INBOX_TTL_MS))
     );
 
-    let mut long = delta.clone();
-    long.expires_at_ms = Some(now_ms + u128::from(MAX_RELAY_INBOX_TTL_MS));
-    long.validate_admissible_at(now_ms, TEST_NETWORK_ID)?;
-
-    let mut too_long = delta;
-    too_long.expires_at_ms =
-        Some(now_ms + u128::from(MAX_RELAY_INBOX_TTL_MS) + TS_OFFSET_TOLERANCE_MS + 1);
+    with_retention(delta.clone(), now_ms + u128::from(MAX_RELAY_INBOX_TTL_MS))
+        .validate_admissible_at(now_ms, TEST_NETWORK_ID)?;
+    let too_long = with_retention(
+        delta,
+        now_ms + u128::from(MAX_RELAY_INBOX_TTL_MS) + TS_OFFSET_TOLERANCE_MS + 1,
+    );
     assert!(matches!(
         too_long.validate_admissible_at(now_ms, TEST_NETWORK_ID),
         Err(Error::EntryLifetimeExceedsMax)
@@ -261,41 +265,96 @@ fn test_inbox_uses_its_own_retention_policy() -> Result<()> {
 }
 
 #[test]
-fn test_hold_authority_admits_only_the_responsible_node() -> Result<()> {
+fn test_witness_refuses_a_delta_larger_than_the_inbox_before_verifying() -> Result<()> {
+    let now_ms = get_epoch_ms();
     let holder = session()?;
     let destination: Did = SecretKey::random().address().into();
-    let held = held_by(&holder, destination, TEST_NETWORK_ID)?;
-    let hold = EntryOperation::Extend(Entry::inbox_delta(&held)?);
+    let mut delta = live_delta(&held_by(&holder, destination, TEST_NETWORK_ID)?, now_ms)?;
+    for _ in 0..RELAY_INBOX_MAX_LEN {
+        delta
+            .data
+            .push(held_by(&holder, destination, TEST_NETWORK_ID)?.encode()?);
+    }
+    assert_eq!(delta.data.len(), RELAY_INBOX_MAX_LEN + 1);
+    assert!(matches!(
+        delta.validate_admissible_at(now_ms, TEST_NETWORK_ID),
+        Err(Error::RelayInboxDeltaExceedsCapacity)
+    ));
+    Ok(())
+}
+
+#[test]
+fn test_hold_law_admits_only_the_responsible_holder_of_a_live_message() -> Result<()> {
+    let now_ms = get_epoch_ms();
+    let holder = session()?;
+    let other = session()?;
+    let destination: Did = SecretKey::random().address().into();
     let responsible = holder.account_did();
     let stranger: Did = SecretKey::random().address().into();
+    let hold = EntryOperation::Extend(live_delta(
+        &held_by(&holder, destination, TEST_NETWORK_ID)?,
+        now_ms,
+    )?);
 
-    hold.validate_inbox_authority(responsible, Some(responsible))?;
+    hold.validate_inbox_write(responsible, Some(responsible), now_ms, TEST_NETWORK_ID)?;
+    for (writer, node) in [
+        (stranger, Some(responsible)),
+        (responsible, Some(stranger)),
+        (responsible, None),
+    ] {
+        assert!(matches!(
+            hold.validate_inbox_write(writer, node, now_ms, TEST_NETWORK_ID),
+            Err(Error::RelayMessageHolderNotResponsible)
+        ));
+    }
+
+    // A responsible writer relaying another node's hold is not that node's holder.
+    let relayed = EntryOperation::Extend(live_delta(
+        &held_by(&other, destination, TEST_NETWORK_ID)?,
+        now_ms,
+    )?);
     assert!(matches!(
-        hold.validate_inbox_authority(stranger, Some(responsible)),
+        relayed.validate_inbox_write(responsible, Some(responsible), now_ms, TEST_NETWORK_ID),
         Err(Error::RelayMessageHolderNotResponsible)
     ));
+
+    // A hold whose sender proof has expired by the owner's clock is stale, however the holder
+    // stamped it; the witness alone would still admit it.
+    let stale_now = now_ms + u128::from(DEFAULT_TTL_MS) + TS_OFFSET_TOLERANCE_MS + 1;
+    let stale = EntryOperation::Extend(live_delta(
+        &held_by(&holder, destination, TEST_NETWORK_ID)?,
+        stale_now,
+    )?);
+    stale
+        .entry()
+        .validate_admissible_at(stale_now, TEST_NETWORK_ID)?;
     assert!(matches!(
-        hold.validate_inbox_authority(responsible, Some(stranger)),
-        Err(Error::RelayMessageHolderNotResponsible)
-    ));
-    assert!(matches!(
-        hold.validate_inbox_authority(responsible, None),
-        Err(Error::RelayMessageHolderNotResponsible)
+        stale.validate_inbox_write(responsible, Some(responsible), stale_now, TEST_NETWORK_ID),
+        Err(Error::RelayMessageHoldStale)
     ));
     Ok(())
 }
 
 #[test]
 fn test_removal_authority_is_the_recipient_alone_and_nothing_else_is_allowed() -> Result<()> {
+    let now_ms = get_epoch_ms();
     let destination: Did = SecretKey::random().address().into();
     let carrier = Entry::new(inbox_key(destination), Vec::new(), EntryKind::RelayMessage);
     let responsible: Did = SecretKey::random().address().into();
 
-    EntryOperation::Tombstone(carrier.clone())
-        .validate_inbox_authority(destination, Some(responsible))?;
+    EntryOperation::Tombstone(carrier.clone()).validate_inbox_write(
+        destination,
+        Some(responsible),
+        now_ms,
+        TEST_NETWORK_ID,
+    )?;
     assert!(matches!(
-        EntryOperation::Tombstone(carrier.clone())
-            .validate_inbox_authority(responsible, Some(responsible)),
+        EntryOperation::Tombstone(carrier.clone()).validate_inbox_write(
+            responsible,
+            Some(responsible),
+            now_ms,
+            TEST_NETWORK_ID
+        ),
         Err(Error::RelayInboxWriterNotRecipient)
     ));
     for op in [
@@ -304,12 +363,12 @@ fn test_removal_authority_is_the_recipient_alone_and_nothing_else_is_allowed() -
         EntryOperation::CompactData(carrier.clone()),
     ] {
         assert!(matches!(
-            op.validate_inbox_authority(destination, Some(responsible)),
+            op.validate_inbox_write(destination, Some(responsible), now_ms, TEST_NETWORK_ID),
             Err(Error::RelayInboxOperationNotAllowed)
         ));
     }
     assert!(matches!(
-        carrier.compact_data(get_epoch_ms(), carrier.clone(), destination),
+        carrier.compact_data(now_ms, carrier.clone(), destination),
         Err(Error::RelayInboxOperationNotAllowed)
     ));
     Ok(())
@@ -330,7 +389,7 @@ fn test_relocation_is_accepted_from_the_predecessor_alone() {
 }
 
 #[test]
-fn test_drain_delivers_the_witnessed_elements_and_retires_every_element_by_dot() -> Result<()> {
+fn test_partition_pairs_each_witnessed_element_with_its_dot_and_retires_the_rest() -> Result<()> {
     let now_ms = get_epoch_ms();
     let holder = session()?;
     let destination: Did = SecretKey::random().address().into();
@@ -339,33 +398,40 @@ fn test_drain_delivers_the_witnessed_elements_and_retires_every_element_by_dot()
     let second = held_by(&holder, destination, TEST_NETWORK_ID)?;
     let junk = held_by(&holder, destination, TEST_NETWORK_ID + 1)?;
 
-    let mut carrier = carrier_with(Entry::inbox_delta(&first)?, now_ms, actor)?;
-    carrier = carrier.extend(now_ms + 1, Entry::inbox_delta(&second)?, actor)?;
-    let mut with_junk = Entry::inbox_delta(&junk)?;
-    with_junk.data.push(junk.encode()?);
-    carrier = carrier.extend(now_ms + 2, with_junk, actor)?;
+    let carrier = Entry::new(inbox_key(destination), Vec::new(), EntryKind::RelayMessage)
+        .extend(now_ms, Entry::inbox_delta(&first)?, actor)?
+        .extend(now_ms + 1, Entry::inbox_delta(&second)?, actor)?
+        .extend(now_ms + 2, Entry::inbox_delta(&junk)?, actor)?;
     assert_eq!(carrier.data.len(), 3);
 
-    let drain = carrier.drain_inbox(now_ms + 3, TEST_NETWORK_ID);
+    let drain = carrier.partition_inbox(now_ms + 3, TEST_NETWORK_ID);
     assert_eq!(
         drain
             .deliverable
             .iter()
-            .map(|payload| payload.transaction.tx_id)
+            .map(|element| element.payload.transaction.tx_id)
             .collect::<Vec<_>>(),
         vec![
             first.payload.transaction.tx_id,
             second.payload.transaction.tx_id
         ]
     );
-    assert_eq!(drain.rejected, 1);
-    assert_eq!(drain.retired.crdt.dots, carrier.crdt.dots);
-    assert!(drain.retired.data.is_empty());
+    let delivered_dots = drain
+        .deliverable
+        .iter()
+        .map(|element| element.dot)
+        .chain(drain.rejected.crdt.dots.iter().copied())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(delivered_dots, carrier.crdt.dots.iter().copied().collect());
+    assert_eq!(drain.rejected.crdt.dots.len(), 1);
 
-    // Retiring by dot removes exactly the drained elements, and a stale copy that still carries
-    // them cannot resurrect them; an element held afterwards is untouched.
+    // Retiring by dot removes exactly the named element, a stale copy cannot resurrect it, and
+    // an element held afterwards is untouched.
     let stale = carrier.clone();
-    let retired = carrier.tombstone(drain.retired)?;
+    let mut retired = carrier.tombstone(drain.rejected)?;
+    for element in &drain.deliverable {
+        retired = retired.tombstone(carrier.removal_of([element.dot]))?;
+    }
     assert!(retired.data.is_empty());
     assert!(retired.join(stale)?.data.is_empty());
     let third = held_by(&holder, destination, TEST_NETWORK_ID)?;
@@ -380,19 +446,38 @@ fn test_inbox_keeps_the_newest_elements_and_bounds_its_tombstones() -> Result<()
     let holder = session()?;
     let destination: Did = SecretKey::random().address().into();
     let actor = holder.account_did();
-    let mut carrier = Entry::new(inbox_key(destination), Vec::new(), EntryKind::RelayMessage);
-    let mut newest = None;
-    for index in 0..RELAY_INBOX_MAX_LEN + 1 {
-        let held = held_by(&holder, destination, TEST_NETWORK_ID)?;
-        newest = Some(held.encode()?);
-        carrier = carrier.extend(now_ms + index as u128, Entry::inbox_delta(&held)?, actor)?;
-    }
-    assert_eq!(carrier.data.len(), RELAY_INBOX_MAX_LEN);
-    assert_eq!(carrier.data.last(), newest.as_ref());
 
-    let drained = carrier.drain_inbox(now_ms, TEST_NETWORK_ID);
-    let retired = carrier.tombstone(drained.retired)?;
-    assert!(retired.data.is_empty());
-    assert!(retired.crdt.tombstones.len() <= RELAY_INBOX_MAX_LEN);
+    // Two full inboxes, drained in turn: the second drain leaves twice the cap of removals to
+    // choose from, and the carrier keeps the newest cap of them.
+    let mut carrier = Entry::new(inbox_key(destination), Vec::new(), EntryKind::RelayMessage);
+    let mut clock = now_ms;
+    let mut first_round_dots = Vec::new();
+    for round in 0..2 {
+        let mut newest = None;
+        for _ in 0..RELAY_INBOX_MAX_LEN + 1 {
+            clock += 1;
+            let held = held_by(&holder, destination, TEST_NETWORK_ID)?;
+            newest = Some(held.encode()?);
+            carrier = carrier.extend(clock, Entry::inbox_delta(&held)?, actor)?;
+        }
+        assert_eq!(carrier.data.len(), RELAY_INBOX_MAX_LEN);
+        assert_eq!(carrier.data.last(), newest.as_ref());
+        if round == 0 {
+            first_round_dots = carrier.crdt.dots.clone();
+        }
+        let drained = carrier.partition_inbox(clock, TEST_NETWORK_ID);
+        let removal = carrier.removal_of(drained.deliverable.iter().map(|element| element.dot));
+        carrier = carrier.tombstone(removal)?;
+        assert!(carrier.data.is_empty());
+    }
+
+    assert_eq!(carrier.crdt.tombstones.len(), RELAY_INBOX_MAX_LEN);
+    let kept = carrier
+        .crdt
+        .tombstones
+        .iter()
+        .copied()
+        .collect::<std::collections::BTreeSet<_>>();
+    assert!(first_round_dots.iter().all(|dot| !kept.contains(dot)));
     Ok(())
 }

--- a/crates/core/src/dht/entry/test_inbox.rs
+++ b/crates/core/src/dht/entry/test_inbox.rs
@@ -1,195 +1,394 @@
 use super::inbox::inbox_destination;
 use super::inbox::inbox_key;
+use super::inbox::validate_inbox_relocation;
+use super::inbox::HeldMessage;
+use super::inbox::HELD_MESSAGE_DOMAIN_TAG;
 use super::Entry;
 use super::EntryKind;
 use super::EntryOperation;
 use crate::consts::DEFAULT_RELAY_INBOX_TTL_MS;
+use crate::consts::DEFAULT_TTL_MS;
 use crate::consts::MAX_RELAY_INBOX_TTL_MS;
 use crate::consts::MAX_TTL_MS;
+use crate::consts::RELAY_INBOX_MAX_LEN;
 use crate::consts::TS_OFFSET_TOLERANCE_MS;
 use crate::dht::Did;
 use crate::ecc::SecretKey;
 use crate::error::Error;
 use crate::error::Result;
+use crate::message::Encoder;
 use crate::message::Message;
 use crate::message::MessagePayload;
 use crate::message::MessageSigner;
+use crate::message::MessageVerification;
+use crate::message::NotifyPredecessorSend;
+use crate::message::SigningDomain;
 use crate::session::SessionSk;
 use crate::tests::TEST_NETWORK_ID;
-
-const NOW_MS: u128 = 1_700_000_000_000;
+use crate::utils::get_epoch_ms;
 
 fn session() -> Result<SessionSk> {
     SessionSk::new_with_seckey(&SecretKey::random())
 }
 
-fn custom_to(destination: Did, network_id: u32) -> Result<MessagePayload> {
-    let session = session()?;
+fn payload_to(message: Message, destination: Did, network_id: u32) -> Result<MessagePayload> {
+    let sender = session()?;
     MessagePayload::new_send(
-        Message::custom(b"held")?,
-        MessageSigner::new(&session, network_id),
+        message,
+        MessageSigner::new(&sender, network_id),
         destination,
         destination,
     )
 }
 
-fn live(mut entry: Entry) -> Entry {
-    entry.expires_at_ms = Some(NOW_MS + 1_000);
+fn custom_to(destination: Did, network_id: u32) -> Result<MessagePayload> {
+    payload_to(Message::custom(b"held")?, destination, network_id)
+}
+
+/// A hold by `holder` of a fresh custom message to `destination`, inside `network_id`.
+fn held_by(holder: &SessionSk, destination: Did, network_id: u32) -> Result<HeldMessage> {
+    HeldMessage::hold(
+        custom_to(destination, network_id)?,
+        MessageSigner::new(holder, network_id),
+    )
+}
+
+/// A holder signature stamped at an arbitrary instant, for laws about the hold instant.
+fn holder_signature_at(
+    holder: &SessionSk,
+    payload: &MessagePayload,
+    ts_ms: u128,
+) -> Result<MessageVerification> {
+    let data = rings_codec::serialize(payload).map_err(Error::CodecSerialize)?;
+    let domain = SigningDomain::new(HELD_MESSAGE_DOMAIN_TAG, TEST_NETWORK_ID);
+    let msg = domain.transcript(&data, ts_ms, DEFAULT_TTL_MS);
+    Ok(MessageVerification {
+        session: holder.session(),
+        sig: holder.sign(&msg)?,
+        ttl_ms: DEFAULT_TTL_MS,
+        ts_ms,
+    })
+}
+
+/// A carrier stamped live at `now_ms`.
+fn live_at(entry: Entry, now_ms: u128) -> Entry {
+    let mut entry = entry;
+    entry.expires_at_ms = Some(now_ms + u128::from(DEFAULT_RELAY_INBOX_TTL_MS));
     entry
 }
 
-/// Law: `inbox_destination ∘ inbox_key = id`, and the inbox of `d` is the position after `d`.
+/// The owner's carrier after admitting `delta` as a hold at `now_ms`.
+fn carrier_with(delta: Entry, now_ms: u128, actor: Did) -> Result<Entry> {
+    Entry::new(delta.did, Vec::new(), EntryKind::RelayMessage).extend(now_ms, delta, actor)
+}
+
 #[test]
 fn test_inbox_key_is_the_position_after_the_destination() {
     let destination = Did::from(41u32);
     assert_eq!(inbox_key(destination), Did::from(42u32));
     assert_eq!(inbox_destination(inbox_key(destination)), destination);
-    assert_eq!(inbox_destination(Did::from(0u32)), -Did::from(1u32));
 }
 
-/// Witness: a held message is admissible iff it is addressed to the inbox owner, carries an
-/// application message, and both signatures verify inside the receiver's overlay.
 #[test]
-fn test_inbox_admits_only_messages_addressed_to_its_owner() -> Result<()> {
+fn test_witness_admits_a_held_custom_message_addressed_to_the_recipient() -> Result<()> {
+    let now_ms = get_epoch_ms();
+    let holder = session()?;
     let destination: Did = SecretKey::random().address().into();
-    let held = live(Entry::inbox_delta(&custom_to(
-        destination,
-        TEST_NETWORK_ID,
-    )?)?);
-    assert_eq!(held.did, inbox_key(destination));
-    assert_eq!(held.kind, EntryKind::RelayMessage);
-    held.validate_admissible_at(NOW_MS, TEST_NETWORK_ID)?;
-    assert_eq!(
-        held.deliverable_inbox_messages(TEST_NETWORK_ID)
-            .into_iter()
-            .map(|payload| payload.transaction.destination)
-            .collect::<Vec<_>>(),
-        vec![destination]
-    );
+    let held = held_by(&holder, destination, TEST_NETWORK_ID)?;
+    let delta = live_at(Entry::inbox_delta(&held)?, now_ms);
 
-    let misfiled = live(Entry::new(
-        held.did,
-        Entry::inbox_delta(&custom_to(
-            SecretKey::random().address().into(),
-            TEST_NETWORK_ID,
-        )?)?
-        .data,
-        EntryKind::RelayMessage,
-    ));
+    assert_eq!(delta.did, inbox_key(destination));
+    delta.validate_admissible_at(now_ms, TEST_NETWORK_ID)?;
+    assert_eq!(held.holder(), holder.account_did());
+    Ok(())
+}
+
+#[test]
+fn test_witness_rejects_a_message_addressed_elsewhere() -> Result<()> {
+    let now_ms = get_epoch_ms();
+    let destination: Did = SecretKey::random().address().into();
+    let held = held_by(&session()?, destination, TEST_NETWORK_ID)?;
+    let mut misfiled = live_at(Entry::inbox_delta(&held)?, now_ms);
+    misfiled.did = inbox_key(SecretKey::random().address().into());
+
     assert!(matches!(
-        misfiled.validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
+        misfiled.validate_admissible_at(now_ms, TEST_NETWORK_ID),
         Err(Error::RelayMessageNotAddressedToInbox)
     ));
-    assert!(misfiled
-        .deliverable_inbox_messages(TEST_NETWORK_ID)
-        .is_empty());
     Ok(())
 }
 
-/// Witness: a message signed inside another overlay is not admitted, even when addressed
-/// correctly.
 #[test]
-fn test_inbox_rejects_messages_signed_in_another_overlay() -> Result<()> {
+fn test_witness_rejects_every_message_but_custom() -> Result<()> {
+    let now_ms = get_epoch_ms();
+    let holder = session()?;
     let destination: Did = SecretKey::random().address().into();
-    let foreign = live(Entry::inbox_delta(&custom_to(
+    let control = payload_to(
+        Message::NotifyPredecessorSend(NotifyPredecessorSend { did: destination }),
         destination,
-        TEST_NETWORK_ID + 1,
-    )?)?);
+        TEST_NETWORK_ID,
+    )?;
+    let held = HeldMessage::hold(control, MessageSigner::new(&holder, TEST_NETWORK_ID))?;
+
     assert!(matches!(
-        foreign.validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
+        held.validate_witness(destination, now_ms, TEST_NETWORK_ID),
+        Err(Error::RelayMessageNotCustom)
+    ));
+    Ok(())
+}
+
+#[test]
+fn test_witness_binds_holder_and_payload_to_the_overlay() -> Result<()> {
+    let now_ms = get_epoch_ms();
+    let holder = session()?;
+    let destination: Did = SecretKey::random().address().into();
+
+    let foreign_hold = HeldMessage::hold(
+        custom_to(destination, TEST_NETWORK_ID)?,
+        MessageSigner::new(&holder, TEST_NETWORK_ID + 1),
+    )?;
+    assert!(matches!(
+        foreign_hold.validate_witness(destination, now_ms, TEST_NETWORK_ID),
         Err(Error::RelayMessageUnverifiable)
     ));
-    Ok(())
-}
 
-/// Witness: only application messages may be held; a control message is refused.
-#[test]
-fn test_inbox_rejects_control_messages() -> Result<()> {
-    let destination: Did = SecretKey::random().address().into();
-    let session = session()?;
-    let control = MessagePayload::new_send(
-        Message::PeerLivenessProbe(crate::message::PeerLivenessProbe { sent_at_ms: 1 }),
-        MessageSigner::new(&session, TEST_NETWORK_ID),
-        destination,
-        destination,
+    let foreign_payload = HeldMessage::hold(
+        custom_to(destination, TEST_NETWORK_ID + 1)?,
+        MessageSigner::new(&holder, TEST_NETWORK_ID),
     )?;
-    let held = live(Entry::inbox_delta(&control)?);
     assert!(matches!(
-        held.validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
-        Err(Error::RelayMessageNotApplication)
+        foreign_payload.validate_witness(destination, now_ms, TEST_NETWORK_ID),
+        Err(Error::RelayMessageHeldOutsideSenderProof)
     ));
     Ok(())
 }
 
-/// Witness: an element that is not a payload at all is refused.
 #[test]
-fn test_inbox_rejects_undecodable_elements() {
-    let held = live(Entry::new(
-        inbox_key(Did::from(7u32)),
-        vec![crate::message::Encoded::from("not a payload")],
-        EntryKind::RelayMessage,
+fn test_witness_rejects_a_hold_ahead_of_the_clock() -> Result<()> {
+    let now_ms = get_epoch_ms();
+    let destination: Did = SecretKey::random().address().into();
+    let held = held_by(&session()?, destination, TEST_NETWORK_ID)?;
+
+    let behind = now_ms - TS_OFFSET_TOLERANCE_MS - 1;
+    assert!(matches!(
+        held.validate_witness(destination, behind, TEST_NETWORK_ID),
+        Err(Error::RelayMessageHeldAheadOfClock)
     ));
-    assert!(held
-        .validate_admissible_at(NOW_MS, TEST_NETWORK_ID)
-        .is_err());
+    Ok(())
 }
 
-/// Retention policy is a property of the kind: a relay inbox is stamped with and admitted up to
-/// its own, longer, bounds, while a data topic keeps the message bounds.
+#[test]
+fn test_witness_judges_the_payload_as_of_the_hold_instant() -> Result<()> {
+    let holder = session()?;
+    let destination: Did = SecretKey::random().address().into();
+    let payload = custom_to(destination, TEST_NETWORK_ID)?;
+
+    // A hold after the sender's proof lifetime is not a hold of a live message.
+    let late = get_epoch_ms() + u128::from(DEFAULT_TTL_MS) + TS_OFFSET_TOLERANCE_MS + 1;
+    let held_late = HeldMessage {
+        holder: holder_signature_at(&holder, &payload, late)?,
+        payload: payload.clone(),
+    };
+    assert!(matches!(
+        held_late.validate_witness(destination, late, TEST_NETWORK_ID),
+        Err(Error::RelayMessageHeldOutsideSenderProof)
+    ));
+
+    // A hold inside it stays admissible however far the receiver's clock has moved on: the
+    // witness is monotone in `now_ms`.
+    let held = HeldMessage::hold(payload, MessageSigner::new(&holder, TEST_NETWORK_ID))?;
+    let far_future = get_epoch_ms() + u128::from(MAX_RELAY_INBOX_TTL_MS);
+    held.validate_witness(destination, far_future, TEST_NETWORK_ID)?;
+    Ok(())
+}
+
+#[test]
+fn test_witness_rejects_a_tampered_payload_and_a_reset_floor() -> Result<()> {
+    let now_ms = get_epoch_ms();
+    let holder = session()?;
+    let destination: Did = SecretKey::random().address().into();
+    let mut held = held_by(&holder, destination, TEST_NETWORK_ID)?;
+    held.payload.transaction.tx_id = uuid::Uuid::new_v4();
+    assert!(matches!(
+        held.validate_witness(destination, now_ms, TEST_NETWORK_ID),
+        Err(Error::RelayMessageUnverifiable)
+    ));
+
+    let held = held_by(&holder, destination, TEST_NETWORK_ID)?;
+    let mut with_floor = live_at(Entry::inbox_delta(&held)?, now_ms);
+    with_floor.crdt.register = Some(super::EntryVersion::new(
+        now_ms,
+        holder.account_did(),
+        Did::from(0u32),
+    ));
+    assert!(matches!(
+        with_floor.validate_admissible_at(now_ms, TEST_NETWORK_ID),
+        Err(Error::RelayInboxRegisterNotAllowed)
+    ));
+    Ok(())
+}
+
 #[test]
 fn test_inbox_uses_its_own_retention_policy() -> Result<()> {
+    let now_ms = get_epoch_ms();
     let destination: Did = SecretKey::random().address().into();
-    let delta = Entry::inbox_delta(&custom_to(destination, TEST_NETWORK_ID)?)?;
-    let stamped = EntryOperation::Extend(delta.clone()).stamped(NOW_MS, Did::from(1u32))?;
+    let held = held_by(&session()?, destination, TEST_NETWORK_ID)?;
+    let delta = Entry::inbox_delta(&held)?;
+
+    let stamped = EntryOperation::Extend(delta.clone()).stamped(now_ms, Did::from(9u32))?;
     assert_eq!(
         stamped.entry().expires_at_ms,
-        Some(NOW_MS + u128::from(DEFAULT_RELAY_INBOX_TTL_MS))
+        Some(now_ms + u128::from(DEFAULT_RELAY_INBOX_TTL_MS))
     );
-    assert!(u128::from(DEFAULT_RELAY_INBOX_TTL_MS) > u128::from(MAX_TTL_MS));
 
-    let mut at_limit = delta.clone();
-    at_limit.expires_at_ms =
-        Some(NOW_MS + u128::from(MAX_RELAY_INBOX_TTL_MS) + TS_OFFSET_TOLERANCE_MS);
-    at_limit.validate_admissible_at(NOW_MS, TEST_NETWORK_ID)?;
+    let mut long = delta.clone();
+    long.expires_at_ms = Some(now_ms + u128::from(MAX_RELAY_INBOX_TTL_MS));
+    long.validate_admissible_at(now_ms, TEST_NETWORK_ID)?;
 
-    let mut beyond = delta;
-    beyond.expires_at_ms =
-        Some(NOW_MS + u128::from(MAX_RELAY_INBOX_TTL_MS) + TS_OFFSET_TOLERANCE_MS + 1);
+    let mut too_long = delta;
+    too_long.expires_at_ms =
+        Some(now_ms + u128::from(MAX_RELAY_INBOX_TTL_MS) + TS_OFFSET_TOLERANCE_MS + 1);
     assert!(matches!(
-        beyond.validate_admissible_at(NOW_MS, TEST_NETWORK_ID),
+        too_long.validate_admissible_at(now_ms, TEST_NETWORK_ID),
         Err(Error::EntryLifetimeExceedsMax)
+    ));
+    assert!(u128::from(MAX_TTL_MS) < u128::from(MAX_RELAY_INBOX_TTL_MS));
+    Ok(())
+}
+
+#[test]
+fn test_hold_authority_admits_only_the_responsible_node() -> Result<()> {
+    let holder = session()?;
+    let destination: Did = SecretKey::random().address().into();
+    let held = held_by(&holder, destination, TEST_NETWORK_ID)?;
+    let hold = EntryOperation::Extend(Entry::inbox_delta(&held)?);
+    let responsible = holder.account_did();
+    let stranger: Did = SecretKey::random().address().into();
+
+    hold.validate_inbox_authority(responsible, Some(responsible))?;
+    assert!(matches!(
+        hold.validate_inbox_authority(stranger, Some(responsible)),
+        Err(Error::RelayMessageHolderNotResponsible)
+    ));
+    assert!(matches!(
+        hold.validate_inbox_authority(responsible, Some(stranger)),
+        Err(Error::RelayMessageHolderNotResponsible)
+    ));
+    assert!(matches!(
+        hold.validate_inbox_authority(responsible, None),
+        Err(Error::RelayMessageHolderNotResponsible)
     ));
     Ok(())
 }
 
-/// Draining: compacting the delivered messages out of the inbox leaves a floor that excludes
-/// them from every later join, so a stale copy cannot redeliver.
 #[test]
-fn test_compaction_retires_delivered_messages_from_the_inbox() -> Result<()> {
+fn test_removal_authority_is_the_recipient_alone_and_nothing_else_is_allowed() -> Result<()> {
     let destination: Did = SecretKey::random().address().into();
-    let owner = Did::from(9u32);
-    let first = Entry::inbox_delta(&custom_to(destination, TEST_NETWORK_ID)?)?;
-    let second = Entry::inbox_delta(&custom_to(destination, TEST_NETWORK_ID)?)?;
-    let inbox = Entry::new(first.did, Vec::new(), EntryKind::RelayMessage)
-        .operate(
-            NOW_MS,
-            EntryOperation::Extend(first.clone()).stamped(NOW_MS, owner)?,
-            owner,
-        )?
-        .operate(
-            NOW_MS,
-            EntryOperation::Extend(second.clone()).stamped(NOW_MS, owner)?,
-            owner,
-        )?;
-    assert_eq!(inbox.data.len(), 2);
+    let carrier = Entry::new(inbox_key(destination), Vec::new(), EntryKind::RelayMessage);
+    let responsible: Did = SecretKey::random().address().into();
 
-    let delivered = Entry::new(first.did, first.data.clone(), EntryKind::RelayMessage);
-    let compaction = EntryOperation::CompactData(delivered).stamped(NOW_MS + 1, destination)?;
-    let compacted = inbox.operate(NOW_MS + 1, compaction, destination)?;
-    assert_eq!(compacted.data, second.data);
-    assert!(compacted.crdt.tombstones.is_empty());
+    EntryOperation::Tombstone(carrier.clone())
+        .validate_inbox_authority(destination, Some(responsible))?;
+    assert!(matches!(
+        EntryOperation::Tombstone(carrier.clone())
+            .validate_inbox_authority(responsible, Some(responsible)),
+        Err(Error::RelayInboxWriterNotRecipient)
+    ));
+    for op in [
+        EntryOperation::Overwrite(carrier.clone()),
+        EntryOperation::Touch(carrier.clone()),
+        EntryOperation::CompactData(carrier.clone()),
+    ] {
+        assert!(matches!(
+            op.validate_inbox_authority(destination, Some(responsible)),
+            Err(Error::RelayInboxOperationNotAllowed)
+        ));
+    }
+    assert!(matches!(
+        carrier.compact_data(get_epoch_ms(), carrier.clone(), destination),
+        Err(Error::RelayInboxOperationNotAllowed)
+    ));
+    Ok(())
+}
 
-    let stale_copy = compacted.join(inbox)?;
-    assert_eq!(stale_copy.data, second.data);
+#[test]
+fn test_relocation_is_accepted_from_the_predecessor_alone() {
+    let predecessor = Did::from(3u32);
+    assert!(validate_inbox_relocation(predecessor, Some(predecessor)).is_ok());
+    assert!(matches!(
+        validate_inbox_relocation(Did::from(4u32), Some(predecessor)),
+        Err(Error::RelayInboxNotRelocatable)
+    ));
+    assert!(matches!(
+        validate_inbox_relocation(predecessor, None),
+        Err(Error::RelayInboxNotRelocatable)
+    ));
+}
+
+#[test]
+fn test_drain_delivers_the_witnessed_elements_and_retires_every_element_by_dot() -> Result<()> {
+    let now_ms = get_epoch_ms();
+    let holder = session()?;
+    let destination: Did = SecretKey::random().address().into();
+    let actor = holder.account_did();
+    let first = held_by(&holder, destination, TEST_NETWORK_ID)?;
+    let second = held_by(&holder, destination, TEST_NETWORK_ID)?;
+    let junk = held_by(&holder, destination, TEST_NETWORK_ID + 1)?;
+
+    let mut carrier = carrier_with(Entry::inbox_delta(&first)?, now_ms, actor)?;
+    carrier = carrier.extend(now_ms + 1, Entry::inbox_delta(&second)?, actor)?;
+    let mut with_junk = Entry::inbox_delta(&junk)?;
+    with_junk.data.push(junk.encode()?);
+    carrier = carrier.extend(now_ms + 2, with_junk, actor)?;
+    assert_eq!(carrier.data.len(), 3);
+
+    let drain = carrier.drain_inbox(now_ms + 3, TEST_NETWORK_ID);
+    assert_eq!(
+        drain
+            .deliverable
+            .iter()
+            .map(|payload| payload.transaction.tx_id)
+            .collect::<Vec<_>>(),
+        vec![
+            first.payload.transaction.tx_id,
+            second.payload.transaction.tx_id
+        ]
+    );
+    assert_eq!(drain.rejected, 1);
+    assert_eq!(drain.retired.crdt.dots, carrier.crdt.dots);
+    assert!(drain.retired.data.is_empty());
+
+    // Retiring by dot removes exactly the drained elements, and a stale copy that still carries
+    // them cannot resurrect them; an element held afterwards is untouched.
+    let stale = carrier.clone();
+    let retired = carrier.tombstone(drain.retired)?;
+    assert!(retired.data.is_empty());
+    assert!(retired.join(stale)?.data.is_empty());
+    let third = held_by(&holder, destination, TEST_NETWORK_ID)?;
+    let after = retired.extend(now_ms + 4, Entry::inbox_delta(&third)?, actor)?;
+    assert_eq!(after.data, vec![third.encode()?]);
+    Ok(())
+}
+
+#[test]
+fn test_inbox_keeps_the_newest_elements_and_bounds_its_tombstones() -> Result<()> {
+    let now_ms = get_epoch_ms();
+    let holder = session()?;
+    let destination: Did = SecretKey::random().address().into();
+    let actor = holder.account_did();
+    let mut carrier = Entry::new(inbox_key(destination), Vec::new(), EntryKind::RelayMessage);
+    let mut newest = None;
+    for index in 0..RELAY_INBOX_MAX_LEN + 1 {
+        let held = held_by(&holder, destination, TEST_NETWORK_ID)?;
+        newest = Some(held.encode()?);
+        carrier = carrier.extend(now_ms + index as u128, Entry::inbox_delta(&held)?, actor)?;
+    }
+    assert_eq!(carrier.data.len(), RELAY_INBOX_MAX_LEN);
+    assert_eq!(carrier.data.last(), newest.as_ref());
+
+    let drained = carrier.drain_inbox(now_ms, TEST_NETWORK_ID);
+    let retired = carrier.tombstone(drained.retired)?;
+    assert!(retired.data.is_empty());
+    assert!(retired.crdt.tombstones.len() <= RELAY_INBOX_MAX_LEN);
     Ok(())
 }

--- a/crates/core/src/dht/entry/test_inbox.rs
+++ b/crates/core/src/dht/entry/test_inbox.rs
@@ -6,6 +6,8 @@ use super::Entry;
 use super::EntryKind;
 use super::EntryOperation;
 use super::EntryVersion;
+use super::PlacedEntry;
+use super::PlacedEntryOperation;
 use crate::consts::DEFAULT_RELAY_INBOX_TTL_MS;
 use crate::consts::DEFAULT_TTL_MS;
 use crate::consts::MAX_RELAY_INBOX_TTL_MS;
@@ -77,6 +79,41 @@ fn test_inbox_key_is_the_position_after_the_destination() {
     let destination = Did::from(41u32);
     assert_eq!(inbox_key(destination), Did::from(42u32));
     assert_eq!(inbox_destination(inbox_key(destination)), destination);
+}
+
+/// Placement law: a relay carrier has one placement, its DID, whatever redundancy the receiver
+/// configures, so no rotated replica key ever admits a hold; a data topic keeps its affine set.
+#[test]
+fn test_relay_carrier_has_one_placement_whatever_the_redundancy() -> Result<()> {
+    let holder = session()?;
+    let destination: Did = SecretKey::random().address().into();
+    let inbox = live_delta(
+        &held_by(&holder, destination, TEST_NETWORK_ID)?,
+        get_epoch_ms(),
+    )?;
+    let mut keys = inbox.did.rotate_affine(2)?.into_iter();
+    let (Some(own), Some(rotated)) = (keys.next(), keys.next()) else {
+        return Err(Error::InvalidAffineScalar);
+    };
+    assert_eq!(own, inbox.did);
+
+    assert!(PlacedEntry::new(own, inbox.clone())
+        .validate_placement(2)
+        .is_ok());
+    assert!(PlacedEntry::new(rotated, inbox.clone())
+        .validate_placement(2)
+        .is_err());
+    let hold = PlacedEntryOperation {
+        placement: rotated,
+        op: EntryOperation::Extend(inbox.clone()),
+    };
+    assert!(hold.validate_placement(2).is_err());
+
+    let topic = Entry::new(inbox.did, Vec::new(), EntryKind::Data);
+    assert!(PlacedEntry::new(rotated, topic)
+        .validate_placement(2)
+        .is_ok());
+    Ok(())
 }
 
 #[test]

--- a/crates/core/src/dht/entry/test_inbox.rs
+++ b/crates/core/src/dht/entry/test_inbox.rs
@@ -25,6 +25,7 @@ use crate::message::MessageVerification;
 use crate::message::NotifyPredecessorSend;
 use crate::message::SigningDomain;
 use crate::session::SessionSk;
+use crate::tests::with_retention;
 use crate::tests::TEST_NETWORK_ID;
 use crate::utils::get_epoch_ms;
 
@@ -71,13 +72,6 @@ fn holder_signature_at(
     })
 }
 
-/// A carrier stamped live at `now_ms`.
-fn live_at(entry: Entry, now_ms: u128) -> Entry {
-    let mut entry = entry;
-    entry.expires_at_ms = Some(now_ms + u128::from(DEFAULT_RELAY_INBOX_TTL_MS));
-    entry
-}
-
 /// The owner's carrier after admitting `delta` as a hold at `now_ms`.
 fn carrier_with(delta: Entry, now_ms: u128, actor: Did) -> Result<Entry> {
     Entry::new(delta.did, Vec::new(), EntryKind::RelayMessage).extend(now_ms, delta, actor)
@@ -96,7 +90,10 @@ fn test_witness_admits_a_held_custom_message_addressed_to_the_recipient() -> Res
     let holder = session()?;
     let destination: Did = SecretKey::random().address().into();
     let held = held_by(&holder, destination, TEST_NETWORK_ID)?;
-    let delta = live_at(Entry::inbox_delta(&held)?, now_ms);
+    let delta = with_retention(
+        Entry::inbox_delta(&held)?,
+        now_ms + u128::from(DEFAULT_RELAY_INBOX_TTL_MS),
+    );
 
     assert_eq!(delta.did, inbox_key(destination));
     delta.validate_admissible_at(now_ms, TEST_NETWORK_ID)?;
@@ -109,7 +106,10 @@ fn test_witness_rejects_a_message_addressed_elsewhere() -> Result<()> {
     let now_ms = get_epoch_ms();
     let destination: Did = SecretKey::random().address().into();
     let held = held_by(&session()?, destination, TEST_NETWORK_ID)?;
-    let mut misfiled = live_at(Entry::inbox_delta(&held)?, now_ms);
+    let mut misfiled = with_retention(
+        Entry::inbox_delta(&held)?,
+        now_ms + u128::from(DEFAULT_RELAY_INBOX_TTL_MS),
+    );
     misfiled.did = inbox_key(SecretKey::random().address().into());
 
     assert!(matches!(
@@ -216,7 +216,10 @@ fn test_witness_rejects_a_tampered_payload_and_a_reset_floor() -> Result<()> {
     ));
 
     let held = held_by(&holder, destination, TEST_NETWORK_ID)?;
-    let mut with_floor = live_at(Entry::inbox_delta(&held)?, now_ms);
+    let mut with_floor = with_retention(
+        Entry::inbox_delta(&held)?,
+        now_ms + u128::from(DEFAULT_RELAY_INBOX_TTL_MS),
+    );
     with_floor.crdt.register = Some(EntryVersion::new(
         now_ms,
         holder.account_did(),

--- a/crates/core/src/dht/entry/test_inbox.rs
+++ b/crates/core/src/dht/entry/test_inbox.rs
@@ -1,6 +1,6 @@
 use super::inbox::inbox_destination;
 use super::inbox::inbox_key;
-use super::inbox::validate_inbox_relocation;
+use super::inbox::relocates_from_predecessor;
 use super::inbox::HeldMessage;
 use super::Entry;
 use super::EntryKind;
@@ -414,15 +414,12 @@ fn test_removal_authority_is_the_recipient_alone_and_nothing_else_is_allowed() -
 #[test]
 fn test_relocation_is_accepted_from_the_predecessor_alone() {
     let predecessor = Did::from(3u32);
-    assert!(validate_inbox_relocation(predecessor, Some(predecessor)).is_ok());
-    assert!(matches!(
-        validate_inbox_relocation(Did::from(4u32), Some(predecessor)),
-        Err(Error::RelayInboxNotRelocatable)
+    assert!(relocates_from_predecessor(predecessor, Some(predecessor)));
+    assert!(!relocates_from_predecessor(
+        Did::from(4u32),
+        Some(predecessor)
     ));
-    assert!(matches!(
-        validate_inbox_relocation(predecessor, None),
-        Err(Error::RelayInboxNotRelocatable)
-    ));
+    assert!(!relocates_from_predecessor(predecessor, None));
 }
 
 #[test]

--- a/crates/core/src/dht/entry/test_inbox.rs
+++ b/crates/core/src/dht/entry/test_inbox.rs
@@ -6,6 +6,7 @@ use super::inbox::HELD_MESSAGE_DOMAIN_TAG;
 use super::Entry;
 use super::EntryKind;
 use super::EntryOperation;
+use super::EntryVersion;
 use crate::consts::DEFAULT_RELAY_INBOX_TTL_MS;
 use crate::consts::DEFAULT_TTL_MS;
 use crate::consts::MAX_RELAY_INBOX_TTL_MS;
@@ -216,7 +217,7 @@ fn test_witness_rejects_a_tampered_payload_and_a_reset_floor() -> Result<()> {
 
     let held = held_by(&holder, destination, TEST_NETWORK_ID)?;
     let mut with_floor = live_at(Entry::inbox_delta(&held)?, now_ms);
-    with_floor.crdt.register = Some(super::EntryVersion::new(
+    with_floor.crdt.register = Some(EntryVersion::new(
         now_ms,
         holder.account_did(),
         Did::from(0u32),

--- a/crates/core/src/dht/entry/test_inbox.rs
+++ b/crates/core/src/dht/entry/test_inbox.rs
@@ -442,30 +442,28 @@ fn test_partition_pairs_each_witnessed_element_with_its_dot_and_retires_the_rest
 
 #[test]
 fn test_inbox_keeps_the_newest_elements_and_bounds_its_tombstones() -> Result<()> {
-    let now_ms = get_epoch_ms();
     let holder = session()?;
     let destination: Did = SecretKey::random().address().into();
     let actor = holder.account_did();
 
     // Two full inboxes, drained in turn: the second drain leaves twice the cap of removals to
-    // choose from, and the carrier keeps the newest cap of them.
+    // choose from, and the carrier keeps the newest cap of them. Every instant is read from the
+    // clock the holder signatures use, so the witness never sees a hold ahead of its judge.
     let mut carrier = Entry::new(inbox_key(destination), Vec::new(), EntryKind::RelayMessage);
-    let mut clock = now_ms;
     let mut first_round_dots = Vec::new();
     for round in 0..2 {
         let mut newest = None;
         for _ in 0..RELAY_INBOX_MAX_LEN + 1 {
-            clock += 1;
             let held = held_by(&holder, destination, TEST_NETWORK_ID)?;
             newest = Some(held.encode()?);
-            carrier = carrier.extend(clock, Entry::inbox_delta(&held)?, actor)?;
+            carrier = carrier.extend(get_epoch_ms(), Entry::inbox_delta(&held)?, actor)?;
         }
         assert_eq!(carrier.data.len(), RELAY_INBOX_MAX_LEN);
         assert_eq!(carrier.data.last(), newest.as_ref());
         if round == 0 {
             first_round_dots = carrier.crdt.dots.clone();
         }
-        let drained = carrier.partition_inbox(clock, TEST_NETWORK_ID);
+        let drained = carrier.partition_inbox(get_epoch_ms(), TEST_NETWORK_ID);
         let removal = carrier.removal_of(drained.deliverable.iter().map(|element| element.dot));
         carrier = carrier.tombstone(removal)?;
         assert!(carrier.data.is_empty());

--- a/crates/core/src/dht/mod.rs
+++ b/crates/core/src/dht/mod.rs
@@ -22,6 +22,7 @@ pub use chord::EntryStorage;
 pub use chord::PeerRing;
 pub use chord::PeerRingAction;
 pub use chord::RemoteAction as PeerRingRemoteAction;
+pub(crate) use chord::StorageKey;
 pub use chord::TopoInfo;
 pub use did::Did;
 pub use finger::FingerTable;

--- a/crates/core/src/dht/mod.rs
+++ b/crates/core/src/dht/mod.rs
@@ -30,10 +30,12 @@ pub use finger::DEFAULT_FINGER_TABLE_SIZE;
 pub(crate) use stabilization::maintenance_phase_trace_for_test;
 #[cfg(all(test, target_family = "wasm"))]
 pub(crate) use stabilization::reset_maintenance_phase_trace_for_test;
+pub use stabilization::InboxDelivery;
 #[cfg(all(test, target_family = "wasm"))]
 pub(crate) use stabilization::MaintenancePhaseEvent;
 #[cfg(all(test, target_family = "wasm"))]
 pub(crate) use stabilization::MaintenancePhaseKind;
+pub use stabilization::SharedInboxDelivery;
 pub use stabilization::Stabilizer;
 pub use stabilization::StorageRepairOutcome;
 pub(crate) use stabilization::DISCONNECTED_CONNECTION_GRACE_MS;

--- a/crates/core/src/dht/mod.rs
+++ b/crates/core/src/dht/mod.rs
@@ -37,6 +37,8 @@ pub(crate) use stabilization::MaintenancePhaseKind;
 pub use stabilization::Stabilizer;
 pub use stabilization::StorageRepairOutcome;
 pub(crate) use stabilization::DISCONNECTED_CONNECTION_GRACE_MS;
+#[cfg(all(test, feature = "dummy", not(target_family = "wasm")))]
+pub(crate) use stabilization::STORAGE_REPAIR_FRESH_CONNECTION_GRACE_MS;
 pub(crate) use storage::StorageSyncDelivery;
 pub(crate) use storage::StorageSyncDeliveryCursor;
 pub use storage::StorageSyncDestination;

--- a/crates/core/src/dht/mod.rs
+++ b/crates/core/src/dht/mod.rs
@@ -31,12 +31,11 @@ pub use finger::DEFAULT_FINGER_TABLE_SIZE;
 pub(crate) use stabilization::maintenance_phase_trace_for_test;
 #[cfg(all(test, target_family = "wasm"))]
 pub(crate) use stabilization::reset_maintenance_phase_trace_for_test;
-pub use stabilization::InboxDelivery;
+pub(crate) use stabilization::InboxDelivery;
 #[cfg(all(test, target_family = "wasm"))]
 pub(crate) use stabilization::MaintenancePhaseEvent;
 #[cfg(all(test, target_family = "wasm"))]
 pub(crate) use stabilization::MaintenancePhaseKind;
-pub use stabilization::SharedInboxDelivery;
 pub use stabilization::Stabilizer;
 pub use stabilization::StorageRepairOutcome;
 pub(crate) use stabilization::DISCONNECTED_CONNECTION_GRACE_MS;

--- a/crates/core/src/dht/stabilization.rs
+++ b/crates/core/src/dht/stabilization.rs
@@ -21,6 +21,7 @@ use crate::dht::PeerRingRemoteAction;
 use crate::dht::TopoInfo;
 use crate::error::Error;
 use crate::error::Result;
+use crate::message::handlers::inbox::drain_inbox;
 use crate::message::FindSuccessorReportHandler;
 use crate::message::FindSuccessorSend;
 use crate::message::FindSuccessorThen;
@@ -30,6 +31,7 @@ use crate::message::NotifyPredecessorSend;
 use crate::message::PayloadSender;
 use crate::message::PeerLivenessProbe;
 use crate::message::QueryForTopoInfoSend;
+use crate::swarm::callback::SharedSwarmCallback;
 use crate::swarm::transport::PendingConnectionAttempt;
 use crate::swarm::transport::SwarmTransport;
 use crate::swarm::transport::TransportReadiness;
@@ -178,13 +180,19 @@ where F: Future<Output = Result<T>> {
 pub struct Stabilizer {
     transport: Arc<SwarmTransport>,
     dht: Arc<PeerRing>,
+    /// The application the drained relay inbox is delivered to.
+    swarm_callback: SharedSwarmCallback,
 }
 
 impl Stabilizer {
-    /// Create a new stabilization runner.
-    pub fn new(transport: Arc<SwarmTransport>) -> Self {
+    /// Create a new stabilization runner delivering drained inbox messages to `swarm_callback`.
+    pub fn new(transport: Arc<SwarmTransport>, swarm_callback: SharedSwarmCallback) -> Self {
         let dht = transport.dht.clone();
-        Self { transport, dht }
+        Self {
+            transport,
+            dht,
+            swarm_callback,
+        }
     }
 
     /// Run stabilization once.
@@ -195,6 +203,12 @@ impl Stabilizer {
 
     pub(crate) async fn stabilize_with_step_timeout(&self, timeout: Duration) -> Result<()> {
         self.stabilize_topology_with_step_timeout(timeout).await;
+        self.run_step(
+            "drain_inbox",
+            timeout,
+            drain_inbox(self.transport.clone(), &self.swarm_callback),
+        )
+        .await;
         self.transport.claim_storage_repair();
         let repair_outcome = self
             .run_step("repair_storage", timeout, self.repair_storage())

--- a/crates/core/src/dht/stabilization.rs
+++ b/crates/core/src/dht/stabilization.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use futures::future::FutureExt;
 use futures::pin_mut;
 use futures::select;
@@ -30,7 +31,6 @@ use crate::message::NotifyPredecessorSend;
 use crate::message::PayloadSender;
 use crate::message::PeerLivenessProbe;
 use crate::message::QueryForTopoInfoSend;
-use crate::swarm::callback::SwarmCallbackSlot;
 use crate::swarm::transport::PendingConnectionAttempt;
 use crate::swarm::transport::SwarmTransport;
 use crate::swarm::transport::TransportReadiness;
@@ -179,18 +179,36 @@ where F: Future<Output = Result<T>> {
 pub struct Stabilizer {
     transport: Arc<SwarmTransport>,
     dht: Arc<PeerRing>,
-    /// The application the drained relay inbox is delivered to, resolved at delivery time.
-    callback: SwarmCallbackSlot,
+    /// The layer that owns the application, which interprets the intent to deliver the inbox.
+    inbox: SharedInboxDelivery,
 }
 
+/// The one intent the storage maintenance phase emits toward the layer that owns the
+/// application: deliver this node's own relay inbox. The DHT names the intent; the swarm, which
+/// owns the callback and the inbound pipeline, interprets it.
+#[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
+#[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
+pub trait InboxDelivery {
+    /// Deliver every witnessed element of this node's inbox to the application and retire it.
+    async fn deliver_inbox(&self) -> Result<()>;
+}
+
+/// A shared interpreter of the inbox-delivery intent.
+#[cfg(all(feature = "wasm", target_family = "wasm"))]
+pub type SharedInboxDelivery = Arc<dyn InboxDelivery>;
+
+/// A shared interpreter of the inbox-delivery intent.
+#[cfg(not(all(feature = "wasm", target_family = "wasm")))]
+pub type SharedInboxDelivery = Arc<dyn InboxDelivery + Send + Sync>;
+
 impl Stabilizer {
-    /// Create a new stabilization runner delivering drained inbox messages to `callback`.
-    pub fn new(transport: Arc<SwarmTransport>, callback: SwarmCallbackSlot) -> Self {
+    /// Create a new stabilization runner whose inbox-delivery intent `inbox` interprets.
+    pub fn new(transport: Arc<SwarmTransport>, inbox: SharedInboxDelivery) -> Self {
         let dht = transport.dht.clone();
         Self {
             transport,
             dht,
-            callback,
+            inbox,
         }
     }
 

--- a/crates/core/src/dht/stabilization.rs
+++ b/crates/core/src/dht/stabilization.rs
@@ -188,22 +188,22 @@ pub struct Stabilizer {
 /// owns the callback and the inbound pipeline, interprets it.
 #[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
-pub trait InboxDelivery {
+pub(crate) trait InboxDelivery {
     /// Deliver every witnessed element of this node's inbox to the application and retire it.
     async fn deliver_inbox(&self) -> Result<()>;
 }
 
 /// A shared interpreter of the inbox-delivery intent.
 #[cfg(all(feature = "wasm", target_family = "wasm"))]
-pub type SharedInboxDelivery = Arc<dyn InboxDelivery>;
+pub(crate) type SharedInboxDelivery = Arc<dyn InboxDelivery>;
 
 /// A shared interpreter of the inbox-delivery intent.
 #[cfg(not(all(feature = "wasm", target_family = "wasm")))]
-pub type SharedInboxDelivery = Arc<dyn InboxDelivery + Send + Sync>;
+pub(crate) type SharedInboxDelivery = Arc<dyn InboxDelivery + Send + Sync>;
 
 impl Stabilizer {
     /// Create a new stabilization runner whose inbox-delivery intent `inbox` interprets.
-    pub fn new(transport: Arc<SwarmTransport>, inbox: SharedInboxDelivery) -> Self {
+    pub(crate) fn new(transport: Arc<SwarmTransport>, inbox: SharedInboxDelivery) -> Self {
         let dht = transport.dht.clone();
         Self {
             transport,

--- a/crates/core/src/dht/stabilization.rs
+++ b/crates/core/src/dht/stabilization.rs
@@ -30,7 +30,7 @@ use crate::message::NotifyPredecessorSend;
 use crate::message::PayloadSender;
 use crate::message::PeerLivenessProbe;
 use crate::message::QueryForTopoInfoSend;
-use crate::swarm::callback::SharedSwarmCallback;
+use crate::swarm::callback::SwarmCallbackSlot;
 use crate::swarm::transport::PendingConnectionAttempt;
 use crate::swarm::transport::SwarmTransport;
 use crate::swarm::transport::TransportReadiness;
@@ -179,18 +179,18 @@ where F: Future<Output = Result<T>> {
 pub struct Stabilizer {
     transport: Arc<SwarmTransport>,
     dht: Arc<PeerRing>,
-    /// The application the drained relay inbox is delivered to.
-    swarm_callback: SharedSwarmCallback,
+    /// The application the drained relay inbox is delivered to, resolved at delivery time.
+    callback: SwarmCallbackSlot,
 }
 
 impl Stabilizer {
-    /// Create a new stabilization runner delivering drained inbox messages to `swarm_callback`.
-    pub fn new(transport: Arc<SwarmTransport>, swarm_callback: SharedSwarmCallback) -> Self {
+    /// Create a new stabilization runner delivering drained inbox messages to `callback`.
+    pub fn new(transport: Arc<SwarmTransport>, callback: SwarmCallbackSlot) -> Self {
         let dht = transport.dht.clone();
         Self {
             transport,
             dht,
-            swarm_callback,
+            callback,
         }
     }
 
@@ -203,12 +203,7 @@ impl Stabilizer {
     pub(crate) async fn stabilize_with_step_timeout(&self, timeout: Duration) -> Result<()> {
         self.stabilize_topology_with_step_timeout(timeout).await;
         self.transport.claim_storage_repair();
-        let repair_outcome = self
-            .run_step("repair_storage", timeout, self.repair_storage())
-            .await;
-        if !matches!(repair_outcome, Some(StorageRepairOutcome::Complete)) {
-            self.transport.request_storage_repair();
-        }
+        self.maintain_storage_with_step_timeout(timeout).await;
         Ok(())
     }
 

--- a/crates/core/src/dht/stabilization.rs
+++ b/crates/core/src/dht/stabilization.rs
@@ -626,7 +626,7 @@ impl Stabilizer {
         if self.dht.did != successor_min {
             for s in successor_list {
                 let payload =
-                    MessagePayload::new_send(msg.clone(), self.transport.session_sk(), s, s)?;
+                    MessagePayload::new_send(msg.clone(), self.transport.message_signer(), s, s)?;
                 let tx_id = payload.transaction.tx_id;
                 let target_state = self
                     .transport
@@ -700,7 +700,7 @@ impl Stabilizer {
                     });
                     let payload = MessagePayload::new_send(
                         msg.clone(),
-                        self.transport.session_sk(),
+                        self.transport.message_signer(),
                         closest_predecessor,
                         closest_predecessor,
                     )?;

--- a/crates/core/src/dht/stabilization.rs
+++ b/crates/core/src/dht/stabilization.rs
@@ -12,6 +12,7 @@ use rings_transport::core::transport::WebrtcConnectionState;
 
 pub use self::storage_repair::StorageRepairOutcome;
 use crate::dht::successor::SuccessorReader;
+use crate::dht::topology;
 use crate::dht::types::CorrectChord;
 use crate::dht::Chord;
 use crate::dht::Did;
@@ -22,6 +23,7 @@ use crate::dht::TopoInfo;
 use crate::error::Error;
 use crate::error::Result;
 use crate::message::handlers::inbox::drain_inbox;
+use crate::message::handlers::storage::hand_off_storage;
 use crate::message::FindSuccessorReportHandler;
 use crate::message::FindSuccessorSend;
 use crate::message::FindSuccessorThen;
@@ -203,6 +205,8 @@ impl Stabilizer {
 
     pub(crate) async fn stabilize_with_step_timeout(&self, timeout: Duration) -> Result<()> {
         self.stabilize_topology_with_step_timeout(timeout).await;
+        self.run_step("hand_off_storage", timeout, self.hand_off_storage())
+            .await;
         self.run_step(
             "drain_inbox",
             timeout,
@@ -627,6 +631,22 @@ impl Stabilizer {
     #[cfg(all(test, feature = "dummy", not(target_family = "wasm")))]
     pub(crate) async fn probe_peer_liveness_for_simulation(&self) -> Result<()> {
         self.probe_peer_liveness().await
+    }
+
+    /// Placement invariant: every live local entry lies in `(self, head]`, or is offered to the
+    /// head as an ownership hand-off in this round.
+    ///
+    /// Placement is a function of the ring state, so this holds whichever input moved the head
+    /// (a notify report, a topology query, or a direct connection) and however the head was
+    /// reached. It is a round step rather than a transition effect because a delivery sent the
+    /// instant this node admits a peer can precede the peer's own admission of this node and be
+    /// dropped; the next round offers it again, and the ack-gated cleanup makes repetition
+    /// idempotent.
+    async fn hand_off_storage(&self) -> Result<()> {
+        let Some(head) = self.dht.with_topology_state(topology::successor_head)? else {
+            return Ok(());
+        };
+        hand_off_storage(self.transport.clone(), head).await
     }
 
     /// Notify predecessor, this is a DHT operation.

--- a/crates/core/src/dht/stabilization.rs
+++ b/crates/core/src/dht/stabilization.rs
@@ -12,7 +12,6 @@ use rings_transport::core::transport::WebrtcConnectionState;
 
 pub use self::storage_repair::StorageRepairOutcome;
 use crate::dht::successor::SuccessorReader;
-use crate::dht::topology;
 use crate::dht::types::CorrectChord;
 use crate::dht::Chord;
 use crate::dht::Did;
@@ -22,8 +21,6 @@ use crate::dht::PeerRingRemoteAction;
 use crate::dht::TopoInfo;
 use crate::error::Error;
 use crate::error::Result;
-use crate::message::handlers::inbox::drain_inbox;
-use crate::message::handlers::storage::hand_off_storage;
 use crate::message::FindSuccessorReportHandler;
 use crate::message::FindSuccessorSend;
 use crate::message::FindSuccessorThen;
@@ -205,14 +202,6 @@ impl Stabilizer {
 
     pub(crate) async fn stabilize_with_step_timeout(&self, timeout: Duration) -> Result<()> {
         self.stabilize_topology_with_step_timeout(timeout).await;
-        self.run_step("hand_off_storage", timeout, self.hand_off_storage())
-            .await;
-        self.run_step(
-            "drain_inbox",
-            timeout,
-            drain_inbox(self.transport.clone(), &self.swarm_callback),
-        )
-        .await;
         self.transport.claim_storage_repair();
         let repair_outcome = self
             .run_step("repair_storage", timeout, self.repair_storage())
@@ -631,22 +620,6 @@ impl Stabilizer {
     #[cfg(all(test, feature = "dummy", not(target_family = "wasm")))]
     pub(crate) async fn probe_peer_liveness_for_simulation(&self) -> Result<()> {
         self.probe_peer_liveness().await
-    }
-
-    /// Placement invariant: every live local entry lies in `(self, head]`, or is offered to the
-    /// head as an ownership hand-off in this round.
-    ///
-    /// Placement is a function of the ring state, so this holds whichever input moved the head
-    /// (a notify report, a topology query, or a direct connection) and however the head was
-    /// reached. It is a round step rather than a transition effect because a delivery sent the
-    /// instant this node admits a peer can precede the peer's own admission of this node and be
-    /// dropped; the next round offers it again, and the ack-gated cleanup makes repetition
-    /// idempotent.
-    async fn hand_off_storage(&self) -> Result<()> {
-        let Some(head) = self.dht.with_topology_state(topology::successor_head)? else {
-            return Ok(());
-        };
-        hand_off_storage(self.transport.clone(), head).await
     }
 
     /// Notify predecessor, this is a DHT operation.

--- a/crates/core/src/dht/stabilization/maintenance.rs
+++ b/crates/core/src/dht/stabilization/maintenance.rs
@@ -356,7 +356,8 @@ impl Stabilizer {
         &self,
         timeout: Duration,
     ) -> StorageRepairOutcome {
-        self.run_step("deliver_inbox", timeout, self.deliver_inbox())
+        // The intent to deliver this node's own relay inbox; the swarm interprets it.
+        self.run_step("deliver_inbox", timeout, self.inbox.deliver_inbox())
             .await;
         let outcome = self
             .run_step("repair_storage", timeout, self.repair_storage())

--- a/crates/core/src/dht/stabilization/maintenance.rs
+++ b/crates/core/src/dht/stabilization/maintenance.rs
@@ -274,8 +274,8 @@ impl Stabilizer {
 
     /// Run staggered maintenance until `stop` asks this loop to exit.
     ///
-    /// Repair requests are shared with disconnect handlers and survive missed
-    /// phase deadlines. Cooperative stop is observed between phases; the
+    /// Repair requests are shared with disconnect handlers and successor-head
+    /// changes and survive missed phase deadlines. Cooperative stop is observed between phases; the
     /// per-step deadline may still cancel a hung network maintenance future.
     pub async fn wait_with(self: Arc<Self>, interval: Duration, stop: StopToken) {
         let origin = Instant::now();

--- a/crates/core/src/dht/stabilization/maintenance.rs
+++ b/crates/core/src/dht/stabilization/maintenance.rs
@@ -323,7 +323,7 @@ impl Stabilizer {
                         MaintenanceTask::Repair,
                         now_ms,
                     );
-                    if let Some(outcome) = self.run_requested_storage_repair().await {
+                    if let Some(outcome) = self.run_requested_storage_maintenance().await {
                         schedule
                             .complete_repair(monotonic_elapsed_ms(&origin), outcome.is_complete());
                     }
@@ -339,22 +339,33 @@ impl Stabilizer {
         }
     }
 
-    pub(crate) async fn run_requested_storage_repair(&self) -> Option<StorageRepairOutcome> {
+    /// Run the storage maintenance phase if one was requested: deliver this node's own inbox,
+    /// then restore placement (ownership hand-off and additive republish).
+    pub(crate) async fn run_requested_storage_maintenance(&self) -> Option<StorageRepairOutcome> {
         if !self.transport.claim_storage_repair() {
             return None;
         }
+        Some(
+            self.maintain_storage_with_step_timeout(STABILIZATION_STEP_TIMEOUT)
+                .await,
+        )
+    }
+
+    /// The storage maintenance phase as two steps; an incomplete repair re-requests the phase.
+    pub(super) async fn maintain_storage_with_step_timeout(
+        &self,
+        timeout: Duration,
+    ) -> StorageRepairOutcome {
+        self.run_step("deliver_inbox", timeout, self.deliver_inbox())
+            .await;
         let outcome = self
-            .run_step(
-                "repair_storage",
-                STABILIZATION_STEP_TIMEOUT,
-                self.repair_storage(),
-            )
+            .run_step("repair_storage", timeout, self.repair_storage())
             .await
             .unwrap_or(StorageRepairOutcome::Deferred);
         if !outcome.is_complete() {
             self.transport.request_storage_repair();
         }
-        Some(outcome)
+        outcome
     }
 }
 

--- a/crates/core/src/dht/stabilization/storage_repair.rs
+++ b/crates/core/src/dht/stabilization/storage_repair.rs
@@ -353,7 +353,6 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::dht::entry::Entry;
     use crate::dht::entry::EntryKind;
     use crate::dht::entry::PlacedEntry;
     use crate::dht::StorageSyncDestination;
@@ -368,7 +367,8 @@ mod tests {
             .copied()
             .map(|value| {
                 let destination = StorageSyncDestination::PlacementKey(Did::from(value));
-                let entry = Entry::new(Did::from(value + 100), vec![], EntryKind::Data);
+                let entry =
+                    crate::tests::live_entry(Did::from(value + 100), vec![], EntryKind::Data);
                 PeerRingAction::sync_entries_for_repair(destination, vec![PlacedEntry::new(
                     destination.did(),
                     entry,

--- a/crates/core/src/dht/stabilization/storage_repair.rs
+++ b/crates/core/src/dht/stabilization/storage_repair.rs
@@ -313,12 +313,6 @@ impl Stabilizer {
         }
     }
 
-    /// Emit the intent to deliver this node's own relay inbox; the swarm interprets it (see
-    /// `swarm::inbox`).
-    pub(super) async fn deliver_inbox(&self) -> Result<()> {
-        self.inbox.deliver_inbox().await
-    }
-
     /// One bounded pass restoring the placement invariant of local storage.
     ///
     /// Invariant: every live local entry lies in `(self, head]` and at each of its affine

--- a/crates/core/src/dht/stabilization/storage_repair.rs
+++ b/crates/core/src/dht/stabilization/storage_repair.rs
@@ -320,7 +320,7 @@ impl Stabilizer {
         let callback = self
             .callback
             .read()
-            .map_err(|_| Error::CallbackSyncLockError)?
+            .map_err(|_| Error::LockPoisoned)?
             .clone();
         drain_inbox(self.transport.clone(), callback).await
     }
@@ -373,6 +373,7 @@ mod tests {
     use crate::session::SessionSk;
     use crate::storage::MemStorage;
     use crate::swarm::SwarmBuilder;
+    use crate::tests::live_entry;
 
     fn repair_deliveries(values: &[u32]) -> Result<Vec<StorageSyncDelivery>> {
         let actions = values
@@ -380,8 +381,7 @@ mod tests {
             .copied()
             .map(|value| {
                 let destination = StorageSyncDestination::PlacementKey(Did::from(value));
-                let entry =
-                    crate::tests::live_entry(Did::from(value + 100), vec![], EntryKind::Data);
+                let entry = live_entry(Did::from(value + 100), vec![], EntryKind::Data);
                 PeerRingAction::sync_entries_for_repair(destination, vec![PlacedEntry::new(
                     destination.did(),
                     entry,

--- a/crates/core/src/dht/stabilization/storage_repair.rs
+++ b/crates/core/src/dht/stabilization/storage_repair.rs
@@ -403,10 +403,10 @@ mod tests {
         );
 
         let selected = [
-            selected_destination(&swarm.stabilizer(), &[1, 2, 3])?,
-            selected_destination(&swarm.stabilizer(), &[2, 3])?,
-            selected_destination(&swarm.stabilizer(), &[1, 2, 3])?,
-            selected_destination(&swarm.stabilizer(), &[1, 2, 3])?,
+            selected_destination(&swarm.stabilizer()?, &[1, 2, 3])?,
+            selected_destination(&swarm.stabilizer()?, &[2, 3])?,
+            selected_destination(&swarm.stabilizer()?, &[1, 2, 3])?,
+            selected_destination(&swarm.stabilizer()?, &[1, 2, 3])?,
         ];
 
         assert_eq!(selected, [
@@ -430,7 +430,7 @@ mod tests {
             )
             .build(),
         );
-        let stabilizer = swarm.stabilizer();
+        let stabilizer = swarm.stabilizer()?;
 
         let selected = [
             selected_destination(&stabilizer, &[1, 2])?,

--- a/crates/core/src/dht/stabilization/storage_repair.rs
+++ b/crates/core/src/dht/stabilization/storage_repair.rs
@@ -9,7 +9,7 @@ use crate::dht::PeerRingAction;
 use crate::dht::StorageSyncDelivery;
 use crate::error::Error;
 use crate::error::Result;
-use crate::message::handlers::inbox::drain_inbox;
+use crate::message::handlers::inbox::deliver_inbox;
 use crate::message::SyncEntriesWithSuccessor;
 use crate::swarm::transport::TrackedStorageSyncOutcome;
 use crate::swarm::transport::TransportReadiness;
@@ -317,12 +317,7 @@ impl Stabilizer {
     /// Deliver this node's own relay inbox to the application it currently serves and retire the
     /// delivered elements (see `message::handlers::inbox`).
     pub(super) async fn deliver_inbox(&self) -> Result<()> {
-        let callback = self
-            .callback
-            .read()
-            .map_err(|_| Error::LockPoisoned)?
-            .clone();
-        drain_inbox(self.transport.clone(), callback).await
+        deliver_inbox(self.transport.clone(), self.callback.current()?).await
     }
 
     /// One bounded pass restoring the placement invariant of local storage.
@@ -355,7 +350,7 @@ impl Stabilizer {
         tracing::debug!(
             target: "rings_core::dht::stabilization",
             local = %self.dht.did,
-            "STABILIZATION repair_storage republish complete"
+            "STABILIZATION repair_storage complete"
         );
         Ok(outcome)
     }

--- a/crates/core/src/dht/stabilization/storage_repair.rs
+++ b/crates/core/src/dht/stabilization/storage_repair.rs
@@ -8,7 +8,6 @@ use crate::dht::Did;
 use crate::dht::PeerRingAction;
 use crate::dht::StorageSyncDelivery;
 use crate::error::Error;
-use crate::error::Error as CoreError;
 use crate::error::Result;
 use crate::message::handlers::inbox::drain_inbox;
 use crate::message::SyncEntriesWithSuccessor;
@@ -321,7 +320,7 @@ impl Stabilizer {
         let callback = self
             .callback
             .read()
-            .map_err(|_| CoreError::CallbackSyncLockError)?
+            .map_err(|_| Error::CallbackSyncLockError)?
             .clone();
         drain_inbox(self.transport.clone(), callback).await
     }

--- a/crates/core/src/dht/stabilization/storage_repair.rs
+++ b/crates/core/src/dht/stabilization/storage_repair.rs
@@ -8,6 +8,7 @@ use crate::dht::Did;
 use crate::dht::PeerRingAction;
 use crate::dht::StorageSyncDelivery;
 use crate::error::Error;
+use crate::error::Error as CoreError;
 use crate::error::Result;
 use crate::message::handlers::inbox::drain_inbox;
 use crate::message::SyncEntriesWithSuccessor;
@@ -314,26 +315,27 @@ impl Stabilizer {
         }
     }
 
-    /// The live local entries beyond `(self, head]`, offered to the head as an ownership
-    /// hand-off; nothing when the node stands alone.
-    async fn hand_off_action(&self) -> Result<PeerRingAction> {
-        match self.dht.with_topology_state(topology::successor_head)? {
-            Some(head) => self.dht.sync_entries_with_successor(head).await,
-            None => Ok(PeerRingAction::None),
-        }
+    /// Deliver this node's own relay inbox to the application it currently serves and retire the
+    /// delivered elements (see `message::handlers::inbox`).
+    pub(super) async fn deliver_inbox(&self) -> Result<()> {
+        let callback = self
+            .callback
+            .read()
+            .map_err(|_| CoreError::CallbackSyncLockError)?
+            .clone();
+        drain_inbox(self.transport.clone(), callback).await
     }
 
     /// One bounded pass restoring the placement invariant of local storage.
     ///
     /// Invariant: every live local entry lies in `(self, head]` and at each of its affine
-    /// owners, and this node's own inbox has been delivered. The pass drains the inbox, offers
-    /// the entries beyond the head to the head (ownership hand-off, whose local cleanup is
-    /// ack-gated), and republishes local entries to missing affine owners (additive), then sends
-    /// the deliveries through one repair window. Placement is a function of the ring state, so
-    /// the pass is the same whichever input moved the head; a head change only requests it, and
-    /// the fresh-connection grace of the window outlives the peer's own admission of this node,
-    /// which a send at admission time would race. Repetition is idempotent: deliveries are joins
-    /// and every local removal is acknowledged first.
+    /// owners. The pass offers the entries beyond the head to the head (ownership hand-off,
+    /// whose local cleanup is ack-gated) and republishes local entries to missing affine owners
+    /// (additive), then sends the deliveries through one repair window. Placement is a function
+    /// of the ring state, so the pass is the same whichever input moved the head; a head change
+    /// only requests it, and the fresh-connection grace of the window outlives the peer's own
+    /// admission of this node, which a send at admission time would race. Repetition is
+    /// idempotent: deliveries are joins and every local removal is acknowledged first.
     pub async fn repair_storage(&self) -> Result<StorageRepairOutcome> {
         tracing::debug!(
             target: "rings_core::dht::stabilization",
@@ -341,28 +343,15 @@ impl Stabilizer {
             redundancy = self.transport.storage_redundancy(),
             "STABILIZATION repair_storage start"
         );
-        drain_inbox(self.transport.clone(), &self.swarm_callback).await?;
-        let handoff = self.hand_off_action().await?;
+        let handoff = match self.dht.with_topology_state(topology::successor_head)? {
+            Some(head) => self.dht.sync_entries_with_successor(head).await?,
+            None => PeerRingAction::None,
+        };
         let republish = self
             .dht
             .republish_local_entries(self.transport.storage_redundancy())
             .await?;
         let action = PeerRingAction::MultiActions(vec![handoff, republish]);
-        let (action_kind, action_count) = match &action {
-            PeerRingAction::None => ("None", 0),
-            PeerRingAction::Some(_) => ("Some", 1),
-            PeerRingAction::SomeEntry(_) => ("SomeEntry", 1),
-            PeerRingAction::EntryMisses(misses) => ("EntryMisses", misses.len()),
-            PeerRingAction::RemoteAction(_, _) => ("RemoteAction", 1),
-            PeerRingAction::MultiActions(actions) => ("MultiActions", actions.len()),
-        };
-        tracing::debug!(
-            target: "rings_core::dht::stabilization",
-            local = %self.dht.did,
-            action_kind,
-            action_count,
-            "STABILIZATION repair_storage republish action prepared"
-        );
         let outcome = self.handle_storage_repair_action(action).await?;
         tracing::debug!(
             target: "rings_core::dht::stabilization",
@@ -428,10 +417,10 @@ mod tests {
         );
 
         let selected = [
-            selected_destination(&swarm.stabilizer()?, &[1, 2, 3])?,
-            selected_destination(&swarm.stabilizer()?, &[2, 3])?,
-            selected_destination(&swarm.stabilizer()?, &[1, 2, 3])?,
-            selected_destination(&swarm.stabilizer()?, &[1, 2, 3])?,
+            selected_destination(&swarm.stabilizer(), &[1, 2, 3])?,
+            selected_destination(&swarm.stabilizer(), &[2, 3])?,
+            selected_destination(&swarm.stabilizer(), &[1, 2, 3])?,
+            selected_destination(&swarm.stabilizer(), &[1, 2, 3])?,
         ];
 
         assert_eq!(selected, [
@@ -455,7 +444,7 @@ mod tests {
             )
             .build(),
         );
-        let stabilizer = swarm.stabilizer()?;
+        let stabilizer = swarm.stabilizer();
 
         let selected = [
             selected_destination(&stabilizer, &[1, 2])?,

--- a/crates/core/src/dht/stabilization/storage_repair.rs
+++ b/crates/core/src/dht/stabilization/storage_repair.rs
@@ -1,12 +1,15 @@
 use super::Stabilizer;
 use super::STORAGE_REPAIR_FRESH_CONNECTION_GRACE_MS;
 use super::STORAGE_REPAIR_MAX_DELIVERIES_PER_STEP;
+use crate::dht::topology;
 use crate::dht::types::ChordStorageRepair;
+use crate::dht::ChordStorageSync;
 use crate::dht::Did;
 use crate::dht::PeerRingAction;
 use crate::dht::StorageSyncDelivery;
 use crate::error::Error;
 use crate::error::Result;
+use crate::message::handlers::inbox::drain_inbox;
 use crate::message::SyncEntriesWithSuccessor;
 use crate::swarm::transport::TrackedStorageSyncOutcome;
 use crate::swarm::transport::TransportReadiness;
@@ -311,18 +314,40 @@ impl Stabilizer {
         }
     }
 
-    /// Republish locally-held entries to their current affine owners.
+    /// The live local entries beyond `(self, head]`, offered to the head as an ownership
+    /// hand-off; nothing when the node stands alone.
+    async fn hand_off_action(&self) -> Result<PeerRingAction> {
+        match self.dht.with_topology_state(topology::successor_head)? {
+            Some(head) => self.dht.sync_entries_with_successor(head).await,
+            None => Ok(PeerRingAction::None),
+        }
+    }
+
+    /// One bounded pass restoring the placement invariant of local storage.
+    ///
+    /// Invariant: every live local entry lies in `(self, head]` and at each of its affine
+    /// owners, and this node's own inbox has been delivered. The pass drains the inbox, offers
+    /// the entries beyond the head to the head (ownership hand-off, whose local cleanup is
+    /// ack-gated), and republishes local entries to missing affine owners (additive), then sends
+    /// the deliveries through one repair window. Placement is a function of the ring state, so
+    /// the pass is the same whichever input moved the head; a head change only requests it, and
+    /// the fresh-connection grace of the window outlives the peer's own admission of this node,
+    /// which a send at admission time would race. Repetition is idempotent: deliveries are joins
+    /// and every local removal is acknowledged first.
     pub async fn repair_storage(&self) -> Result<StorageRepairOutcome> {
         tracing::debug!(
             target: "rings_core::dht::stabilization",
             local = %self.dht.did,
             redundancy = self.transport.storage_redundancy(),
-            "STABILIZATION repair_storage republish start"
+            "STABILIZATION repair_storage start"
         );
-        let action = self
+        drain_inbox(self.transport.clone(), &self.swarm_callback).await?;
+        let handoff = self.hand_off_action().await?;
+        let republish = self
             .dht
             .republish_local_entries(self.transport.storage_redundancy())
             .await?;
+        let action = PeerRingAction::MultiActions(vec![handoff, republish]);
         let (action_kind, action_count) = match &action {
             PeerRingAction::None => ("None", 0),
             PeerRingAction::Some(_) => ("Some", 1),

--- a/crates/core/src/dht/stabilization/storage_repair.rs
+++ b/crates/core/src/dht/stabilization/storage_repair.rs
@@ -9,7 +9,6 @@ use crate::dht::PeerRingAction;
 use crate::dht::StorageSyncDelivery;
 use crate::error::Error;
 use crate::error::Result;
-use crate::message::handlers::inbox::deliver_inbox;
 use crate::message::SyncEntriesWithSuccessor;
 use crate::swarm::transport::TrackedStorageSyncOutcome;
 use crate::swarm::transport::TransportReadiness;
@@ -314,10 +313,10 @@ impl Stabilizer {
         }
     }
 
-    /// Deliver this node's own relay inbox to the application it currently serves and retire the
-    /// delivered elements (see `message::handlers::inbox`).
+    /// Emit the intent to deliver this node's own relay inbox; the swarm interprets it (see
+    /// `swarm::inbox`).
     pub(super) async fn deliver_inbox(&self) -> Result<()> {
-        deliver_inbox(self.transport.clone(), self.callback.current()?).await
+        self.inbox.deliver_inbox().await
     }
 
     /// One bounded pass restoring the placement invariant of local storage.

--- a/crates/core/src/dht/storage/mod.rs
+++ b/crates/core/src/dht/storage/mod.rs
@@ -42,9 +42,15 @@ pub enum StorageSyncPurpose {
 }
 
 impl StorageSyncPurpose {
-    /// Returns whether reports for this sync kind may drive source cleanup.
-    pub const fn permits_source_cleanup(self) -> bool {
+    /// Whether this sync moves ownership of its placements.
+    pub const fn is_ownership_handoff(self) -> bool {
         matches!(self, Self::OwnershipHandoff)
+    }
+
+    /// Returns whether reports for this sync kind may drive source cleanup: exactly the syncs
+    /// that move ownership.
+    pub const fn permits_source_cleanup(self) -> bool {
+        self.is_ownership_handoff()
     }
 }
 

--- a/crates/core/src/dht/storage/mod.rs
+++ b/crates/core/src/dht/storage/mod.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 use super::chord::PeerRing;
 use super::chord::PeerRingAction;
 use super::chord::RemoteAction;
+use super::entry::EntryKind;
 use super::entry::PlacedEntry;
 use super::topology;
 use super::topology::FindSuccessorStep;
@@ -315,6 +316,20 @@ impl PeerRing {
         owners.extend(state.predecessor);
         owners.extend(state.fingers.iter().flatten().copied());
         StorageVirtualNodes::from_owners(self.storage_virtual_node_config(), owners)
+    }
+
+    /// The owner of `placement_key` for a carrier of `kind`: a relay inbox is placed by the ring
+    /// geometry alone, so that its owner can attest who is responsible for its recipient (see
+    /// the `inbox` module); a data topic follows the configured storage mode.
+    pub(crate) fn find_storage_owner_for(
+        &self,
+        placement_key: Did,
+        kind: EntryKind,
+    ) -> Result<PeerRingAction> {
+        match kind {
+            EntryKind::Data => self.find_storage_owner(placement_key),
+            EntryKind::RelayMessage => self.find_successor(placement_key),
+        }
     }
 
     pub(crate) fn find_storage_owner(&self, placement_key: Did) -> Result<PeerRingAction> {

--- a/crates/core/src/dht/storage/repair.rs
+++ b/crates/core/src/dht/storage/repair.rs
@@ -35,9 +35,16 @@
 //! still cannot authorize source cleanup unless the sync purpose carries a
 //! non-virtual `handoff_proof`.
 //!
+//! Retention:
+//! Every stored entry carries a retention bound (see [`Entry`]). Reads retire
+//! a value whose bound has elapsed before returning it, so `sigma_n[k]` below
+//! always denotes the live value; an expired value is absent from every
+//! transition here and is never republished, copied, or acknowledged.
+//!
 //! Safety:
-//! - S1 Additivity (#612): repair transitions in this module never call
-//!   `storage.remove`; they only deliver additional joins.
+//! - S1 Additivity (#612): repair transitions in this module never remove a
+//!   live value; they only deliver additional joins. The only removals they
+//!   perform are retention retirements of values that are already expired.
 //! - S1' Ownership validation: receivers persist only placements they accept
 //!   under their current `view`; stale senders keep local entries and retry in a
 //!   later anti-entropy round.
@@ -75,6 +82,7 @@ use crate::dht::entry::PlacementMiss;
 use crate::dht::ChordStorageRepair;
 use crate::dht::Did;
 use crate::error::Result;
+use crate::utils::get_epoch_ms;
 
 fn merge_actions(actions: Vec<PeerRingAction>) -> PeerRingAction {
     if actions.is_empty() {
@@ -207,7 +215,7 @@ impl ChordStorageRepair<PeerRingAction> for PeerRing {
         // redundancy) is either joined locally when self accepts it or emitted
         // as a copy action toward the local view's storage-sync destination.
         let mut actions = Vec::new();
-        for (_, entry) in self.storage.get_all().await? {
+        for (_, entry) in self.live_storage_entries(get_epoch_ms()).await? {
             let action = self.republish_entry(entry, redundancy).await?;
             push_action(&mut actions, action);
         }

--- a/crates/core/src/dht/storage/repair.rs
+++ b/crates/core/src/dht/storage/repair.rs
@@ -77,6 +77,7 @@ use super::StorageSyncTarget;
 use crate::dht::chord::PeerRing;
 use crate::dht::chord::PeerRingAction;
 use crate::dht::entry::Entry;
+use crate::dht::entry::EntryKind;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::PlacementMiss;
 use crate::dht::ChordStorageRepair;
@@ -192,7 +193,8 @@ impl PeerRing {
         entry: Entry,
         redundancy: u16,
     ) -> Result<PeerRingAction> {
-        if redundancy <= 1 {
+        // A relay inbox has one owner and is never replicated.
+        if redundancy <= 1 || entry.kind == EntryKind::RelayMessage {
             return Ok(PeerRingAction::None);
         }
 

--- a/crates/core/src/dht/storage/repair.rs
+++ b/crates/core/src/dht/storage/repair.rs
@@ -77,7 +77,6 @@ use super::StorageSyncTarget;
 use crate::dht::chord::PeerRing;
 use crate::dht::chord::PeerRingAction;
 use crate::dht::entry::Entry;
-use crate::dht::entry::EntryKind;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::PlacementMiss;
 use crate::dht::ChordStorageRepair;
@@ -193,8 +192,7 @@ impl PeerRing {
         entry: Entry,
         redundancy: u16,
     ) -> Result<PeerRingAction> {
-        // A relay inbox has one owner and is never replicated.
-        if redundancy <= 1 || entry.kind == EntryKind::RelayMessage {
+        if entry.kind.replication(redundancy) <= 1 {
             return Ok(PeerRingAction::None);
         }
 

--- a/crates/core/src/dht/storage/repair.rs
+++ b/crates/core/src/dht/storage/repair.rs
@@ -126,6 +126,7 @@ impl PeerRing {
 
     async fn copy_entry_to_placement(
         &self,
+        now_ms: u128,
         placement_key: Did,
         entry: &Entry,
     ) -> Result<PeerRingAction> {
@@ -141,7 +142,7 @@ impl PeerRing {
         let placed = PlacedEntry::new(placement_key, entry.clone());
         match self.storage_sync_target(placement_key)? {
             StorageSyncTarget::Local => {
-                self.join_storage_entry(placement_key, entry.clone())
+                self.join_storage_entry(now_ms, placement_key, entry.clone())
                     .await?;
                 Ok(PeerRingAction::None)
             }
@@ -155,6 +156,7 @@ impl PeerRing {
 
     async fn copy_entry_to_observed_miss(
         &self,
+        now_ms: u128,
         miss: PlacementMiss,
         entry: &Entry,
         redundancy: u16,
@@ -173,7 +175,8 @@ impl PeerRing {
         let placed = PlacedEntry::new(miss.key, entry.clone());
         placed.validate_placement(redundancy)?;
         if miss.owner == self.did {
-            self.join_storage_entry(placed.key, placed.entry).await?;
+            self.join_storage_entry(now_ms, placed.key, placed.entry)
+                .await?;
             Ok(PeerRingAction::None)
         } else {
             Ok(PeerRingAction::sync_entries_for_repair(
@@ -183,7 +186,12 @@ impl PeerRing {
         }
     }
 
-    async fn republish_entry(&self, entry: Entry, redundancy: u16) -> Result<PeerRingAction> {
+    async fn republish_entry(
+        &self,
+        now_ms: u128,
+        entry: Entry,
+        redundancy: u16,
+    ) -> Result<PeerRingAction> {
         if redundancy <= 1 {
             return Ok(PeerRingAction::None);
         }
@@ -191,7 +199,9 @@ impl PeerRing {
         let entry = entry.try_into_storage_entry()?;
         let mut actions = Vec::new();
         for placement_key in entry.did.rotate_affine(redundancy)? {
-            let action = self.copy_entry_to_placement(placement_key, &entry).await?;
+            let action = self
+                .copy_entry_to_placement(now_ms, placement_key, &entry)
+                .await?;
             push_action(&mut actions, action);
         }
         Ok(merge_actions(actions))
@@ -214,9 +224,10 @@ impl ChordStorageRepair<PeerRingAction> for PeerRing {
         // Post S4: for every local entry e, each key in place(id(e),
         // redundancy) is either joined locally when self accepts it or emitted
         // as a copy action toward the local view's storage-sync destination.
+        let now_ms = get_epoch_ms();
         let mut actions = Vec::new();
-        for (_, entry) in self.live_storage_entries(get_epoch_ms()).await? {
-            let action = self.republish_entry(entry, redundancy).await?;
+        for (_, entry) in self.live_storage_entries(now_ms).await? {
+            let action = self.republish_entry(now_ms, entry, redundancy).await?;
             push_action(&mut actions, action);
         }
         Ok(merge_actions(actions))
@@ -240,10 +251,11 @@ impl ChordStorageRepair<PeerRingAction> for PeerRing {
         // used only to validate observed misses, never to synthesize targets.
         // Preservation S1/S3: this transition never removes and duplicate copy
         // actions are duplicate Entry::join deliveries.
+        let now_ms = get_epoch_ms();
         let mut actions = Vec::new();
         for miss in misses.iter().copied() {
             let action = self
-                .copy_entry_to_observed_miss(miss, &entry, redundancy)
+                .copy_entry_to_observed_miss(now_ms, miss, &entry, redundancy)
                 .await?;
             push_action(&mut actions, action);
         }

--- a/crates/core/src/dht/storage/sync.rs
+++ b/crates/core/src/dht/storage/sync.rs
@@ -124,7 +124,9 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
         let mut data = Vec::<PlacedEntry>::new();
         let all_items = self.live_storage_entries(get_epoch_ms()).await?;
 
-        // Pre: new_successor is the successor adopted by stabilization.
+        // Pre: new_successor is the current successor head, whichever input
+        // moved it. The stabilizer runs this every round, so a delivery lost
+        // before the head admitted this node is offered again.
         // Post S1: forall key in local_before, local_after[key] =
         // local_before[key]; this transition emits join deliveries only.
         // Post S2(copy): every emitted PlacedEntry keeps the exact local

--- a/crates/core/src/dht/storage/sync.rs
+++ b/crates/core/src/dht/storage/sync.rs
@@ -125,8 +125,8 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
         let all_items = self.live_storage_entries(get_epoch_ms()).await?;
 
         // Pre: new_successor is the current successor head, whichever input
-        // moved it. The stabilizer runs this every round, so a delivery lost
-        // before the head admitted this node is offered again.
+        // moved it. The storage repair pass runs this, so a delivery deferred
+        // or lost before the head admitted this node is offered again.
         // Post S1: forall key in local_before, local_after[key] =
         // local_before[key]; this transition emits join deliveries only.
         // Post S2(copy): every emitted PlacedEntry keeps the exact local

--- a/crates/core/src/dht/storage/sync.rs
+++ b/crates/core/src/dht/storage/sync.rs
@@ -146,12 +146,8 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
         let now_ms = get_epoch_ms();
         for ack in acks {
             let key = StorageKey::new(ack.entry.kind, ack.key);
-            let Some(local_entry) = self.live_storage_entry(key, now_ms).await? else {
-                continue;
-            };
-            if ack.confirms_local_value(&local_entry)? {
-                self.storage.remove(&key.to_string()).await?;
-            }
+            self.remove_storage_entry_confirmed_by(key, now_ms, ack)
+                .await?;
         }
 
         Ok(PeerRingAction::None)

--- a/crates/core/src/dht/storage/sync.rs
+++ b/crates/core/src/dht/storage/sync.rs
@@ -13,7 +13,6 @@ use crate::dht::chord::PeerRing;
 use crate::dht::chord::PeerRingAction;
 use crate::dht::did::BiasId;
 use crate::dht::entry::Entry;
-use crate::dht::entry::EntryKind;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::SyncedEntryAck;
 use crate::dht::ChordStorageSync;
@@ -124,7 +123,7 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
         // (see the `inbox` module); data topics follow the configured mode.
         let (relay, data): (Vec<_>, Vec<_>) = all_items
             .into_iter()
-            .partition(|(_, entry)| entry.kind == EntryKind::RelayMessage);
+            .partition(|(_, entry)| entry.kind.is_relay_inbox());
         let mut actions = vec![self.hand_off_beyond_successor(new_successor, relay)?];
         actions.push(if self.storage_virtual_nodes_enabled()? {
             self.copy_entries_to_observed_virtual_storage_owners(data)?
@@ -183,9 +182,7 @@ impl PeerRing {
         let mut data = Vec::<PlacedEntry>::new();
         for (entry_key_str, entry) in items {
             let entry_key = Did::from_str(&entry_key_str)?;
-            if BiasId::cmp_from_observer(self.did, entry_key, new_successor)
-                == std::cmp::Ordering::Greater
-            {
+            if self.placed_beyond(entry_key, new_successor) {
                 data.push(PlacedEntry::new(entry_key, entry));
             }
         }
@@ -201,6 +198,12 @@ impl PeerRing {
             })
             .collect::<Vec<_>>()
             .into())
+    }
+
+    /// `key ∉ (self, head]`: the placement lies beyond this node's interval up to `head`, so
+    /// `head` (or a node past it) owns it now.
+    fn placed_beyond(&self, key: Did, head: Did) -> bool {
+        BiasId::cmp_from_observer(self.did, key, head) == std::cmp::Ordering::Greater
     }
 
     fn copy_entries_to_observed_virtual_storage_owners(

--- a/crates/core/src/dht/storage/sync.rs
+++ b/crates/core/src/dht/storage/sync.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use async_trait::async_trait;
 use rings_transport::core::transport::MAX_DATA_CHANNEL_MESSAGE_SIZE;
 use serde::Serialize;
@@ -17,6 +15,7 @@ use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::SyncedEntryAck;
 use crate::dht::ChordStorageSync;
 use crate::dht::Did;
+use crate::dht::StorageKey;
 use crate::error::Error;
 use crate::error::Result;
 use crate::message::types::Message;
@@ -146,11 +145,12 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
         // is skipped.
         let now_ms = get_epoch_ms();
         for ack in acks {
-            let Some(local_entry) = self.live_storage_entry(ack.key, now_ms).await? else {
+            let key = StorageKey::new(ack.entry.kind, ack.key);
+            let Some(local_entry) = self.live_storage_entry(key, now_ms).await? else {
                 continue;
             };
             if ack.confirms_local_value(&local_entry)? {
-                self.storage.remove(&ack.key.to_string()).await?;
+                self.storage.remove(&key.to_string()).await?;
             }
         }
 
@@ -177,13 +177,12 @@ impl PeerRing {
     fn hand_off_beyond_successor(
         &self,
         new_successor: Did,
-        items: Vec<(String, Entry)>,
+        items: Vec<(StorageKey, Entry)>,
     ) -> Result<PeerRingAction> {
         let mut data = Vec::<PlacedEntry>::new();
-        for (entry_key_str, entry) in items {
-            let entry_key = Did::from_str(&entry_key_str)?;
-            if self.placed_beyond(entry_key, new_successor) {
-                data.push(PlacedEntry::new(entry_key, entry));
+        for (key, entry) in items {
+            if self.placed_beyond(key.placement(), new_successor) {
+                data.push(PlacedEntry::new(key.placement(), entry));
             }
         }
 
@@ -208,7 +207,7 @@ impl PeerRing {
 
     fn copy_entries_to_observed_virtual_storage_owners(
         &self,
-        all_items: Vec<(String, Entry)>,
+        all_items: Vec<(StorageKey, Entry)>,
     ) -> Result<PeerRingAction> {
         let mut by_target =
             std::collections::BTreeMap::<StorageSyncDestination, Vec<PlacedEntry>>::new();
@@ -223,13 +222,12 @@ impl PeerRing {
         // Preservation S1'': this transition cannot create a delete-capable
         // report. Only non-virtual physical handoff has an ownership proof
         // strong enough to permit source cleanup.
-        for (entry_key_str, entry) in all_items {
-            let entry_key = Did::from_str(&entry_key_str)?;
-            if let StorageSyncTarget::Remote(target) = self.storage_sync_target(entry_key)? {
+        for (key, entry) in all_items {
+            if let StorageSyncTarget::Remote(target) = self.storage_sync_target(key.placement())? {
                 by_target
                     .entry(target)
                     .or_default()
-                    .push(PlacedEntry::new(entry_key, entry));
+                    .push(PlacedEntry::new(key.placement(), entry));
             }
         }
 

--- a/crates/core/src/dht/storage/sync.rs
+++ b/crates/core/src/dht/storage/sync.rs
@@ -12,6 +12,8 @@ use crate::consts::TRANSPORT_CUSTOM_OVERHEAD;
 use crate::dht::chord::PeerRing;
 use crate::dht::chord::PeerRingAction;
 use crate::dht::did::BiasId;
+use crate::dht::entry::Entry;
+use crate::dht::entry::EntryKind;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::SyncedEntryAck;
 use crate::dht::ChordStorageSync;
@@ -117,45 +119,19 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
     /// `Entry`s that are no longer between current node and `new_successor`,
     /// and copy them to the new successor.
     async fn sync_entries_with_successor(&self, new_successor: Did) -> Result<PeerRingAction> {
-        if self.storage_virtual_nodes_enabled()? {
-            return self.copy_entries_to_observed_virtual_storage_owners().await;
-        }
-
-        let mut data = Vec::<PlacedEntry>::new();
         let all_items = self.live_storage_entries(get_epoch_ms()).await?;
-
-        // Pre: new_successor is the current successor head, whichever input
-        // moved it. The storage repair pass runs this, so a delivery deferred
-        // or lost before the head admitted this node is offered again.
-        // Post S1: forall key in local_before, local_after[key] =
-        // local_before[key]; this transition emits join deliveries only.
-        // Post S2(copy): every emitted PlacedEntry keeps the exact local
-        // placement key, so an eventual ack names the key whose durable copy was
-        // reported by the receiver.
-        // Preservation #611/#614: sync hand-off is join-before-ack-before-local
-        // cleanup. acknowledge_synced_entries is the only value-dependent local
-        // cleanup transition and does not define storage convergence; retention
-        // expiry retires values independently of their content.
-        for (entry_key_str, entry) in all_items {
-            let entry_key = Did::from_str(&entry_key_str)?;
-            if BiasId::cmp_from_observer(self.did, entry_key, new_successor)
-                == std::cmp::Ordering::Greater
-            {
-                data.push(PlacedEntry::new(entry_key, entry));
-            }
-        }
-
-        let batches = sync_entries_batches(data, SYNC_BATCH_MAX_BYTES)?;
-        Ok(batches
+        // Relay inboxes are placed by the ring geometry in every storage mode
+        // (see the `inbox` module); data topics follow the configured mode.
+        let (relay, data): (Vec<_>, Vec<_>) = all_items
             .into_iter()
-            .map(|batch| {
-                PeerRingAction::sync_entries_for_handoff(
-                    StorageSyncDestination::PhysicalOwner(new_successor),
-                    batch,
-                )
-            })
-            .collect::<Vec<_>>()
-            .into())
+            .partition(|(_, entry)| entry.kind == EntryKind::RelayMessage);
+        let mut actions = vec![self.hand_off_beyond_successor(new_successor, relay)?];
+        actions.push(if self.storage_virtual_nodes_enabled()? {
+            self.copy_entries_to_observed_virtual_storage_owners(data)?
+        } else {
+            self.hand_off_beyond_successor(new_successor, data)?
+        });
+        Ok(actions.into())
     }
 
     async fn acknowledge_synced_entries(&self, acks: &[SyncedEntryAck]) -> Result<PeerRingAction> {
@@ -184,8 +160,53 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
 }
 
 impl PeerRing {
-    async fn copy_entries_to_observed_virtual_storage_owners(&self) -> Result<PeerRingAction> {
-        let all_items = self.live_storage_entries(get_epoch_ms()).await?;
+    /// Offer every item placed beyond `(self, new_successor]` to `new_successor` as an
+    /// ownership hand-off.
+    ///
+    /// Pre: new_successor is the current successor head, whichever input
+    /// moved it. The storage repair pass runs this, so a delivery deferred
+    /// or lost before the head admitted this node is offered again.
+    /// Post S1: forall key in local_before, local_after[key] =
+    /// local_before[key]; this transition emits join deliveries only.
+    /// Post S2(copy): every emitted PlacedEntry keeps the exact local
+    /// placement key, so an eventual ack names the key whose durable copy was
+    /// reported by the receiver.
+    /// Preservation #611/#614: sync hand-off is join-before-ack-before-local
+    /// cleanup. acknowledge_synced_entries is the only value-dependent local
+    /// cleanup transition and does not define storage convergence; retention
+    /// expiry retires values independently of their content.
+    fn hand_off_beyond_successor(
+        &self,
+        new_successor: Did,
+        items: Vec<(String, Entry)>,
+    ) -> Result<PeerRingAction> {
+        let mut data = Vec::<PlacedEntry>::new();
+        for (entry_key_str, entry) in items {
+            let entry_key = Did::from_str(&entry_key_str)?;
+            if BiasId::cmp_from_observer(self.did, entry_key, new_successor)
+                == std::cmp::Ordering::Greater
+            {
+                data.push(PlacedEntry::new(entry_key, entry));
+            }
+        }
+
+        let batches = sync_entries_batches(data, SYNC_BATCH_MAX_BYTES)?;
+        Ok(batches
+            .into_iter()
+            .map(|batch| {
+                PeerRingAction::sync_entries_for_handoff(
+                    StorageSyncDestination::PhysicalOwner(new_successor),
+                    batch,
+                )
+            })
+            .collect::<Vec<_>>()
+            .into())
+    }
+
+    fn copy_entries_to_observed_virtual_storage_owners(
+        &self,
+        all_items: Vec<(String, Entry)>,
+    ) -> Result<PeerRingAction> {
         let mut by_target =
             std::collections::BTreeMap::<StorageSyncDestination, Vec<PlacedEntry>>::new();
 

--- a/crates/core/src/dht/storage/sync.rs
+++ b/crates/core/src/dht/storage/sync.rs
@@ -12,7 +12,6 @@ use crate::consts::TRANSPORT_CUSTOM_OVERHEAD;
 use crate::dht::chord::PeerRing;
 use crate::dht::chord::PeerRingAction;
 use crate::dht::did::BiasId;
-use crate::dht::entry::Entry;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::SyncedEntryAck;
 use crate::dht::ChordStorageSync;
@@ -21,6 +20,7 @@ use crate::error::Error;
 use crate::error::Result;
 use crate::message::types::Message;
 use crate::message::types::SyncEntriesWithSuccessor;
+use crate::utils::get_epoch_ms;
 
 /// Maximum wire budget for one `SyncEntriesWithSuccessor` hand-off batch.
 ///
@@ -122,7 +122,7 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
         }
 
         let mut data = Vec::<PlacedEntry>::new();
-        let all_items: Vec<(String, Entry)> = self.storage.get_all().await?;
+        let all_items = self.live_storage_entries(get_epoch_ms()).await?;
 
         // Pre: new_successor is the successor adopted by stabilization.
         // Post S1: forall key in local_before, local_after[key] =
@@ -131,8 +131,9 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
         // placement key, so an eventual ack names the key whose durable copy was
         // reported by the receiver.
         // Preservation #611/#614: sync hand-off is join-before-ack-before-local
-        // cleanup. acknowledge_synced_entries is the only local cleanup
-        // transition and does not define storage convergence.
+        // cleanup. acknowledge_synced_entries is the only value-dependent local
+        // cleanup transition and does not define storage convergence; retention
+        // expiry retires values independently of their content.
         for (entry_key_str, entry) in all_items {
             let entry_key = Did::from_str(&entry_key_str)?;
             if BiasId::cmp_from_observer(self.did, entry_key, new_successor)
@@ -166,8 +167,9 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
         // Preservation #614: a write racing between copy and ack changes the
         // canonical local value, so confirms_local_value is false and delete
         // is skipped.
+        let now_ms = get_epoch_ms();
         for ack in acks {
-            let Some(local_entry) = self.storage.get(&ack.key.to_string()).await? else {
+            let Some(local_entry) = self.live_storage_entry(ack.key, now_ms).await? else {
                 continue;
             };
             if ack.confirms_local_value(&local_entry)? {
@@ -181,7 +183,7 @@ impl ChordStorageSync<PeerRingAction> for PeerRing {
 
 impl PeerRing {
     async fn copy_entries_to_observed_virtual_storage_owners(&self) -> Result<PeerRingAction> {
-        let all_items: Vec<(String, Entry)> = self.storage.get_all().await?;
+        let all_items = self.live_storage_entries(get_epoch_ms()).await?;
         let mut by_target =
             std::collections::BTreeMap::<StorageSyncDestination, Vec<PlacedEntry>>::new();
 

--- a/crates/core/src/dht/storage/tests/mod.rs
+++ b/crates/core/src/dht/storage/tests/mod.rs
@@ -883,6 +883,32 @@ async fn test_live_storage_read_retires_expired_value() -> Result<()> {
     Ok(())
 }
 
+/// Retention law at the read boundary: a value written to storage without a retention bound (a
+/// fixture built with `Entry::new`, or a value from a build that predates retention) is not live,
+/// so it is reported absent, removed, and never republished or handed off.
+#[tokio::test]
+async fn test_live_storage_read_retires_an_unstamped_value() -> Result<()> {
+    let node = PeerRing::new_with_storage(Did::from(0u32), 3, Box::new(MemStorage::new()));
+    let placement_key = Did::from(100u32);
+    let unstamped = Entry::new(Did::from(10u32), vec!["value".into()], EntryKind::Data);
+    assert_eq!(unstamped.expires_at_ms, None);
+    node.storage
+        .put(&placement_key.to_string(), &unstamped)
+        .await?;
+
+    assert_eq!(
+        node.live_storage_entry(
+            StorageKey::new(EntryKind::Data, placement_key),
+            get_epoch_ms()
+        )
+        .await?,
+        None
+    );
+    assert_eq!(node.storage.get(&placement_key.to_string()).await?, None);
+    assert_eq!(node.republish_local_entries(2).await?, PeerRingAction::None);
+    Ok(())
+}
+
 /// Retention law: a bulk read returns only live values and retires the rest, so hand-off and
 /// republish never offer an expired value.
 #[tokio::test]

--- a/crates/core/src/dht/storage/tests/mod.rs
+++ b/crates/core/src/dht/storage/tests/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::str::FromStr;
 
 use async_trait::async_trait;
 
@@ -10,6 +11,7 @@ use super::sync::sync_entries_batches;
 use super::sync::SYNC_BATCH_MAX_BYTES;
 use crate::consts::MAX_CHUNK_ENVELOPE_OVERHEAD;
 use crate::consts::TRANSPORT_CUSTOM_OVERHEAD;
+use crate::dht::entry::inbox::inbox_key;
 use crate::dht::entry::Entry;
 use crate::dht::entry::EntryKind;
 use crate::dht::entry::EntryLookupKey;
@@ -26,17 +28,22 @@ use crate::dht::ChordStorageCache;
 use crate::dht::ChordStorageRepair;
 use crate::dht::ChordStorageSync;
 use crate::dht::Did;
+use crate::dht::StorageKey;
 use crate::dht::StorageSyncDestination;
 use crate::dht::StorageSyncPurpose;
 use crate::dht::StorageSyncRoute;
 use crate::dht::VirtualNodeConfig;
+use crate::ecc::SecretKey;
 use crate::error::Error;
 use crate::error::Result;
 use crate::message::types::Message;
 use crate::message::types::SyncEntriesWithSuccessor;
+use crate::message::Encoded;
+use crate::session::SessionSk;
 use crate::storage::KvStorageInterface;
 use crate::storage::MemStorage;
 use crate::tests::expired;
+use crate::tests::held_inbox_for;
 use crate::tests::live_entry;
 use crate::utils::get_epoch_ms;
 
@@ -865,8 +872,11 @@ async fn test_live_storage_read_retires_expired_value() -> Result<()> {
         .await?;
 
     assert_eq!(
-        node.live_storage_entry(placement_key, get_epoch_ms())
-            .await?,
+        node.live_storage_entry(
+            StorageKey::new(EntryKind::Data, placement_key),
+            get_epoch_ms()
+        )
+        .await?,
         None
     );
     assert_eq!(node.storage.get(&placement_key.to_string()).await?, None);
@@ -890,8 +900,65 @@ async fn test_live_storage_entries_retires_expired_values() -> Result<()> {
         .await?;
 
     let entries = node.live_storage_entries(get_epoch_ms()).await?;
-    assert_eq!(entries, vec![(live_key.to_string(), live_value)]);
+    assert_eq!(entries, vec![(
+        StorageKey::new(EntryKind::Data, live_key),
+        live_value
+    )]);
     assert_eq!(node.storage.count().await?, 1);
+    Ok(())
+}
+
+/// Key law: the two kinds a position can carry occupy distinct slots, the data slot keeps the
+/// historical rendering of a bare placement, and rendering is injective and invertible.
+#[test]
+fn test_storage_key_partitions_kinds_and_keeps_the_data_rendering() -> Result<()> {
+    let placement = Did::from(42u32);
+    let topic = StorageKey::new(EntryKind::Data, placement);
+    let inbox = StorageKey::new(EntryKind::RelayMessage, placement);
+
+    assert_eq!(topic.to_string(), placement.to_string());
+    assert_ne!(topic.to_string(), inbox.to_string());
+    assert_eq!(StorageKey::from_str(&topic.to_string())?, topic);
+    assert_eq!(StorageKey::from_str(&inbox.to_string())?, inbox);
+    assert_eq!(topic.placement(), placement);
+    assert_eq!(inbox.placement(), placement);
+    Ok(())
+}
+
+/// Namespace law at the write funnel: a data topic parked at the inbox position `d + 1` (any
+/// node may name any position through an overwrite) and the relay inbox kept for `d` are
+/// distinct carriers, so the topic cannot block the hold and the hold cannot touch the topic.
+#[tokio::test]
+async fn test_data_topic_at_the_inbox_position_does_not_block_the_hold() -> Result<()> {
+    let holder = SessionSk::new_with_seckey(&SecretKey::random())?;
+    // Standing alone, the node routes every position to itself and is the hold authority.
+    let node = PeerRing::new_with_storage(holder.account_did(), 3, Box::new(MemStorage::new()));
+    let destination = Did::from(50u32);
+    let position = inbox_key(destination);
+    let now_ms = get_epoch_ms();
+
+    let park = EntryOperation::Overwrite(data_entry_with_data(position, "parked"))
+        .stamped(now_ms, node.did)?;
+    node.operate_storage_entry(now_ms, position, park, node.did)
+        .await?;
+    let hold =
+        EntryOperation::Extend(held_inbox_for(destination, &holder)?).stamped(now_ms, node.did)?;
+    node.operate_storage_entry(now_ms, position, hold, node.did)
+        .await?;
+
+    let topic = node
+        .live_storage_entry(StorageKey::new(EntryKind::Data, position), now_ms)
+        .await?
+        .ok_or_else(|| Error::InvalidMessage("parked topic vanished".to_string()))?;
+    let inbox = node
+        .live_storage_entry(StorageKey::new(EntryKind::RelayMessage, position), now_ms)
+        .await?
+        .ok_or_else(|| Error::InvalidMessage("hold was not stored".to_string()))?;
+    assert_eq!(topic.kind, EntryKind::Data);
+    assert_eq!(topic.data, vec![Encoded::from("parked")]);
+    assert_eq!(inbox.kind, EntryKind::RelayMessage);
+    assert_eq!(inbox.data.len(), 1);
+    assert_eq!(node.storage.count().await?, 2);
     Ok(())
 }
 

--- a/crates/core/src/dht/storage/tests/mod.rs
+++ b/crates/core/src/dht/storage/tests/mod.rs
@@ -418,7 +418,7 @@ async fn test_local_fetch_falls_back_when_local_virtual_owner_has_no_entry() -> 
         )])])
     );
 
-    let local_fetch_lookup = node.entry_lookup_for_fetch::<1>(placement).await?;
+    let local_fetch_lookup = node.entry_lookup_for_fetch(placement, 1).await?;
     assert_eq!(
         local_fetch_lookup,
         PeerRingAction::MultiActions(vec![PeerRingAction::RemoteAction(

--- a/crates/core/src/dht/storage/tests/mod.rs
+++ b/crates/core/src/dht/storage/tests/mod.rs
@@ -36,6 +36,7 @@ use crate::message::types::Message;
 use crate::message::types::SyncEntriesWithSuccessor;
 use crate::storage::KvStorageInterface;
 use crate::storage::MemStorage;
+use crate::tests::expired;
 use crate::tests::live_entry;
 use crate::utils::get_epoch_ms;
 
@@ -849,11 +850,6 @@ async fn test_sync_batch_ack_deletes_acked_batch_and_retries_unacked_batches() -
     );
     assert_eq!(retried_entries, expected_remaining);
     Ok(())
-}
-
-fn expired(mut entry: Entry) -> Entry {
-    entry.expires_at_ms = Some(1);
-    entry
 }
 
 /// Retention law: a stored value whose bound elapsed is retired on read and reported absent.

--- a/crates/core/src/dht/storage/tests/mod.rs
+++ b/crates/core/src/dht/storage/tests/mod.rs
@@ -884,8 +884,8 @@ async fn test_live_storage_entries_retires_expired_values() -> Result<()> {
     let node = PeerRing::new_with_storage(Did::from(0u32), 3, Box::new(MemStorage::new()));
     let live_key = Did::from(100u32);
     let expired_key = Did::from(200u32);
-    let live_entry = data_entry(Did::from(10u32));
-    node.storage.put(&live_key.to_string(), &live_entry).await?;
+    let live_value = data_entry(Did::from(10u32));
+    node.storage.put(&live_key.to_string(), &live_value).await?;
     node.storage
         .put(
             &expired_key.to_string(),
@@ -894,7 +894,7 @@ async fn test_live_storage_entries_retires_expired_values() -> Result<()> {
         .await?;
 
     let entries = node.live_storage_entries(get_epoch_ms()).await?;
-    assert_eq!(entries, vec![(live_key.to_string(), live_entry)]);
+    assert_eq!(entries, vec![(live_key.to_string(), live_value)]);
     assert_eq!(node.storage.count().await?, 1);
     Ok(())
 }
@@ -906,7 +906,7 @@ async fn test_join_storage_entry_rejects_pinned_register() -> Result<()> {
     let node = PeerRing::new_with_storage(Did::from(0u32), 3, Box::new(MemStorage::new()));
     let placement_key = Did::from(100u32);
     let honest = data_entry_with_data(Did::from(10u32), "honest");
-    node.join_storage_entry(placement_key, honest.clone())
+    node.join_storage_entry(get_epoch_ms(), placement_key, honest.clone())
         .await?;
 
     let mut pinned = data_entry_with_data(Did::from(10u32), "pinned");
@@ -916,7 +916,8 @@ async fn test_join_storage_entry_rejects_pinned_register() -> Result<()> {
         Did::from(1u32),
     ));
     assert!(matches!(
-        node.join_storage_entry(placement_key, pinned).await,
+        node.join_storage_entry(get_epoch_ms(), placement_key, pinned)
+            .await,
         Err(Error::EntryVersionAheadOfClock)
     ));
     assert_eq!(
@@ -933,14 +934,19 @@ async fn test_join_storage_entry_bounds_retention() -> Result<()> {
     let placement_key = Did::from(100u32);
 
     assert!(matches!(
-        node.join_storage_entry(placement_key, expired(data_entry(Did::from(10u32))))
-            .await,
+        node.join_storage_entry(
+            get_epoch_ms(),
+            placement_key,
+            expired(data_entry(Did::from(10u32)))
+        )
+        .await,
         Err(Error::EntryNotLive)
     ));
     let mut overlong = data_entry(Did::from(10u32));
     overlong.expires_at_ms = Some(u128::MAX);
     assert!(matches!(
-        node.join_storage_entry(placement_key, overlong).await,
+        node.join_storage_entry(get_epoch_ms(), placement_key, overlong)
+            .await,
         Err(Error::EntryLifetimeExceedsMax)
     ));
     assert_eq!(node.storage.count().await?, 0);
@@ -959,8 +965,11 @@ async fn test_join_storage_entry_keeps_the_later_retention_bound() -> Result<()>
     let mut later = data_entry_with_data(Did::from(10u32), "b");
     later.expires_at_ms = Some(now_ms + 2_000);
 
-    node.join_storage_entry(placement_key, later).await?;
-    let stored = node.join_storage_entry(placement_key, earlier).await?;
+    node.join_storage_entry(now_ms, placement_key, later)
+        .await?;
+    let stored = node
+        .join_storage_entry(now_ms, placement_key, earlier)
+        .await?;
     assert_eq!(stored.expires_at_ms, Some(now_ms + 2_000));
     Ok(())
 }

--- a/crates/core/src/dht/storage/tests/mod.rs
+++ b/crates/core/src/dht/storage/tests/mod.rs
@@ -988,6 +988,100 @@ async fn test_data_topic_at_the_inbox_position_does_not_block_the_hold() -> Resu
     Ok(())
 }
 
+/// A store whose every access yields to the executor first, so two operations on one slot
+/// interleave at each of their storage awaits, the way a hold from the inbound actor and a
+/// drain from the stabilizer do.
+struct YieldingStorage(MemStorage<Entry>);
+
+#[async_trait]
+impl KvStorageInterface<Entry> for YieldingStorage {
+    async fn get(&self, key: &str) -> Result<Option<Entry>> {
+        tokio::task::yield_now().await;
+        self.0.get(key).await
+    }
+
+    async fn put(&self, key: &str, value: &Entry) -> Result<()> {
+        tokio::task::yield_now().await;
+        self.0.put(key, value).await
+    }
+
+    async fn get_all(&self) -> Result<Vec<(String, Entry)>> {
+        tokio::task::yield_now().await;
+        self.0.get_all().await
+    }
+
+    async fn remove(&self, key: &str) -> Result<()> {
+        tokio::task::yield_now().await;
+        self.0.remove(key).await
+    }
+
+    async fn clear(&self) -> Result<()> {
+        self.0.clear().await
+    }
+
+    async fn count(&self) -> Result<u32> {
+        self.0.count().await
+    }
+}
+
+/// Storage transition law: two operations on one slot that interleave at their storage awaits
+/// are serialized, so neither read-modify-write overwrites the other. Here two holds land in
+/// one inbox at once, and one hold races the recipient's removal of an earlier element; both
+/// holds survive either way.
+#[tokio::test]
+async fn test_interleaved_operations_on_one_slot_do_not_lose_a_write() -> Result<()> {
+    let holder = SessionSk::new_with_seckey(&SecretKey::random())?;
+    let node = PeerRing::new_with_storage(
+        holder.account_did(),
+        3,
+        Box::new(YieldingStorage(MemStorage::new())),
+    );
+    let destination = Did::from(50u32);
+    let position = inbox_key(destination);
+    let now_ms = get_epoch_ms();
+    let slot = StorageKey::inbox_of(destination);
+
+    let first =
+        EntryOperation::Extend(held_inbox_for(destination, &holder)?).stamped(now_ms, node.did)?;
+    let second =
+        EntryOperation::Extend(held_inbox_for(destination, &holder)?).stamped(now_ms, node.did)?;
+    let (first, second) = futures::join!(
+        node.operate_storage_entry(now_ms, position, first, node.did),
+        node.operate_storage_entry(now_ms, position, second, node.did),
+    );
+    first?;
+    second?;
+    let inbox = node
+        .live_storage_entry(slot, now_ms)
+        .await?
+        .ok_or_else(|| Error::InvalidMessage("inbox vanished".to_string()))?;
+    assert_eq!(inbox.data.len(), 2);
+
+    let first_dot = inbox
+        .crdt
+        .dots
+        .first()
+        .copied()
+        .ok_or_else(|| Error::InvalidMessage("inbox has no dots".to_string()))?;
+    let removal =
+        EntryOperation::Tombstone(inbox.removal_of([first_dot])).stamped(now_ms, node.did)?;
+    let third =
+        EntryOperation::Extend(held_inbox_for(destination, &holder)?).stamped(now_ms, node.did)?;
+    let (removal, third) = futures::join!(
+        node.operate_storage_entry(now_ms, position, removal, destination),
+        node.operate_storage_entry(now_ms, position, third, node.did),
+    );
+    removal?;
+    third?;
+    let inbox = node
+        .live_storage_entry(slot, now_ms)
+        .await?
+        .ok_or_else(|| Error::InvalidMessage("inbox vanished".to_string()))?;
+    assert_eq!(inbox.data.len(), 2);
+    assert_eq!(inbox.crdt.tombstones.len(), 1);
+    Ok(())
+}
+
 /// Removal law at the write funnel: a removal never creates a carrier. Against nothing held the
 /// result has no retention, so the slot stays empty instead of holding a value the next read
 /// would retire; for a data topic by value, for a relay inbox by a dot the recipient once saw.

--- a/crates/core/src/dht/storage/tests/mod.rs
+++ b/crates/core/src/dht/storage/tests/mod.rs
@@ -977,7 +977,7 @@ async fn test_data_topic_at_the_inbox_position_does_not_block_the_hold() -> Resu
         .await?
         .ok_or_else(|| Error::InvalidMessage("parked topic vanished".to_string()))?;
     let inbox = node
-        .live_storage_entry(StorageKey::new(EntryKind::RelayMessage, position), now_ms)
+        .live_storage_entry(StorageKey::inbox_of(destination), now_ms)
         .await?
         .ok_or_else(|| Error::InvalidMessage("hold was not stored".to_string()))?;
     assert_eq!(topic.kind, EntryKind::Data);
@@ -985,6 +985,48 @@ async fn test_data_topic_at_the_inbox_position_does_not_block_the_hold() -> Resu
     assert_eq!(inbox.kind, EntryKind::RelayMessage);
     assert_eq!(inbox.data.len(), 1);
     assert_eq!(node.storage.count().await?, 2);
+    Ok(())
+}
+
+/// Removal law at the write funnel: a removal never creates a carrier. Against nothing held the
+/// result has no retention, so the slot stays empty instead of holding a value the next read
+/// would retire; for a data topic by value, for a relay inbox by a dot the recipient once saw.
+#[tokio::test]
+async fn test_removal_against_nothing_held_stores_nothing() -> Result<()> {
+    let holder = SessionSk::new_with_seckey(&SecretKey::random())?;
+    let node = PeerRing::new_with_storage(holder.account_did(), 3, Box::new(MemStorage::new()));
+    let now_ms = get_epoch_ms();
+
+    let topic = Did::from(100u32);
+    let removal = EntryOperation::Tombstone(Entry::new(
+        topic,
+        vec![Encoded::from("gone")],
+        EntryKind::Data,
+    ))
+    .stamped(now_ms, node.did)?;
+    node.operate_storage_entry(now_ms, topic, removal, node.did)
+        .await?;
+    assert_eq!(node.storage.count().await?, 0);
+
+    let destination = Did::from(50u32);
+    let position = inbox_key(destination);
+    let hold =
+        EntryOperation::Extend(held_inbox_for(destination, &holder)?).stamped(now_ms, node.did)?;
+    node.operate_storage_entry(now_ms, position, hold, node.did)
+        .await?;
+    let inbox = node
+        .live_storage_entry(StorageKey::inbox_of(destination), now_ms)
+        .await?
+        .ok_or_else(|| Error::InvalidMessage("hold was not stored".to_string()))?;
+    node.storage
+        .remove(&StorageKey::inbox_of(destination).to_string())
+        .await?;
+
+    let removal = EntryOperation::Tombstone(inbox.removal_of(inbox.crdt.dots.clone()))
+        .stamped(now_ms, node.did)?;
+    node.operate_storage_entry(now_ms, position, removal, destination)
+        .await?;
+    assert_eq!(node.storage.count().await?, 0);
     Ok(())
 }
 

--- a/crates/core/src/dht/storage/tests/mod.rs
+++ b/crates/core/src/dht/storage/tests/mod.rs
@@ -14,6 +14,7 @@ use crate::dht::entry::Entry;
 use crate::dht::entry::EntryKind;
 use crate::dht::entry::EntryLookupKey;
 use crate::dht::entry::EntryOperation;
+use crate::dht::entry::EntryVersion;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::PlacementMiss;
 use crate::dht::entry::SyncedEntryAck;
@@ -21,6 +22,7 @@ use crate::dht::stabilization::STORAGE_REPAIR_MAX_DELIVERIES_PER_STEP;
 use crate::dht::successor::SuccessorWriter;
 use crate::dht::Chord;
 use crate::dht::ChordStorage;
+use crate::dht::ChordStorageCache;
 use crate::dht::ChordStorageRepair;
 use crate::dht::ChordStorageSync;
 use crate::dht::Did;
@@ -34,19 +36,21 @@ use crate::message::types::Message;
 use crate::message::types::SyncEntriesWithSuccessor;
 use crate::storage::KvStorageInterface;
 use crate::storage::MemStorage;
+use crate::tests::live_entry;
+use crate::utils::get_epoch_ms;
 
 mod test_repair;
 
 fn data_entry(did: Did) -> Entry {
-    Entry::new(did, vec![], EntryKind::Data)
+    live_entry(did, vec![], EntryKind::Data)
 }
 
 fn data_entry_with_data(did: Did, data: &str) -> Entry {
-    Entry::new(did, vec![data.into()], EntryKind::Data)
+    live_entry(did, vec![data.into()], EntryKind::Data)
 }
 
 fn data_entry_with_payload_len(did: Did, len: usize) -> Entry {
-    Entry::new(did, vec!["x".repeat(len).into()], EntryKind::Data)
+    live_entry(did, vec!["x".repeat(len).into()], EntryKind::Data)
 }
 
 fn first_two_affine_keys(did: Did) -> Result<(Did, Did)> {
@@ -844,5 +848,148 @@ async fn test_sync_batch_ack_deletes_acked_batch_and_retries_unacked_batches() -
             .filter(|placed| !acked_batch.iter().any(|acked| acked.key == placed.key)),
     );
     assert_eq!(retried_entries, expected_remaining);
+    Ok(())
+}
+
+fn expired(mut entry: Entry) -> Entry {
+    entry.expires_at_ms = Some(1);
+    entry
+}
+
+/// Retention law: a stored value whose bound elapsed is retired on read and reported absent.
+#[tokio::test]
+async fn test_live_storage_read_retires_expired_value() -> Result<()> {
+    let node = PeerRing::new_with_storage(Did::from(0u32), 3, Box::new(MemStorage::new()));
+    let placement_key = Did::from(100u32);
+    node.storage
+        .put(
+            &placement_key.to_string(),
+            &expired(data_entry(Did::from(10u32))),
+        )
+        .await?;
+
+    assert_eq!(
+        node.live_storage_entry(placement_key, get_epoch_ms())
+            .await?,
+        None
+    );
+    assert_eq!(node.storage.get(&placement_key.to_string()).await?, None);
+    Ok(())
+}
+
+/// Retention law: a bulk read returns only live values and retires the rest, so hand-off and
+/// republish never offer an expired value.
+#[tokio::test]
+async fn test_live_storage_entries_retires_expired_values() -> Result<()> {
+    let node = PeerRing::new_with_storage(Did::from(0u32), 3, Box::new(MemStorage::new()));
+    let live_key = Did::from(100u32);
+    let expired_key = Did::from(200u32);
+    let live_entry = data_entry(Did::from(10u32));
+    node.storage.put(&live_key.to_string(), &live_entry).await?;
+    node.storage
+        .put(
+            &expired_key.to_string(),
+            &expired(data_entry(Did::from(20u32))),
+        )
+        .await?;
+
+    let entries = node.live_storage_entries(get_epoch_ms()).await?;
+    assert_eq!(entries, vec![(live_key.to_string(), live_entry)]);
+    assert_eq!(node.storage.count().await?, 1);
+    Ok(())
+}
+
+/// Admission law at the write funnel: a peer-supplied register at `u128::MAX` is rejected and
+/// leaves storage untouched, so it cannot pin the key against honest writers.
+#[tokio::test]
+async fn test_join_storage_entry_rejects_pinned_register() -> Result<()> {
+    let node = PeerRing::new_with_storage(Did::from(0u32), 3, Box::new(MemStorage::new()));
+    let placement_key = Did::from(100u32);
+    let honest = data_entry_with_data(Did::from(10u32), "honest");
+    node.join_storage_entry(placement_key, honest.clone())
+        .await?;
+
+    let mut pinned = data_entry_with_data(Did::from(10u32), "pinned");
+    pinned.crdt.register = Some(EntryVersion::new(
+        u128::MAX,
+        Did::from(99u32),
+        Did::from(1u32),
+    ));
+    assert!(matches!(
+        node.join_storage_entry(placement_key, pinned).await,
+        Err(Error::EntryVersionAheadOfClock)
+    ));
+    assert_eq!(
+        node.storage.get(&placement_key.to_string()).await?,
+        Some(honest.try_into_storage_entry()?)
+    );
+    Ok(())
+}
+
+/// Admission law at the write funnel: an expired or over-long retention bound is rejected.
+#[tokio::test]
+async fn test_join_storage_entry_bounds_retention() -> Result<()> {
+    let node = PeerRing::new_with_storage(Did::from(0u32), 3, Box::new(MemStorage::new()));
+    let placement_key = Did::from(100u32);
+
+    assert!(matches!(
+        node.join_storage_entry(placement_key, expired(data_entry(Did::from(10u32))))
+            .await,
+        Err(Error::EntryNotLive)
+    ));
+    let mut overlong = data_entry(Did::from(10u32));
+    overlong.expires_at_ms = Some(u128::MAX);
+    assert!(matches!(
+        node.join_storage_entry(placement_key, overlong).await,
+        Err(Error::EntryLifetimeExceedsMax)
+    ));
+    assert_eq!(node.storage.count().await?, 0);
+    Ok(())
+}
+
+/// Retention law under join: an accepted write extends the stored bound to the later of the
+/// two, and never shortens it.
+#[tokio::test]
+async fn test_join_storage_entry_keeps_the_later_retention_bound() -> Result<()> {
+    let node = PeerRing::new_with_storage(Did::from(0u32), 3, Box::new(MemStorage::new()));
+    let placement_key = Did::from(100u32);
+    let now_ms = get_epoch_ms();
+    let mut earlier = data_entry_with_data(Did::from(10u32), "a");
+    earlier.expires_at_ms = Some(now_ms + 1_000);
+    let mut later = data_entry_with_data(Did::from(10u32), "b");
+    later.expires_at_ms = Some(now_ms + 2_000);
+
+    node.join_storage_entry(placement_key, later).await?;
+    let stored = node.join_storage_entry(placement_key, earlier).await?;
+    assert_eq!(stored.expires_at_ms, Some(now_ms + 2_000));
+    Ok(())
+}
+
+/// The fetched-entry cache shares the admission law and retires expired values on read.
+#[tokio::test]
+async fn test_local_cache_shares_admission_and_retention() -> Result<()> {
+    let node = PeerRing::new_with_storage(Did::from(0u32), 3, Box::new(MemStorage::new()));
+    let resource = Did::from(10u32);
+
+    assert!(matches!(
+        node.local_cache_put(expired(data_entry(resource))).await,
+        Err(Error::EntryNotLive)
+    ));
+    let mut pinned = data_entry(resource);
+    pinned.crdt.register = Some(EntryVersion::new(
+        u128::MAX,
+        Did::from(9u32),
+        Did::from(1u32),
+    ));
+    assert!(matches!(
+        node.local_cache_put(pinned).await,
+        Err(Error::EntryVersionAheadOfClock)
+    ));
+
+    node.cache
+        .put(&resource.to_string(), &expired(data_entry(resource)))
+        .await?;
+    assert_eq!(node.local_cache_get(resource).await?, None);
+    assert_eq!(node.cache.count().await?, 0);
     Ok(())
 }

--- a/crates/core/src/dht/topology.rs
+++ b/crates/core/src/dht/topology.rs
@@ -406,7 +406,14 @@ pub fn find_successor(state: &TopologyState, did: Did) -> FindSuccessorStep {
 }
 
 /// Correct predecessor value after one HMCC/Zave rectify transition.
+///
+/// Law: `local` is never its own predecessor, so a candidate equal to `local` leaves the
+/// current value; the responsibility interval `(pred, local]` is then never empty by a
+/// self-reference.
 pub fn rectify_predecessor(local: Did, current: Option<Did>, candidate: Did) -> Option<Did> {
+    if candidate == local {
+        return current;
+    }
     match current {
         Some(cur) if dist(local, cur) >= dist(local, candidate) => Some(cur),
         _ => Some(candidate),

--- a/crates/core/src/dht/topology.rs
+++ b/crates/core/src/dht/topology.rs
@@ -17,6 +17,17 @@
 //! transitions over this state. Stabilize/notify/finger refinement are monotone
 //! over the finite known topology set; their least fixpoint is the converged
 //! Chord state plus a finger table derived from that topology.
+//!
+//! Head law: `head(s)` is the nearest successor other than `local`, the upper
+//! end of the local placement interval `(local, head]`.
+//! [`step`](crate::dht::topology::step) emits
+//! [`TopologyAction::SuccessorHeadChanged`](crate::dht::topology::TopologyAction::SuccessorHeadChanged)`(h)`
+//! iff `head(next) = Some(h)` and
+//! `head(state) ≠ Some(h)`, once per transition, after the event's own actions.
+//! Placement is a function of the ring state, not of the input that changed it,
+//! so every input that moves the head (join, admit, remove, update, stabilize)
+//! is reported through this one action and the shell schedules the placement
+//! repair from it.
 
 use std::collections::BTreeSet;
 
@@ -198,6 +209,8 @@ pub enum TopologyAction {
     QuerySuccessorList(Did),
     /// Notify this successor that `local` is its predecessor candidate.
     Notify(Did),
+    /// The successor head became this node (see the head law).
+    SuccessorHeadChanged(Did),
 }
 
 /// Result of applying one pure topology transition.
@@ -343,7 +356,6 @@ fn closest_preceding_finger(state: &TopologyState, target: &BigUint) -> Option<D
 
 /// `head(s)`: the nearest successor other than `local`, the upper end of the
 /// local placement interval `(local, head]`; `None` when the node stands alone.
-/// Placement is a function of this value alone, whichever input moved it.
 pub fn successor_head(state: &TopologyState) -> Option<Did> {
     state
         .successors
@@ -571,8 +583,22 @@ fn step_fix_finger(state: &TopologyState) -> TopologyStep {
 /// Apply one pure topology transition.
 ///
 /// Post: the returned state depends only on `state` and `event`; no locks,
-/// storage, clocks, randomness, or transport effects are read here.
+/// storage, clocks, randomness, or transport effects are read here. The head
+/// law holds: `SuccessorHeadChanged(h)` is the last action iff the head moved
+/// to `h`.
 pub fn step(state: &TopologyState, event: TopologyEvent, capacity: usize) -> TopologyStep {
+    let mut next = step_event(state, event, capacity);
+    if let Some(head) =
+        successor_head(&next.state).filter(|head| successor_head(state) != Some(*head))
+    {
+        next.actions
+            .push(TopologyAction::SuccessorHeadChanged(head));
+    }
+    next
+}
+
+/// The event's own transition, before the head law is applied.
+fn step_event(state: &TopologyState, event: TopologyEvent, capacity: usize) -> TopologyStep {
     match event {
         TopologyEvent::Join { peer } => step_join(state, peer, capacity),
         TopologyEvent::Admit {

--- a/crates/core/src/dht/topology.rs
+++ b/crates/core/src/dht/topology.rs
@@ -341,6 +341,17 @@ fn closest_preceding_finger(state: &TopologyState, target: &BigUint) -> Option<D
         .find(|peer| precedes(state.local, *peer, target))
 }
 
+/// `head(s)`: the nearest successor other than `local`, the upper end of the
+/// local placement interval `(local, head]`; `None` when the node stands alone.
+/// Placement is a function of this value alone, whichever input moved it.
+pub fn successor_head(state: &TopologyState) -> Option<Did> {
+    state
+        .successors
+        .iter()
+        .copied()
+        .find(|successor| *successor != state.local)
+}
+
 /// Pure Chord successor lookup against one topology state.
 ///
 /// `Local(head)` answers when `did` lies in the local successor interval
@@ -358,12 +369,7 @@ fn closest_preceding_finger(state: &TopologyState, target: &BigUint) -> Option<D
 /// every state, so every remote step is a strict clockwise advance and never a
 /// self hop.
 pub fn find_successor(state: &TopologyState, did: Did) -> FindSuccessorStep {
-    let Some(head) = state
-        .successors
-        .iter()
-        .copied()
-        .find(|successor| *successor != state.local)
-    else {
+    let Some(head) = successor_head(state) else {
         return FindSuccessorStep::Local(state.local);
     };
     let target = dist(state.local, did);

--- a/crates/core/src/dht/topology.rs
+++ b/crates/core/src/dht/topology.rs
@@ -364,6 +364,19 @@ pub fn successor_head(state: &TopologyState) -> Option<Did> {
         .find(|successor| *successor != state.local)
 }
 
+/// `Responsible(n, id)`: `id ∈ (pred(n), n]`, so `n` is the Chord successor of the position
+/// `id`. Without a known predecessor `n` is responsible only when it stands alone: a node that
+/// has successors but has not yet learned its predecessor is uninformed, not responsible for
+/// the whole ring.
+pub fn is_responsible_for(state: &TopologyState, id: Did) -> bool {
+    match state.predecessor {
+        Some(predecessor) => {
+            id != predecessor && dist(predecessor, id) <= dist(predecessor, state.local)
+        }
+        None => successor_head(state).is_none(),
+    }
+}
+
 /// Pure Chord successor lookup against one topology state.
 ///
 /// `Local(head)` answers when `did` lies in the local successor interval

--- a/crates/core/src/dht/topology.rs
+++ b/crates/core/src/dht/topology.rs
@@ -209,7 +209,7 @@ pub enum TopologyAction {
     QuerySuccessorList(Did),
     /// Notify this successor that `local` is its predecessor candidate.
     Notify(Did),
-    /// The successor head became this node (see the head law).
+    /// The successor head moved to this node (see the head law).
     SuccessorHeadChanged(Did),
 }
 

--- a/crates/core/src/dht/topology/tests.rs
+++ b/crates/core/src/dht/topology/tests.rs
@@ -651,3 +651,20 @@ fn test_predecessor_and_finger_steps_never_report_a_head_change() {
             .any(|action| matches!(action, TopologyAction::SuccessorHeadChanged(_))));
     }
 }
+
+#[test]
+fn test_responsibility_is_the_predecessor_interval_or_standing_alone() {
+    let local = did(10);
+    let with_predecessor = state(local, vec![did(20)], Some(did(5)), vec![None; 5], 0);
+    assert!(is_responsible_for(&with_predecessor, did(10)));
+    assert!(is_responsible_for(&with_predecessor, did(7)));
+    assert!(!is_responsible_for(&with_predecessor, did(5)));
+    assert!(!is_responsible_for(&with_predecessor, did(15)));
+
+    let uninformed = state(local, vec![did(20)], None, vec![None; 5], 0);
+    assert!(!is_responsible_for(&uninformed, did(7)));
+
+    let alone = state(local, Vec::new(), None, vec![None; 5], 0);
+    assert!(is_responsible_for(&alone, did(7)));
+    assert!(is_responsible_for(&alone, did(15)));
+}

--- a/crates/core/src/dht/topology/tests.rs
+++ b/crates/core/src/dht/topology/tests.rs
@@ -63,7 +63,8 @@ fn test_join_step_updates_successors_fingers_and_connect_action() {
         TopologyAction::FindSuccessorForConnect {
             next: peer,
             did: local
-        }
+        },
+        TopologyAction::SuccessorHeadChanged(peer),
     ]);
 }
 
@@ -234,7 +235,9 @@ fn test_remove_step_replaces_unavailable_head_with_validated_successors_only() {
         Some(fallback),
         Some(verified_tail)
     ]);
-    assert!(next.actions.is_empty());
+    assert_eq!(next.actions, vec![TopologyAction::SuccessorHeadChanged(
+        fallback
+    )]);
 }
 
 #[test]
@@ -266,7 +269,8 @@ fn test_admit_step_commits_join_and_pending_fingers_in_one_state() {
         TopologyAction::FindSuccessorForConnect {
             next: peer,
             did: local
-        }
+        },
+        TopologyAction::SuccessorHeadChanged(peer),
     ]);
 }
 
@@ -529,4 +533,121 @@ fn test_successor_head_skips_local_and_is_absent_when_alone() {
         successor_head(&state(local, vec![local], None, vec![None; 5], 0)),
         None
     );
+}
+
+/// The head law: `SuccessorHeadChanged(h)` is emitted, last and once, iff the head moved to `h`.
+fn assert_head_law(before: &TopologyState, next: &TopologyStep) {
+    let head_changes = next
+        .actions
+        .iter()
+        .filter(|action| matches!(action, TopologyAction::SuccessorHeadChanged(_)))
+        .count();
+    match successor_head(&next.state).filter(|head| successor_head(before) != Some(*head)) {
+        Some(head) => {
+            assert_eq!(head_changes, 1);
+            assert_eq!(
+                next.actions.last(),
+                Some(&TopologyAction::SuccessorHeadChanged(head))
+            );
+        }
+        None => assert_eq!(head_changes, 0),
+    }
+}
+
+#[test]
+fn test_admit_step_reports_head_change_only_when_the_head_moves() {
+    let local = did(0);
+    let current = state(local, vec![did(30)], None, vec![None; 5], 0);
+
+    let closer = step(
+        &current,
+        TopologyEvent::Admit {
+            peer: did(20),
+            fixed_fingers: Vec::new(),
+        },
+        DEFAULT_SUCCESSOR_CAPACITY,
+    );
+    assert_head_law(&current, &closer);
+    assert_eq!(
+        closer.actions.last(),
+        Some(&TopologyAction::SuccessorHeadChanged(did(20)))
+    );
+
+    let farther = step(
+        &current,
+        TopologyEvent::Admit {
+            peer: did(40),
+            fixed_fingers: Vec::new(),
+        },
+        DEFAULT_SUCCESSOR_CAPACITY,
+    );
+    assert_head_law(&current, &farther);
+    assert!(!farther
+        .actions
+        .iter()
+        .any(|action| matches!(action, TopologyAction::SuccessorHeadChanged(_))));
+}
+
+#[test]
+fn test_stabilize_step_reports_head_change_when_reported_predecessor_precedes_head() {
+    let local = did(0);
+    let current = state(local, vec![did(30)], None, vec![None; 5], 0);
+    let next = step(
+        &current,
+        TopologyEvent::Stabilize {
+            successors: vec![did(30), did(40)],
+            predecessor: Some(did(20)),
+        },
+        DEFAULT_SUCCESSOR_CAPACITY,
+    );
+
+    assert_eq!(next.state.successors, vec![did(20), did(30)]);
+    assert_head_law(&current, &next);
+    assert_eq!(
+        next.actions.last(),
+        Some(&TopologyAction::SuccessorHeadChanged(did(20)))
+    );
+}
+
+#[test]
+fn test_remove_step_reports_head_change_to_the_surviving_successor() {
+    let local = did(0);
+    let current = state(local, vec![did(20), did(30)], None, vec![None; 5], 0);
+    let next = step(
+        &current,
+        TopologyEvent::Remove {
+            peer: did(20),
+            successor: SuccessorRemoval::Preserve,
+        },
+        DEFAULT_SUCCESSOR_CAPACITY,
+    );
+
+    assert_head_law(&current, &next);
+    assert_eq!(next.actions, vec![TopologyAction::SuccessorHeadChanged(
+        did(30)
+    )]);
+}
+
+#[test]
+fn test_predecessor_and_finger_steps_never_report_a_head_change() {
+    let local = did(0);
+    let current = state(local, vec![did(30)], None, vec![None; 5], 0);
+    for event in [
+        TopologyEvent::Notify {
+            predecessor: did(90),
+        },
+        TopologyEvent::FixFinger,
+        TopologyEvent::ApplyFinger {
+            index: 2,
+            successor: did(40),
+        },
+        TopologyEvent::UpdateSuccessor { successor: did(30) },
+    ] {
+        let next = step(&current, event, DEFAULT_SUCCESSOR_CAPACITY);
+        assert_head_law(&current, &next);
+        assert!(!next
+            .actions
+            .iter()
+            .any(|action| matches!(action, TopologyAction::SuccessorHeadChanged(_))));
+    }
 }

--- a/crates/core/src/dht/topology/tests.rs
+++ b/crates/core/src/dht/topology/tests.rs
@@ -668,3 +668,24 @@ fn test_responsibility_is_the_predecessor_interval_or_standing_alone() {
     assert!(is_responsible_for(&alone, did(7)));
     assert!(is_responsible_for(&alone, did(15)));
 }
+
+/// Law: a node is never its own predecessor. A candidate equal to `local` leaves the current
+/// value, whether one is known or not, so `(pred, local]` is never emptied by a self-reference.
+#[test]
+fn test_rectify_never_adopts_the_local_node_as_predecessor() {
+    let local = did(10);
+    assert_eq!(rectify_predecessor(local, None, local), None);
+    assert_eq!(
+        rectify_predecessor(local, Some(did(5)), local),
+        Some(did(5))
+    );
+    assert_eq!(rectify_predecessor(local, None, did(5)), Some(did(5)));
+
+    let notified_by_itself = step(
+        &state(local, vec![did(20)], Some(did(5)), vec![None; 5], 0),
+        TopologyEvent::Notify { predecessor: local },
+        DEFAULT_SUCCESSOR_CAPACITY,
+    );
+    assert_eq!(notified_by_itself.state.predecessor, Some(did(5)));
+    assert!(is_responsible_for(&notified_by_itself.state, did(7)));
+}

--- a/crates/core/src/dht/topology/tests.rs
+++ b/crates/core/src/dht/topology/tests.rs
@@ -517,3 +517,16 @@ fn test_referenced_peers_collect_every_topology_slot_except_local() {
     assert!(!current.references(local));
     assert!(!current.references(did(1)));
 }
+
+#[test]
+fn test_successor_head_skips_local_and_is_absent_when_alone() {
+    let local = did(0);
+    assert_eq!(
+        successor_head(&state(local, vec![local, did(20)], None, vec![None; 5], 0)),
+        Some(did(20))
+    );
+    assert_eq!(
+        successor_head(&state(local, vec![local], None, vec![None; 5], 0)),
+        None
+    );
+}

--- a/crates/core/src/dht/types.rs
+++ b/crates/core/src/dht/types.rs
@@ -78,7 +78,7 @@ pub trait ChordStorage<Action, const REDUNDANT: u16>: Chord<Action> {
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
 pub trait ChordStorageSync<Action>: Chord<Action> {
     /// Offer the live `Entry`s no longer placed in `(self, new_successor]` to
-    /// `new_successor`. The stabilizer runs this every round against the current
+    /// `new_successor`. The storage repair pass runs this against the current
     /// successor head, whichever input moved it, so repetition must be idempotent.
     ///
     /// Mode law: with storage virtual nodes enabled, `new_successor` is only the

--- a/crates/core/src/dht/types.rs
+++ b/crates/core/src/dht/types.rs
@@ -78,7 +78,7 @@ pub trait ChordStorage<Action, const REDUNDANT: u16>: Chord<Action> {
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
 pub trait ChordStorageSync<Action>: Chord<Action> {
     /// When the successor of a node is updated, it needs to check if there are
-    /// `Entry`s that are no longer between current node and `new_successor`,
+    /// live `Entry`s that are no longer between current node and `new_successor`,
     /// and copy them to the new successor.
     ///
     /// Mode law: with storage virtual nodes enabled, `new_successor` is only the
@@ -101,16 +101,17 @@ pub trait ChordStorageSync<Action>: Chord<Action> {
 
 /// ChordStorageRepair defines additive repair for redundant DHT storage.
 ///
-/// Repair never deletes local copies. It only republishes a known [`Entry`] as
-/// a join delivery to the current affine placement set so missing owners can
-/// regain a copy.
+/// Repair never deletes a live local copy. It only republishes a known
+/// [`Entry`] as a join delivery to the current affine placement set so missing
+/// owners can regain a copy; values whose retention bound has elapsed are
+/// retired before republish and are never offered.
 #[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
 pub trait ChordStorageRepair<Action>: Chord<Action> {
-    /// Republish every locally stored entry to its current affine owners.
+    /// Republish every live locally stored entry to its current affine owners.
     ///
-    /// Post: no local key is removed. Remote actions, if any, are join-delivery
-    /// sync messages carrying explicit placement keys.
+    /// Post: no live local key is removed. Remote actions, if any, are
+    /// join-delivery sync messages carrying explicit placement keys.
     async fn republish_local_entries(&self, redundancy: u16) -> Result<Action>;
 
     /// Copy a found entry only to placement keys observed missing during lookup.
@@ -127,12 +128,16 @@ pub trait ChordStorageRepair<Action>: Chord<Action> {
 }
 
 /// ChordStorageCache defines the basic API for getting and setting DHT cache storage.
+///
+/// The cache is bounded and shares the storage admission law: a fetched entry
+/// is cached only if it could have been accepted into storage, and it is
+/// retired once its retention bound elapses.
 #[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
 pub trait ChordStorageCache<Action>: Chord<Action> {
     /// Cache fetched resource locally.
     async fn local_cache_put(&self, entry: Entry) -> Result<()>;
-    /// Get local cache.
+    /// Get a live cached entry.
     async fn local_cache_get(&self, entry_key: Did) -> Result<Option<Entry>>;
 }
 

--- a/crates/core/src/dht/types.rs
+++ b/crates/core/src/dht/types.rs
@@ -81,9 +81,10 @@ pub trait ChordStorageSync<Action>: Chord<Action> {
     /// `new_successor`. The storage repair pass runs this against the current
     /// successor head, whichever input moved it, so repetition must be idempotent.
     ///
-    /// Mode law: with storage virtual nodes enabled, `new_successor` is only the
-    /// stabilization trigger. The copy target is the current
-    /// `storage_owner(k, view, cfg)` relation, not necessarily `new_successor`.
+    /// Mode law: a relay inbox is placed by the ring geometry in every mode and
+    /// is always offered to `new_successor`. With storage virtual nodes enabled a
+    /// data topic follows the current `storage_owner(k, view, cfg)` relation
+    /// instead, and `new_successor` is only the trigger of that additive copy.
     ///
     /// Post: this only delivers entry joins. Local cleanup is performed by
     /// [`Self::acknowledge_synced_entries`] after the successor reports durable

--- a/crates/core/src/dht/types.rs
+++ b/crates/core/src/dht/types.rs
@@ -77,9 +77,9 @@ pub trait ChordStorage<Action, const REDUNDANT: u16>: Chord<Action> {
 #[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
 pub trait ChordStorageSync<Action>: Chord<Action> {
-    /// When the successor of a node is updated, it needs to check if there are
-    /// live `Entry`s that are no longer between current node and `new_successor`,
-    /// and copy them to the new successor.
+    /// Offer the live `Entry`s no longer placed in `(self, new_successor]` to
+    /// `new_successor`. The stabilizer runs this every round against the current
+    /// successor head, whichever input moved it, so repetition must be idempotent.
     ///
     /// Mode law: with storage virtual nodes enabled, `new_successor` is only the
     /// stabilization trigger. The copy target is the current

--- a/crates/core/src/error/kind.rs
+++ b/crates/core/src/error/kind.rs
@@ -190,9 +190,9 @@ pub enum Error {
     #[error("A storage count or record length does not fit its interface width")]
     StorageCountOverflow,
 
-    /// A storage lock was poisoned by a panicking holder
-    #[error("A storage lock was poisoned by a panicking holder")]
-    StorageLockPoisoned,
+    /// A lock was poisoned by a panicking holder
+    #[error("A lock was poisoned by a panicking holder")]
+    LockPoisoned,
 
     /// Affine rotation scalar must be greater than zero
     #[error("Affine rotation scalar must be greater than zero")]
@@ -791,14 +791,6 @@ pub enum Error {
     /// IO error: {0}
     #[error("IO error: {0}")]
     IOError(std::io::Error),
-
-    /// Failed to get dht from a sync lock
-    #[error("Failed to get dht from a sync lock")]
-    DHTSyncLockError,
-
-    /// Failed to lock callback of swarm
-    #[error("Failed to lock callback of swarm")]
-    CallbackSyncLockError,
 
     /// Failed to build swarm: {0}
     #[error("Failed to build swarm: {0}")]

--- a/crates/core/src/error/kind.rs
+++ b/crates/core/src/error/kind.rs
@@ -188,12 +188,6 @@ pub enum Error {
     #[error("Relay inbox removal was not issued by the inbox's recipient")]
     RelayInboxWriterNotRecipient,
 
-    /// Relay inbox carrier may only be relocated by an ownership hand-off from the predecessor
-    #[error(
-        "Relay inbox carrier may only be relocated by an ownership hand-off from the predecessor"
-    )]
-    RelayInboxNotRelocatable,
-
     /// A storage count or record length does not fit its interface width
     #[error("A storage count or record length does not fit its interface width")]
     StorageCountOverflow,

--- a/crates/core/src/error/kind.rs
+++ b/crates/core/src/error/kind.rs
@@ -128,6 +128,18 @@ pub enum Error {
         index: usize,
     },
 
+    /// Entry carries no retention bound or its retention bound has elapsed
+    #[error("Entry carries no retention bound or its retention bound has elapsed")]
+    EntryNotLive,
+
+    /// Entry retention bound exceeds the maximum time-to-live
+    #[error("Entry retention bound exceeds the maximum time-to-live")]
+    EntryLifetimeExceedsMax,
+
+    /// Entry version logical time is beyond the accepted clock skew
+    #[error("Entry version logical time is beyond the accepted clock skew")]
+    EntryVersionAheadOfClock,
+
     /// Affine rotation scalar must be greater than zero
     #[error("Affine rotation scalar must be greater than zero")]
     InvalidAffineScalar,
@@ -708,6 +720,15 @@ pub enum Error {
     /// Invalid capacity value
     #[error("Invalid capacity value")]
     InvalidCapacity,
+
+    /// A value of {required} bytes cannot fit a storage budget of {capacity} bytes
+    #[error("A value of {required} bytes cannot fit a storage budget of {capacity} bytes")]
+    StorageValueExceedsCapacity {
+        /// Bytes the value occupies on disk.
+        required: u64,
+        /// Total byte budget of the storage.
+        capacity: u64,
+    },
 
     /// entry not found
     #[error("entry not found")]

--- a/crates/core/src/error/kind.rs
+++ b/crates/core/src/error/kind.rs
@@ -148,13 +148,47 @@ pub enum Error {
     #[error("Relay inbox element is not addressed to the peer the inbox is kept for")]
     RelayMessageNotAddressedToInbox,
 
-    /// Relay inbox element does not carry an application message
-    #[error("Relay inbox element does not carry an application message")]
-    RelayMessageNotApplication,
+    /// Relay inbox element does not carry a custom message
+    #[error("Relay inbox element does not carry a custom message")]
+    RelayMessageNotCustom,
 
-    /// Relay inbox element signatures do not verify inside this overlay
-    #[error("Relay inbox element signatures do not verify inside this overlay")]
+    /// Relay inbox element holder signature does not verify inside this overlay
+    #[error("Relay inbox element holder signature does not verify inside this overlay")]
     RelayMessageUnverifiable,
+
+    /// Relay inbox element was held ahead of the receiver's clock
+    #[error("Relay inbox element was held ahead of the receiver's clock")]
+    RelayMessageHeldAheadOfClock,
+
+    /// Relay inbox element payload does not verify as of its hold instant
+    #[error("Relay inbox element payload does not verify as of its hold instant")]
+    RelayMessageHeldOutsideSenderProof,
+
+    /// Relay inbox element was not held by the node responsible for its destination
+    #[error("Relay inbox element was not held by the node responsible for its destination")]
+    RelayMessageHolderNotResponsible,
+
+    /// Relay inbox carrier must not carry a reset floor
+    #[error("Relay inbox carrier must not carry a reset floor")]
+    RelayInboxRegisterNotAllowed,
+
+    /// Relay inbox operation is not a hold or a removal
+    #[error("Relay inbox operation is not a hold or a removal")]
+    RelayInboxOperationNotAllowed,
+
+    /// Relay inbox removal was not issued by the inbox's recipient
+    #[error("Relay inbox removal was not issued by the inbox's recipient")]
+    RelayInboxWriterNotRecipient,
+
+    /// Relay inbox carrier may only be relocated by an ownership hand-off from the predecessor
+    #[error(
+        "Relay inbox carrier may only be relocated by an ownership hand-off from the predecessor"
+    )]
+    RelayInboxNotRelocatable,
+
+    /// A storage count or record length does not fit its interface width
+    #[error("A storage count or record length does not fit its interface width")]
+    StorageCountOverflow,
 
     /// A storage lock was poisoned by a panicking holder
     #[error("A storage lock was poisoned by a panicking holder")]

--- a/crates/core/src/error/kind.rs
+++ b/crates/core/src/error/kind.rs
@@ -164,6 +164,14 @@ pub enum Error {
     #[error("Relay inbox element payload does not verify as of its hold instant")]
     RelayMessageHeldOutsideSenderProof,
 
+    /// Relay inbox hold arrived after its message's sender proof expired
+    #[error("Relay inbox hold arrived after its message's sender proof expired")]
+    RelayMessageHoldStale,
+
+    /// Relay inbox delta carries more elements than the inbox keeps
+    #[error("Relay inbox delta carries more elements than the inbox keeps")]
+    RelayInboxDeltaExceedsCapacity,
+
     /// Relay inbox element was not held by the node responsible for its destination
     #[error("Relay inbox element was not held by the node responsible for its destination")]
     RelayMessageHolderNotResponsible,

--- a/crates/core/src/error/kind.rs
+++ b/crates/core/src/error/kind.rs
@@ -144,6 +144,18 @@ pub enum Error {
     #[error("Entry payload exceeds the per-payload size bound")]
     EntryPayloadExceedsMax,
 
+    /// Relay inbox element is not addressed to the peer the inbox is kept for
+    #[error("Relay inbox element is not addressed to the peer the inbox is kept for")]
+    RelayMessageNotAddressedToInbox,
+
+    /// Relay inbox element does not carry an application message
+    #[error("Relay inbox element does not carry an application message")]
+    RelayMessageNotApplication,
+
+    /// Relay inbox element signatures do not verify inside this overlay
+    #[error("Relay inbox element signatures do not verify inside this overlay")]
+    RelayMessageUnverifiable,
+
     /// A storage lock was poisoned by a panicking holder
     #[error("A storage lock was poisoned by a panicking holder")]
     StorageLockPoisoned,

--- a/crates/core/src/error/kind.rs
+++ b/crates/core/src/error/kind.rs
@@ -140,6 +140,14 @@ pub enum Error {
     #[error("Entry version logical time is beyond the accepted clock skew")]
     EntryVersionAheadOfClock,
 
+    /// Entry payload exceeds the per-payload size bound
+    #[error("Entry payload exceeds the per-payload size bound")]
+    EntryPayloadExceedsMax,
+
+    /// A storage lock was poisoned by a panicking holder
+    #[error("A storage lock was poisoned by a panicking holder")]
+    StorageLockPoisoned,
+
     /// Affine rotation scalar must be greater than zero
     #[error("Affine rotation scalar must be greater than zero")]
     InvalidAffineScalar,

--- a/crates/core/src/message/effects.rs
+++ b/crates/core/src/message/effects.rs
@@ -461,7 +461,9 @@ mod tests {
     use crate::dht::StorageSyncPurpose;
     use crate::ecc::SecretKey;
     use crate::message::types::QueryFor;
+    use crate::message::MessageSigner;
     use crate::session::SessionSk;
+    use crate::tests::TEST_NETWORK_ID;
 
     fn did() -> Did {
         SecretKey::random().address().into()
@@ -472,7 +474,7 @@ mod tests {
         let session_sk = SessionSk::new_with_seckey(&key)?;
         MessagePayload::new_send(
             Message::custom(b"hello")?,
-            &session_sk,
+            MessageSigner::new(&session_sk, TEST_NETWORK_ID),
             destination,
             destination,
         )

--- a/crates/core/src/message/effects.rs
+++ b/crates/core/src/message/effects.rs
@@ -228,6 +228,11 @@ pub(crate) enum CoreEffect<'payload> {
         /// Payload whose destination this node is responsible for but cannot reach.
         payload: &'payload MessagePayload,
     },
+    /// Request a storage repair round: the placement interval changed, so the stabilizer's next
+    /// repair pass must hand off what lies beyond the new successor head. Only the intent is
+    /// recorded here; the pass itself runs under the repair schedule, whose admission grace
+    /// outlives the peer's own admission of this node.
+    RequestStorageRepair,
 }
 
 impl<'payload> CoreEffect<'payload> {
@@ -276,6 +281,11 @@ impl<'payload> CoreEffect<'payload> {
     /// Create a DHT connection effect.
     pub(crate) const fn connect_dht_peer(peer: Did) -> Self {
         Self::ConnectDhtPeer { peer }
+    }
+
+    /// Create a storage repair request effect.
+    pub(crate) const fn request_storage_repair() -> Self {
+        Self::RequestStorageRepair
     }
 }
 
@@ -331,6 +341,9 @@ pub(crate) fn lower_dht_action<'payload>(
         PeerRingAction::RemoteAction(peer, PeerRingRemoteAction::TryConnect) => {
             Ok(Some(CoreEffect::connect_dht_peer(*peer)))
         }
+        PeerRingAction::RemoteAction(_, PeerRingRemoteAction::HandOffStorage) => {
+            Ok(Some(CoreEffect::request_storage_repair()))
+        }
         PeerRingAction::RemoteAction(target, PeerRingRemoteAction::Notify(predecessor)) => {
             let (target, predecessor) = (*target, *predecessor);
             Ok(if target == predecessor {
@@ -384,6 +397,10 @@ impl<'handler> CoreEffectInterpreter<'handler> {
             }
             CoreEffect::HoldForOfflineDestination { payload } => {
                 hold_for_offline_destination(self.transport.clone(), payload).await
+            }
+            CoreEffect::RequestStorageRepair => {
+                self.transport.request_storage_repair();
+                Ok(())
             }
             CoreEffect::SendMessage { msg, destination } => {
                 self.transport.send_message(*msg, destination).await?;
@@ -572,6 +589,21 @@ mod tests {
             }
         }
         Ok(())
+    }
+
+    #[test]
+    fn test_dht_hand_off_storage_lowers_to_a_repair_request() -> Result<()> {
+        let effect = single_effect(lower_dht_action(
+            &PeerRingAction::RemoteAction(did(), PeerRingRemoteAction::HandOffStorage),
+            |_| false,
+        ))?;
+
+        match effect {
+            CoreEffect::RequestStorageRepair => Ok(()),
+            effect => Err(Error::InvalidMessage(format!(
+                "expected RequestStorageRepair, got {effect:?}"
+            ))),
+        }
     }
 
     #[test]

--- a/crates/core/src/message/effects.rs
+++ b/crates/core/src/message/effects.rs
@@ -341,9 +341,7 @@ pub(crate) fn lower_dht_action<'payload>(
         PeerRingAction::RemoteAction(peer, PeerRingRemoteAction::TryConnect) => {
             Ok(Some(CoreEffect::connect_dht_peer(*peer)))
         }
-        PeerRingAction::RemoteAction(_, PeerRingRemoteAction::HandOffStorage) => {
-            Ok(Some(CoreEffect::request_storage_repair()))
-        }
+        PeerRingAction::StorageRepairDue => Ok(Some(CoreEffect::request_storage_repair())),
         PeerRingAction::RemoteAction(target, PeerRingRemoteAction::Notify(predecessor)) => {
             let (target, predecessor) = (*target, *predecessor);
             Ok(if target == predecessor {
@@ -592,11 +590,10 @@ mod tests {
     }
 
     #[test]
-    fn test_dht_hand_off_storage_lowers_to_a_repair_request() -> Result<()> {
-        let effect = single_effect(lower_dht_action(
-            &PeerRingAction::RemoteAction(did(), PeerRingRemoteAction::HandOffStorage),
-            |_| false,
-        ))?;
+    fn test_storage_repair_due_lowers_to_a_repair_request() -> Result<()> {
+        let effect = single_effect(lower_dht_action(&PeerRingAction::StorageRepairDue, |_| {
+            false
+        }))?;
 
         match effect {
             CoreEffect::RequestStorageRepair => Ok(()),

--- a/crates/core/src/message/effects.rs
+++ b/crates/core/src/message/effects.rs
@@ -25,6 +25,7 @@ use crate::dht::PeerRingAction;
 use crate::dht::PeerRingRemoteAction;
 use crate::error::Error;
 use crate::error::Result;
+use crate::message::handlers::inbox::hold_for_offline_destination;
 use crate::message::types::FindSuccessorSend;
 use crate::message::FindSuccessorReportHandler;
 use crate::message::FindSuccessorThen;
@@ -228,6 +229,11 @@ pub(crate) enum CoreEffect<'payload> {
         /// Storage-sync message to route by its storage destination.
         msg: SyncEntriesWithSuccessor,
     },
+    /// Hold an application payload in the relay inbox of its offline destination.
+    HoldForOfflineDestination {
+        /// Payload whose destination this node is responsible for but cannot reach.
+        payload: &'payload MessagePayload,
+    },
 }
 
 impl<'payload> CoreEffect<'payload> {
@@ -250,6 +256,11 @@ impl<'payload> CoreEffect<'payload> {
     /// Create a destination-reset effect.
     pub(crate) fn reset_destination(payload: &'payload MessagePayload, next_hop: Did) -> Self {
         Self::ResetDestination { payload, next_hop }
+    }
+
+    /// Create an effect that holds `payload` in its destination's relay inbox.
+    pub(crate) fn hold_for_offline_destination(payload: &'payload MessagePayload) -> Self {
+        Self::HoldForOfflineDestination { payload }
     }
 
     /// Create a normally-routed send effect.
@@ -381,6 +392,9 @@ impl<'handler> CoreEffectInterpreter<'handler> {
             }
             CoreEffect::ResetDestination { payload, next_hop } => {
                 self.transport.reset_destination(payload, next_hop).await
+            }
+            CoreEffect::HoldForOfflineDestination { payload } => {
+                hold_for_offline_destination(self.transport.clone(), payload).await
             }
             CoreEffect::SendMessage { msg, destination } => {
                 self.transport.send_message(*msg, destination).await?;

--- a/crates/core/src/message/effects.rs
+++ b/crates/core/src/message/effects.rs
@@ -34,7 +34,6 @@ use crate::message::MessagePayload;
 use crate::message::NotifyPredecessorSend;
 use crate::message::PayloadSender;
 use crate::message::QueryForTopoInfoSend;
-use crate::message::SyncEntriesWithSuccessor;
 use crate::swarm::callback::InnerSwarmCallback;
 use crate::swarm::callback::SharedSwarmCallback;
 use crate::swarm::transport::SwarmTransport;
@@ -224,11 +223,6 @@ pub(crate) enum CoreEffect<'payload> {
         /// Peer to connect.
         peer: Did,
     },
-    /// Send copy-only storage entries and register the matching ack capability.
-    SendStorageSync {
-        /// Storage-sync message to route by its storage destination.
-        msg: SyncEntriesWithSuccessor,
-    },
     /// Hold an application payload in the relay inbox of its offline destination.
     HoldForOfflineDestination {
         /// Payload whose destination this node is responsible for but cannot reach.
@@ -282,11 +276,6 @@ impl<'payload> CoreEffect<'payload> {
     /// Create a DHT connection effect.
     pub(crate) const fn connect_dht_peer(peer: Did) -> Self {
         Self::ConnectDhtPeer { peer }
-    }
-
-    /// Create a storage-sync effect.
-    pub(crate) fn send_storage_sync(msg: SyncEntriesWithSuccessor) -> Self {
-        Self::SendStorageSync { msg }
     }
 }
 
@@ -431,12 +420,6 @@ impl<'handler> CoreEffectInterpreter<'handler> {
                     Err(e) => Err(e),
                 }
             }
-            CoreEffect::SendStorageSync { msg } => {
-                self.transport
-                    .send_storage_sync_or_defer(msg, "core_effect")
-                    .await?;
-                Ok(())
-            }
         }
     }
 
@@ -471,8 +454,6 @@ mod tests {
     use std::task::Waker;
 
     use super::*;
-    use crate::dht::StorageSyncDestination;
-    use crate::dht::StorageSyncPurpose;
     use crate::ecc::SecretKey;
     use crate::message::types::QueryFor;
     use crate::message::MessageSigner;
@@ -587,31 +568,6 @@ mod tests {
             effect => {
                 return Err(Error::InvalidMessage(format!(
                     "expected ResetDestination, got {effect:?}"
-                )))
-            }
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn test_storage_sync_effect_owns_sync_message() -> Result<()> {
-        let destination = did();
-        let msg = SyncEntriesWithSuccessor {
-            purpose: StorageSyncPurpose::OwnershipHandoff,
-            destination: StorageSyncDestination::PhysicalOwner(destination),
-            data: vec![],
-        };
-
-        let effect: CoreEffect<'_> = CoreEffect::send_storage_sync(msg.clone());
-
-        match effect {
-            CoreEffect::SendStorageSync { msg: effect_msg } => {
-                assert_eq!(effect_msg.destination, msg.destination);
-                assert!(effect_msg.data.is_empty());
-            }
-            effect => {
-                return Err(Error::InvalidMessage(format!(
-                    "expected SendStorageSync, got {effect:?}"
                 )))
             }
         }

--- a/crates/core/src/message/handlers/custom.rs
+++ b/crates/core/src/message/handlers/custom.rs
@@ -34,14 +34,16 @@ mod tests {
     use crate::ecc::SecretKey;
     use crate::error::Error;
     use crate::message::Message;
+    use crate::message::MessageSigner;
     use crate::session::SessionSk;
+    use crate::tests::TEST_NETWORK_ID;
 
     fn custom_payload(destination: Did) -> Result<MessagePayload> {
         let key = SecretKey::random();
         let session_sk = SessionSk::new_with_seckey(&key)?;
         MessagePayload::new_send(
             Message::custom(b"hello")?,
-            &session_sk,
+            MessageSigner::new(&session_sk, TEST_NETWORK_ID),
             destination,
             destination,
         )

--- a/crates/core/src/message/handlers/custom.rs
+++ b/crates/core/src/message/handlers/custom.rs
@@ -8,14 +8,22 @@ use crate::message::HandleMsg;
 use crate::message::MessageHandler;
 use crate::message::MessagePayload;
 
+/// The effect an application message requires at `local`.
+///
+/// Post: a message for `local` needs no effect; a message for a destination this node is
+/// responsible for but cannot reach is held in that destination's relay inbox; every other
+/// message is forwarded along the relay path.
 pub(crate) fn custom_message_effects<'payload>(
     local: Did,
     ctx: &'payload MessagePayload,
+    destination_offline: bool,
 ) -> Option<CoreEffect<'payload>> {
-    if ctx.should_forward_from(local) {
-        Some(CoreEffect::forward_payload(ctx, None))
-    } else {
+    if !ctx.should_forward_from(local) {
         None
+    } else if destination_offline {
+        Some(CoreEffect::hold_for_offline_destination(ctx))
+    } else {
+        Some(CoreEffect::forward_payload(ctx, None))
     }
 }
 
@@ -23,63 +31,12 @@ pub(crate) fn custom_message_effects<'payload>(
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
 impl HandleMsg<CustomMessage> for MessageHandler {
     async fn handle(&self, ctx: &MessagePayload, _: &CustomMessage) -> Result<()> {
-        self.run_effects(custom_message_effects(self.dht.did, ctx))
-            .await
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::ecc::SecretKey;
-    use crate::error::Error;
-    use crate::message::Message;
-    use crate::message::MessageSigner;
-    use crate::session::SessionSk;
-    use crate::tests::TEST_NETWORK_ID;
-
-    fn custom_payload(destination: Did) -> Result<MessagePayload> {
-        let key = SecretKey::random();
-        let session_sk = SessionSk::new_with_seckey(&key)?;
-        MessagePayload::new_send(
-            Message::custom(b"hello")?,
-            MessageSigner::new(&session_sk, TEST_NETWORK_ID),
-            destination,
-            destination,
-        )
-    }
-
-    #[test]
-    fn test_local_custom_message_has_no_core_effects() -> Result<()> {
-        let local = SecretKey::random().address().into();
-        let payload = custom_payload(local)?;
-
-        assert!(custom_message_effects(local, &payload).is_none());
-        Ok(())
-    }
-
-    #[test]
-    fn test_remote_custom_message_forwards_payload() -> Result<()> {
-        let local = SecretKey::random().address().into();
-        let remote = SecretKey::random().address().into();
-        let payload = custom_payload(remote)?;
-        let effect = custom_message_effects(local, &payload)
-            .ok_or_else(|| Error::InvalidMessage("expected ForwardPayload effect".to_string()))?;
-
-        match effect {
-            CoreEffect::ForwardPayload {
-                payload: forwarded,
-                next_hop,
-            } => {
-                assert!(std::ptr::eq(forwarded, &payload));
-                assert_eq!(next_hop, None);
-            }
-            effect => {
-                return Err(Error::InvalidMessage(format!(
-                    "expected ForwardPayload, got {effect:?}"
-                )))
-            }
-        }
-        Ok(())
+        let destination_offline = self.destination_is_offline(ctx.transaction.destination)?;
+        self.run_effects(custom_message_effects(
+            self.dht.did,
+            ctx,
+            destination_offline,
+        ))
+        .await
     }
 }

--- a/crates/core/src/message/handlers/custom.rs
+++ b/crates/core/src/message/handlers/custom.rs
@@ -8,6 +8,15 @@ use crate::message::HandleMsg;
 use crate::message::MessageHandler;
 use crate::message::MessagePayload;
 
+/// How this node stands to a message's destination.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Reachability {
+    /// The destination can be reached, or is somebody else's to reach: forward.
+    Reachable,
+    /// This node is responsible for the destination's position and it has no connection: hold.
+    Offline,
+}
+
 /// The effect an application message requires at `local`.
 ///
 /// Post: a message for `local` needs no effect; a message for a destination this node is
@@ -16,14 +25,15 @@ use crate::message::MessagePayload;
 pub(crate) fn custom_message_effects<'payload>(
     local: Did,
     ctx: &'payload MessagePayload,
-    destination_offline: bool,
+    destination: Reachability,
 ) -> Option<CoreEffect<'payload>> {
     if !ctx.should_forward_from(local) {
         None
-    } else if destination_offline {
-        Some(CoreEffect::hold_for_offline_destination(ctx))
     } else {
-        Some(CoreEffect::forward_payload(ctx, None))
+        Some(match destination {
+            Reachability::Offline => CoreEffect::hold_for_offline_destination(ctx),
+            Reachability::Reachable => CoreEffect::forward_payload(ctx, None),
+        })
     }
 }
 
@@ -31,12 +41,8 @@ pub(crate) fn custom_message_effects<'payload>(
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
 impl HandleMsg<CustomMessage> for MessageHandler {
     async fn handle(&self, ctx: &MessagePayload, _: &CustomMessage) -> Result<()> {
-        let destination_offline = self.destination_is_offline(ctx.transaction.destination)?;
-        self.run_effects(custom_message_effects(
-            self.dht.did,
-            ctx,
-            destination_offline,
-        ))
-        .await
+        let destination = self.destination_reachability(ctx.transaction.destination)?;
+        self.run_effects(custom_message_effects(self.dht.did, ctx, destination))
+            .await
     }
 }

--- a/crates/core/src/message/handlers/e2e.rs
+++ b/crates/core/src/message/handlers/e2e.rs
@@ -51,7 +51,7 @@ fn e2e_handshake_response_effect<'payload>(
 impl HandleMsg<E2eHandshakeRequest> for MessageHandler {
     async fn handle(&self, ctx: &MessagePayload, msg: &E2eHandshakeRequest) -> Result<()> {
         run_e2e_local_or_forward(self, ctx, || {
-            let responder_public_key = self.transport.session_sk().session().account_pubkey()?;
+            let responder_public_key = self.transport.session().account_pubkey()?;
             Ok(vec![e2e_handshake_response_effect(
                 ctx,
                 msg,

--- a/crates/core/src/message/handlers/e2e.rs
+++ b/crates/core/src/message/handlers/e2e.rs
@@ -10,7 +10,6 @@ use crate::message::Message;
 use crate::message::MessageHandler;
 use crate::message::MessagePayload;
 use crate::message::MessageVerificationExt;
-use crate::message::PayloadSender;
 
 fn e2e_local_or_forward_effects<'payload>(
     local: crate::dht::Did,
@@ -96,7 +95,9 @@ mod tests {
     use crate::error::Error;
     use crate::message::e2e::encrypt_stream_with_rng;
     use crate::message::e2e::E2eHandshakeRequest;
+    use crate::message::MessageSigner;
     use crate::session::SessionSk;
+    use crate::tests::TEST_NETWORK_ID;
 
     fn e2e_payload(destination: crate::dht::Did) -> Result<MessagePayload> {
         let sender = SecretKey::random();
@@ -116,7 +117,7 @@ mod tests {
             .ok_or_else(|| Error::InvalidMessage("expected one E2E stream frame".to_string()))?;
         MessagePayload::new_send(
             Message::E2eStreamFrame(encrypted),
-            &session_sk,
+            MessageSigner::new(&session_sk, TEST_NETWORK_ID),
             destination,
             destination,
         )
@@ -130,7 +131,7 @@ mod tests {
         let session_sk = SessionSk::new_with_seckey(signer)?;
         MessagePayload::new_send(
             Message::E2eHandshakeRequest(request),
-            &session_sk,
+            MessageSigner::new(&session_sk, TEST_NETWORK_ID),
             destination,
             destination,
         )

--- a/crates/core/src/message/handlers/inbox.rs
+++ b/crates/core/src/message/handlers/inbox.rs
@@ -1,111 +1,99 @@
 //! Relay inbox handling: holding messages for offline peers and draining one's own inbox.
 //!
 //! Producer: a `CustomMessage` that reaches the node responsible for its destination's ring
-//! position while the destination is not connected is held in the destination's inbox
-//! carrier (see [`crate::dht::entry::inbox`]) through the ordinary storage write path, so the
-//! storage owner and every replica admit it only under the inbox witness.
+//! position while the destination has no connection is held: wrapped in a
+//! [`HeldMessage`] under this node's signature and written into the destination's inbox carrier
+//! (see [`crate::dht::entry::inbox`]) through the ordinary storage write path, so the storage
+//! owner admits it only under the inbox witness and the holder authority.
 //!
 //! Consumer: the inbox carrier `d + 1` lies in `d`'s own storage interval once `d` is online, so
-//! ownership hand-off moves the held messages to `d` as its predecessor adopts it as successor.
-//! Every stabilization round `d` reads its own inbox from local storage, delivers every element
-//! that passes the witness under the local overlay to the application exactly as an inbound
-//! message would be, and compacts the delivered messages out of the carrier. The compaction
-//! floor also reaches every replica and excludes the delivered elements from later joins, so a
-//! stale copy synced afterwards cannot redeliver.
+//! the predecessor's storage repair pass hands the held messages to `d`. Every storage
+//! maintenance pass `d` reads its own inbox from local storage, delivers every element that
+//! passes the witness under the local overlay through the inbound pipeline (application
+//! validation, handler dispatch, `on_inbound`, each under the inbound deadline), and retires
+//! every element of the drained carrier by its add dot. Delivery is at least once: an element
+//! held again between the read and the tombstone is delivered by the next pass, and a message
+//! rejected by the application is retired like a delivered one, as the inbound path drops it.
 
 use std::sync::Arc;
 
 use super::storage::operate_entry;
 use crate::dht::entry::inbox::inbox_key;
+use crate::dht::entry::inbox::HeldMessage;
 use crate::dht::entry::Entry;
-use crate::dht::entry::EntryKind;
 use crate::dht::entry::EntryOperation;
 use crate::dht::Did;
-use crate::error::Error;
 use crate::error::Result;
-use crate::message::Encoder;
 use crate::message::MessageHandler;
 use crate::message::MessagePayload;
 use crate::message::PayloadSender;
+use crate::swarm::callback::deliver_local_payload;
 use crate::swarm::callback::SharedSwarmCallback;
 use crate::swarm::transport::SwarmTransport;
 use crate::utils::get_epoch_ms;
 
-/// Hold `payload` in the relay inbox of its destination.
+/// Hold `payload` in the relay inbox of its destination under this node's signature.
 ///
-/// Pre: this node is responsible for the destination's ring position and the destination is not
-/// connected.
+/// Pre: this node is responsible for the destination's ring position and the destination has
+/// no connection; `payload` was verified live on arrival.
 pub(crate) async fn hold_for_offline_destination(
     transport: Arc<SwarmTransport>,
     payload: &MessagePayload,
 ) -> Result<()> {
+    let held = HeldMessage::hold(payload.clone(), transport.message_signer())?;
     operate_entry(
         transport,
-        EntryOperation::Extend(Entry::inbox_delta(payload)?),
+        EntryOperation::Extend(Entry::inbox_delta(&held)?),
     )
     .await
 }
 
-/// Deliver the messages held in this node's own inbox and compact them out of the carrier.
+/// Deliver the messages held in this node's own inbox and retire the drained elements.
 ///
-/// Post: every deliverable message in the locally stored inbox was offered to the application,
-/// and the carrier (locally and at every replica) carries a compaction floor above them.
+/// Post: every element of the locally stored inbox that passes the witness was offered to the
+/// application, and every element of that carrier is tombstoned at its owner (locally and, once
+/// relocated, wherever the carrier went).
 pub(crate) async fn drain_inbox(
     transport: Arc<SwarmTransport>,
-    callback: &SharedSwarmCallback,
+    callback: SharedSwarmCallback,
 ) -> Result<()> {
     let now_ms = get_epoch_ms();
     let key = inbox_key(transport.dht.did);
     let Some(inbox) = transport.dht.live_storage_entry(key, now_ms).await? else {
         return Ok(());
     };
-    let messages = inbox.deliverable_inbox_messages(transport.network_id);
-    if messages.is_empty() {
+    if inbox.data.is_empty() {
         return Ok(());
     }
-
-    for payload in &messages {
-        if let Err(error) = deliver_inbox_message(callback, payload).await {
+    let drain = inbox.drain_inbox(now_ms, transport.network_id);
+    if drain.rejected > 0 {
+        tracing::warn!(
+            local = %transport.dht.did,
+            rejected = drain.rejected,
+            "relay inbox elements failed the witness and are retired undelivered"
+        );
+    }
+    for payload in &drain.deliverable {
+        if let Err(error) =
+            deliver_local_payload(transport.clone(), callback.clone(), payload).await
+        {
             tracing::warn!(
                 local = %transport.dht.did,
                 tx_id = %payload.transaction.tx_id,
                 error = ?error,
-                "relay inbox message rejected by the application"
+                "relay inbox message not accepted by the application"
             );
         }
     }
-
-    let delivered = messages
-        .iter()
-        .map(Encoder::encode)
-        .collect::<Result<Vec<_>>>()?;
-    let compaction =
-        EntryOperation::CompactData(Entry::new(key, delivered, EntryKind::RelayMessage));
-    operate_entry(transport, compaction).await
-}
-
-/// Offer one inbox message to the application through the same callbacks an inbound message
-/// passes: validation first, then delivery.
-async fn deliver_inbox_message(
-    callback: &SharedSwarmCallback,
-    payload: &MessagePayload,
-) -> Result<()> {
-    callback
-        .on_validate(payload)
-        .await
-        .map_err(|error| Error::InvalidMessage(error.to_string()))?;
-    callback
-        .on_inbound(payload)
-        .await
-        .map_err(|error| Error::InvalidMessage(error.to_string()))
+    operate_entry(transport, EntryOperation::Tombstone(drain.retired)).await
 }
 
 impl MessageHandler {
     /// Whether `destination` is a peer this node must hold messages for: it occupies a ring
-    /// position this node is the successor of, and it is not connected.
+    /// position this node is responsible for and it has no connection, admitted or pending.
     pub(super) fn destination_is_offline(&self, destination: Did) -> Result<bool> {
         Ok(destination != self.dht.did
-            && !self.transport.is_connected(destination)
+            && !self.transport.has_connection_attempt(destination)?
             && self.dht.is_responsible_for(destination)?)
     }
 }

--- a/crates/core/src/message/handlers/inbox.rs
+++ b/crates/core/src/message/handlers/inbox.rs
@@ -1,22 +1,26 @@
-//! Relay inbox handling: holding messages for offline peers and draining one's own inbox.
+//! Relay inbox handling: holding messages for offline peers and delivering one's own inbox.
 //!
 //! Producer: a `CustomMessage` that reaches the node responsible for its destination's ring
 //! position while the destination has no connection is held: wrapped in a
-//! [`HeldMessage`] under this node's signature and written into the destination's inbox carrier
-//! (see [`crate::dht::entry::inbox`]) through the ordinary storage write path, so the storage
-//! owner admits it only under the inbox witness and the holder authority.
+//! [`HeldMessage`] under this node's signature at this instant and written into the
+//! destination's inbox carrier (see [`crate::dht::entry::inbox`]) through the ordinary storage
+//! write path, so the storage owner admits it only under the inbox write law.
 //!
 //! Consumer: the inbox carrier `d + 1` lies in `d`'s own storage interval once `d` is online, so
 //! the predecessor's storage repair pass hands the held messages to `d`. Every storage
-//! maintenance pass `d` reads its own inbox from local storage, delivers every element that
-//! passes the witness under the local overlay through the inbound pipeline (application
-//! validation, handler dispatch, `on_inbound`, each under the inbound deadline), and retires
-//! every element of the drained carrier by its add dot. Delivery is at least once: an element
-//! held again between the read and the tombstone is delivered by the next pass, and a message
-//! rejected by the application is retired like a delivered one, as the inbound path drops it.
+//! maintenance pass `d` reads its own inbox from local storage, retires at once every element
+//! that fails the witness under the local overlay, and then, element by element, delivers
+//! through the inbound pipeline (application validation, handler dispatch, `on_inbound`, each
+//! under the inbound deadline) and retires the delivered element by its add dot. Retiring per
+//! element makes progress durable: a pass cut short by its step deadline resumes after the last
+//! retired element instead of redelivering the same prefix. Delivery is at least once: an
+//! element held again between the read and its tombstone is delivered by the next pass, and a
+//! message rejected by the application is retired like a delivered one, as the inbound path
+//! drops it.
 
 use std::sync::Arc;
 
+use super::custom::Reachability;
 use super::storage::operate_entry;
 use crate::dht::entry::inbox::inbox_key;
 use crate::dht::entry::inbox::HeldMessage;
@@ -27,7 +31,7 @@ use crate::error::Result;
 use crate::message::MessageHandler;
 use crate::message::MessagePayload;
 use crate::message::PayloadSender;
-use crate::swarm::callback::deliver_local_payload;
+use crate::swarm::callback::LocalDelivery;
 use crate::swarm::callback::SharedSwarmCallback;
 use crate::swarm::transport::SwarmTransport;
 use crate::utils::get_epoch_ms;
@@ -40,7 +44,7 @@ pub(crate) async fn hold_for_offline_destination(
     transport: Arc<SwarmTransport>,
     payload: &MessagePayload,
 ) -> Result<()> {
-    let held = HeldMessage::hold(payload.clone(), transport.message_signer())?;
+    let held = HeldMessage::hold(payload.clone(), transport.message_signer(), get_epoch_ms())?;
     operate_entry(
         transport,
         EntryOperation::Extend(Entry::inbox_delta(&held)?),
@@ -48,12 +52,12 @@ pub(crate) async fn hold_for_offline_destination(
     .await
 }
 
-/// Deliver the messages held in this node's own inbox and retire the drained elements.
+/// Deliver the messages held in this node's own inbox, retiring each element as it goes.
 ///
 /// Post: every element of the locally stored inbox that passes the witness was offered to the
-/// application, and every element of that carrier is tombstoned at its owner (locally and, once
-/// relocated, wherever the carrier went).
-pub(crate) async fn drain_inbox(
+/// application and then tombstoned at its owner; every element that fails the witness was
+/// tombstoned unread.
+pub(crate) async fn deliver_inbox(
     transport: Arc<SwarmTransport>,
     callback: SharedSwarmCallback,
 ) -> Result<()> {
@@ -65,35 +69,46 @@ pub(crate) async fn drain_inbox(
     if inbox.data.is_empty() {
         return Ok(());
     }
-    let drain = inbox.drain_inbox(now_ms, transport.network_id);
-    if drain.rejected > 0 {
+    let drain = inbox.partition_inbox(now_ms, transport.network_id);
+    if !drain.rejected.crdt.dots.is_empty() {
         tracing::warn!(
             local = %transport.dht.did,
-            rejected = drain.rejected,
+            rejected = drain.rejected.crdt.dots.len(),
             "relay inbox elements failed the witness and are retired undelivered"
         );
+        retire(&transport, drain.rejected).await?;
     }
-    for payload in &drain.deliverable {
-        if let Err(error) =
-            deliver_local_payload(transport.clone(), callback.clone(), payload).await
-        {
+    let delivery = LocalDelivery::new(transport.clone(), callback);
+    for element in drain.deliverable {
+        if let Err(error) = delivery.deliver(&element.payload).await {
             tracing::warn!(
                 local = %transport.dht.did,
-                tx_id = %payload.transaction.tx_id,
+                tx_id = %element.payload.transaction.tx_id,
                 error = ?error,
                 "relay inbox message not accepted by the application"
             );
         }
+        retire(&transport, inbox.removal_of([element.dot])).await?;
     }
-    operate_entry(transport, EntryOperation::Tombstone(drain.retired)).await
+    Ok(())
+}
+
+/// Tombstone `removal` at the carrier's owner.
+async fn retire(transport: &Arc<SwarmTransport>, removal: Entry) -> Result<()> {
+    operate_entry(transport.clone(), EntryOperation::Tombstone(removal)).await
 }
 
 impl MessageHandler {
-    /// Whether `destination` is a peer this node must hold messages for: it occupies a ring
-    /// position this node is responsible for and it has no connection, admitted or pending.
-    pub(super) fn destination_is_offline(&self, destination: Did) -> Result<bool> {
-        Ok(destination != self.dht.did
+    /// How this node stands to `destination`: a peer it must hold messages for occupies a ring
+    /// position this node is responsible for and has no connection, admitted or pending.
+    pub(super) fn destination_reachability(&self, destination: Did) -> Result<Reachability> {
+        let offline = destination != self.dht.did
             && !self.transport.has_connection_attempt(destination)?
-            && self.dht.is_responsible_for(destination)?)
+            && self.dht.is_responsible_for(destination)?;
+        Ok(if offline {
+            Reachability::Offline
+        } else {
+            Reachability::Reachable
+        })
     }
 }

--- a/crates/core/src/message/handlers/inbox.rs
+++ b/crates/core/src/message/handlers/inbox.rs
@@ -1,28 +1,16 @@
-//! Relay inbox handling: holding messages for offline peers and delivering one's own inbox.
+//! Relay inbox production: holding messages for offline peers.
 //!
-//! Producer: a `CustomMessage` that reaches the node responsible for its destination's ring
-//! position while the destination has no connection is held: wrapped in a
-//! [`HeldMessage`] under this node's signature at this instant and written into the
-//! destination's inbox carrier (see [`crate::dht::entry::inbox`]) through the ordinary storage
-//! write path, so the storage owner admits it only under the inbox write law.
-//!
-//! Consumer: the inbox carrier `d + 1` lies in `d`'s own storage interval once `d` is online, so
-//! the predecessor's storage repair pass hands the held messages to `d`. Every storage
-//! maintenance pass `d` reads its own inbox from local storage, retires at once every element
-//! that fails the witness under the local overlay, and then, element by element, delivers
-//! through the inbound pipeline (application validation, handler dispatch, `on_inbound`, each
-//! under the inbound deadline) and retires the delivered element by its add dot. Retiring per
-//! element makes progress durable: a pass cut short by its step deadline resumes after the last
-//! retired element instead of redelivering the same prefix. Delivery is at least once: an
-//! element held again between the read and its tombstone is delivered by the next pass, and a
-//! message rejected by the application is retired like a delivered one, as the inbound path
-//! drops it.
+//! A `CustomMessage` that reaches the node responsible for its destination's ring position while
+//! the destination has no connection is held: wrapped in a [`HeldMessage`] under this node's
+//! signature at this instant and written into the destination's inbox carrier (see
+//! [`crate::dht::entry::inbox`]) through the ordinary storage write path, so the storage owner
+//! admits it only under the inbox write law. The consumer side, delivering one's own inbox, is
+//! the swarm's interpretation of the storage maintenance intent (`swarm::inbox`).
 
 use std::sync::Arc;
 
 use super::custom::Reachability;
 use super::storage::operate_entry;
-use crate::dht::entry::inbox::inbox_key;
 use crate::dht::entry::inbox::HeldMessage;
 use crate::dht::entry::Entry;
 use crate::dht::entry::EntryOperation;
@@ -31,8 +19,6 @@ use crate::error::Result;
 use crate::message::MessageHandler;
 use crate::message::MessagePayload;
 use crate::message::PayloadSender;
-use crate::swarm::callback::LocalDelivery;
-use crate::swarm::callback::SharedSwarmCallback;
 use crate::swarm::transport::SwarmTransport;
 use crate::utils::get_epoch_ms;
 
@@ -50,52 +36,6 @@ pub(crate) async fn hold_for_offline_destination(
         EntryOperation::Extend(Entry::inbox_delta(&held)?),
     )
     .await
-}
-
-/// Deliver the messages held in this node's own inbox, retiring each element as it goes.
-///
-/// Post: every element of the locally stored inbox that passes the witness was offered to the
-/// application and then tombstoned at its owner; every element that fails the witness was
-/// tombstoned unread.
-pub(crate) async fn deliver_inbox(
-    transport: Arc<SwarmTransport>,
-    callback: SharedSwarmCallback,
-) -> Result<()> {
-    let now_ms = get_epoch_ms();
-    let key = inbox_key(transport.dht.did);
-    let Some(inbox) = transport.dht.live_storage_entry(key, now_ms).await? else {
-        return Ok(());
-    };
-    if inbox.data.is_empty() {
-        return Ok(());
-    }
-    let drain = inbox.partition_inbox(now_ms, transport.network_id);
-    if !drain.rejected.crdt.dots.is_empty() {
-        tracing::warn!(
-            local = %transport.dht.did,
-            rejected = drain.rejected.crdt.dots.len(),
-            "relay inbox elements failed the witness and are retired undelivered"
-        );
-        retire(&transport, drain.rejected).await?;
-    }
-    let delivery = LocalDelivery::new(transport.clone(), callback);
-    for element in drain.deliverable {
-        if let Err(error) = delivery.deliver(&element.payload).await {
-            tracing::warn!(
-                local = %transport.dht.did,
-                tx_id = %element.payload.transaction.tx_id,
-                error = ?error,
-                "relay inbox message not accepted by the application"
-            );
-        }
-        retire(&transport, inbox.removal_of([element.dot])).await?;
-    }
-    Ok(())
-}
-
-/// Tombstone `removal` at the carrier's owner.
-async fn retire(transport: &Arc<SwarmTransport>, removal: Entry) -> Result<()> {
-    operate_entry(transport.clone(), EntryOperation::Tombstone(removal)).await
 }
 
 impl MessageHandler {

--- a/crates/core/src/message/handlers/inbox.rs
+++ b/crates/core/src/message/handlers/inbox.rs
@@ -1,0 +1,111 @@
+//! Relay inbox handling: holding messages for offline peers and draining one's own inbox.
+//!
+//! Producer: a `CustomMessage` that reaches the node responsible for its destination's ring
+//! position while the destination is not connected is held in the destination's inbox
+//! carrier (see [`crate::dht::entry::inbox`]) through the ordinary storage write path, so the
+//! storage owner and every replica admit it only under the inbox witness.
+//!
+//! Consumer: the inbox carrier `d + 1` lies in `d`'s own storage interval once `d` is online, so
+//! ownership hand-off moves the held messages to `d` as its predecessor adopts it as successor.
+//! Every stabilization round `d` reads its own inbox from local storage, delivers every element
+//! that passes the witness under the local overlay to the application exactly as an inbound
+//! message would be, and compacts the delivered messages out of the carrier. The compaction
+//! floor also reaches every replica and excludes the delivered elements from later joins, so a
+//! stale copy synced afterwards cannot redeliver.
+
+use std::sync::Arc;
+
+use super::storage::operate_entry;
+use crate::dht::entry::inbox::inbox_key;
+use crate::dht::entry::Entry;
+use crate::dht::entry::EntryKind;
+use crate::dht::entry::EntryOperation;
+use crate::dht::Did;
+use crate::error::Error;
+use crate::error::Result;
+use crate::message::Encoder;
+use crate::message::MessageHandler;
+use crate::message::MessagePayload;
+use crate::message::PayloadSender;
+use crate::swarm::callback::SharedSwarmCallback;
+use crate::swarm::transport::SwarmTransport;
+use crate::utils::get_epoch_ms;
+
+/// Hold `payload` in the relay inbox of its destination.
+///
+/// Pre: this node is responsible for the destination's ring position and the destination is not
+/// connected.
+pub(crate) async fn hold_for_offline_destination(
+    transport: Arc<SwarmTransport>,
+    payload: &MessagePayload,
+) -> Result<()> {
+    operate_entry(
+        transport,
+        EntryOperation::Extend(Entry::inbox_delta(payload)?),
+    )
+    .await
+}
+
+/// Deliver the messages held in this node's own inbox and compact them out of the carrier.
+///
+/// Post: every deliverable message in the locally stored inbox was offered to the application,
+/// and the carrier (locally and at every replica) carries a compaction floor above them.
+pub(crate) async fn drain_inbox(
+    transport: Arc<SwarmTransport>,
+    callback: &SharedSwarmCallback,
+) -> Result<()> {
+    let now_ms = get_epoch_ms();
+    let key = inbox_key(transport.dht.did);
+    let Some(inbox) = transport.dht.live_storage_entry(key, now_ms).await? else {
+        return Ok(());
+    };
+    let messages = inbox.deliverable_inbox_messages(transport.network_id);
+    if messages.is_empty() {
+        return Ok(());
+    }
+
+    for payload in &messages {
+        if let Err(error) = deliver_inbox_message(callback, payload).await {
+            tracing::warn!(
+                local = %transport.dht.did,
+                tx_id = %payload.transaction.tx_id,
+                error = ?error,
+                "relay inbox message rejected by the application"
+            );
+        }
+    }
+
+    let delivered = messages
+        .iter()
+        .map(Encoder::encode)
+        .collect::<Result<Vec<_>>>()?;
+    let compaction =
+        EntryOperation::CompactData(Entry::new(key, delivered, EntryKind::RelayMessage));
+    operate_entry(transport, compaction).await
+}
+
+/// Offer one inbox message to the application through the same callbacks an inbound message
+/// passes: validation first, then delivery.
+async fn deliver_inbox_message(
+    callback: &SharedSwarmCallback,
+    payload: &MessagePayload,
+) -> Result<()> {
+    callback
+        .on_validate(payload)
+        .await
+        .map_err(|error| Error::InvalidMessage(error.to_string()))?;
+    callback
+        .on_inbound(payload)
+        .await
+        .map_err(|error| Error::InvalidMessage(error.to_string()))
+}
+
+impl MessageHandler {
+    /// Whether `destination` is a peer this node must hold messages for: it occupies a ring
+    /// position this node is the successor of, and it is not connected.
+    pub(super) fn destination_is_offline(&self, destination: Did) -> Result<bool> {
+        Ok(destination != self.dht.did
+            && !self.transport.is_connected(destination)
+            && self.dht.is_responsible_for(destination)?)
+    }
+}

--- a/crates/core/src/message/handlers/mod.rs
+++ b/crates/core/src/message/handlers/mod.rs
@@ -27,6 +27,8 @@ pub mod connection;
 pub mod custom;
 /// Operator and Handler for E2E encrypted messages
 pub mod e2e;
+/// Relay inbox: holding messages for offline peers and draining one's own inbox.
+pub(crate) mod inbox;
 /// Operator and handler for DHT stabilization
 pub mod stabilization;
 /// Operator and Handler for Storage

--- a/crates/core/src/message/handlers/stabilization/mod.rs
+++ b/crates/core/src/message/handlers/stabilization/mod.rs
@@ -1,13 +1,11 @@
 use async_trait::async_trait;
 
-use crate::dht::ChordStorageSync;
 use crate::error::Error;
 use crate::error::Result;
 use crate::message::effects::CoreEffect;
 use crate::message::types::Message;
 use crate::message::types::NotifyPredecessorReport;
 use crate::message::types::NotifyPredecessorSend;
-use crate::message::types::SyncEntriesWithSuccessor;
 use crate::message::HandleMsg;
 use crate::message::MessageHandler;
 use crate::message::MessagePayload;
@@ -60,22 +58,12 @@ impl MessageHandler {
 #[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
 impl HandleMsg<NotifyPredecessorReport> for MessageHandler {
+    /// The successor reports the node that now precedes it: connect to it. Adopting it as the
+    /// successor head is the admission's topology transition, and the storage hand-off that
+    /// follows is the stabilizer's placement invariant, not this message's.
     async fn handle(&self, _ctx: &MessagePayload, msg: &NotifyPredecessorReport) -> Result<()> {
         self.run_effects([CoreEffect::connect_dht_peer(msg.did)])
-            .await?;
-
-        let deliveries = self
-            .dht
-            .sync_entries_with_successor(msg.did)
-            .await?
-            .coalesced_storage_sync_deliveries()?;
-        let effects = deliveries.into_iter().map(|delivery| {
-            let msg = SyncEntriesWithSuccessor::from_delivery(delivery);
-            CoreEffect::send_storage_sync(msg)
-        });
-        self.run_effects(effects).await?;
-
-        Ok(())
+            .await
     }
 }
 

--- a/crates/core/src/message/handlers/stabilization/tests/mod.rs
+++ b/crates/core/src/message/handlers/stabilization/tests/mod.rs
@@ -1,22 +1,11 @@
 use std::sync::Arc;
 
-use tokio::time::timeout;
-use tokio::time::Duration;
-
 use super::*;
-use crate::dht::entry::EntryKind;
-use crate::dht::entry::PlacedEntry;
-use crate::dht::entry::SyncedEntryAck;
 use crate::dht::successor::SuccessorReader;
-use crate::dht::PeerRingAction;
-use crate::dht::StorageSyncDestination;
-use crate::dht::StorageSyncPurpose;
 use crate::ecc::tests::gen_ordered_keys;
 use crate::ecc::SecretKey;
 use crate::error::Error;
-use crate::message::Encoder;
 use crate::message::MessageSigner;
-use crate::message::SyncEntriesWithSuccessorReport;
 use crate::session::SessionSk;
 use crate::swarm::callback::SwarmCallback;
 use crate::swarm::Swarm;
@@ -38,11 +27,6 @@ fn notify_context(origin: &SecretKey, destination: crate::dht::Did) -> Result<Me
         destination,
         destination,
     )
-}
-
-fn next_generated_key(keys: &mut impl Iterator<Item = SecretKey>) -> Result<SecretKey> {
-    keys.next()
-        .ok_or_else(|| Error::InvalidMessage("expected generated key".to_string()))
 }
 
 #[tokio::test]
@@ -125,124 +109,6 @@ async fn test_triple_nodes_stabilization_2_1_3() -> Result<()> {
 async fn test_triple_nodes_stabilization_1_3_2() -> Result<()> {
     let [key1, key2, key3]: [SecretKey; 3] = gen_ordered_keys::<3>();
     test_triple_desc_ordered_nodes_stabilization(key1, key3, key2).await
-}
-
-#[tokio::test]
-async fn test_notify_predecessor_report_acks_local_branch_when_predecessor_already_connected(
-) -> Result<()> {
-    let mut keys = gen_ordered_keys::<3>().into_iter();
-    let key1 = next_generated_key(&mut keys)?;
-    let key2 = next_generated_key(&mut keys)?;
-    let key3 = next_generated_key(&mut keys)?;
-
-    let node1 = prepare_node(key1).await;
-    let node2 = prepare_node(key2).await;
-    manually_establish_connection(&node1.swarm, &node2.swarm).await;
-    wait_for_msgs([&node1, &node2]).await;
-    assert_no_more_msg([&node1, &node2]).await;
-
-    let entry = crate::tests::live_entry(
-        key3.address().into(),
-        vec![String::from("sync me").encode()?],
-        EntryKind::Data,
-    );
-    node1
-        .dht()
-        .storage
-        .put(&entry.did.to_string(), &entry)
-        .await?;
-    let stored_entry = entry.clone().try_into_storage_entry()?;
-    assert!(matches!(
-        node2.dht().find_storage_owner(entry.did)?,
-        PeerRingAction::Some(witness) if witness == node1.did() && witness != node2.did()
-    ));
-
-    let context_key = SecretKey::random();
-    let context_session = SessionSk::new_with_seckey(&context_key)?;
-    let context = MessagePayload::new_send(
-        Message::custom(b"notify report context")?,
-        MessageSigner::new(&context_session, TEST_NETWORK_ID),
-        node1.did(),
-        node1.did(),
-    )?;
-
-    let handler = MessageHandler::new(node1.swarm.transport.clone(), Arc::new(NoopCallback));
-    handler
-        .handle(&context, &NotifyPredecessorReport { did: node2.did() })
-        .await?;
-
-    let payload = match timeout(Duration::from_secs(1), node2.listen_once()).await {
-        Ok(Some(payload)) => payload,
-        Ok(None) => {
-            return Err(Error::InvalidMessage(
-                "node2 message stream closed before entry sync".to_string(),
-            ))
-        }
-        Err(_) => {
-            return Err(Error::InvalidMessage(
-                "timed out waiting for entry sync".to_string(),
-            ))
-        }
-    };
-
-    match payload.transaction.data::<Message>()? {
-        Message::SyncEntriesWithSuccessor(SyncEntriesWithSuccessor {
-            purpose,
-            destination,
-            data,
-        }) => {
-            assert_eq!(purpose, StorageSyncPurpose::OwnershipHandoff);
-            assert_eq!(
-                destination,
-                StorageSyncDestination::PhysicalOwner(node2.did())
-            );
-            assert_eq!(data, vec![PlacedEntry::new(entry.did, entry.clone())]);
-        }
-        message => {
-            return Err(Error::InvalidMessage(format!(
-                "expected SyncEntriesWithSuccessor, got {message:?}"
-            )))
-        }
-    }
-    let payload = match timeout(Duration::from_secs(1), node1.listen_once()).await {
-        Ok(Some(payload)) => payload,
-        Ok(None) => {
-            return Err(Error::InvalidMessage(
-                "node1 message stream closed before entry sync ack".to_string(),
-            ))
-        }
-        Err(_) => {
-            return Err(Error::InvalidMessage(
-                "timed out waiting for entry sync ack".to_string(),
-            ))
-        }
-    };
-
-    match payload.transaction.data::<Message>()? {
-        Message::SyncEntriesWithSuccessorReport(SyncEntriesWithSuccessorReport {
-            purpose,
-            acks,
-            ..
-        }) => {
-            assert_eq!(purpose, StorageSyncPurpose::OwnershipHandoff);
-            assert_eq!(acks, vec![SyncedEntryAck::new(
-                entry.did,
-                stored_entry.clone()
-            )]);
-        }
-        message => {
-            return Err(Error::InvalidMessage(format!(
-                "expected SyncEntriesWithSuccessorReport, got {message:?}"
-            )))
-        }
-    }
-    assert_eq!(node1.dht().storage.get(&entry.did.to_string()).await?, None);
-    assert_eq!(
-        node2.dht().storage.get(&entry.did.to_string()).await?,
-        Some(stored_entry)
-    );
-
-    Ok(())
 }
 
 async fn test_triple_ordered_nodes_stabilization(

--- a/crates/core/src/message/handlers/stabilization/tests/mod.rs
+++ b/crates/core/src/message/handlers/stabilization/tests/mod.rs
@@ -4,7 +4,6 @@ use tokio::time::timeout;
 use tokio::time::Duration;
 
 use super::*;
-use crate::dht::entry::Entry;
 use crate::dht::entry::EntryKind;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::SyncedEntryAck;
@@ -16,6 +15,7 @@ use crate::ecc::tests::gen_ordered_keys;
 use crate::ecc::SecretKey;
 use crate::error::Error;
 use crate::message::Encoder;
+use crate::message::MessageSigner;
 use crate::message::SyncEntriesWithSuccessorReport;
 use crate::session::SessionSk;
 use crate::swarm::callback::SwarmCallback;
@@ -24,6 +24,7 @@ use crate::tests::default::assert_no_more_msg;
 use crate::tests::default::prepare_node;
 use crate::tests::default::wait_for_msgs;
 use crate::tests::manually_establish_connection;
+use crate::tests::TEST_NETWORK_ID;
 
 struct NoopCallback;
 
@@ -33,7 +34,7 @@ fn notify_context(origin: &SecretKey, destination: crate::dht::Did) -> Result<Me
     let session = SessionSk::new_with_seckey(origin)?;
     MessagePayload::new_send(
         Message::custom(b"notify predecessor context")?,
-        &session,
+        MessageSigner::new(&session, TEST_NETWORK_ID),
         destination,
         destination,
     )
@@ -140,7 +141,7 @@ async fn test_notify_predecessor_report_acks_local_branch_when_predecessor_alrea
     wait_for_msgs([&node1, &node2]).await;
     assert_no_more_msg([&node1, &node2]).await;
 
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         key3.address().into(),
         vec![String::from("sync me").encode()?],
         EntryKind::Data,
@@ -160,7 +161,7 @@ async fn test_notify_predecessor_report_acks_local_branch_when_predecessor_alrea
     let context_session = SessionSk::new_with_seckey(&context_key)?;
     let context = MessagePayload::new_send(
         Message::custom(b"notify report context")?,
-        &context_session,
+        MessageSigner::new(&context_session, TEST_NETWORK_ID),
         node1.did(),
         node1.did(),
     )?;

--- a/crates/core/src/message/handlers/stabilization/tests/mod.rs
+++ b/crates/core/src/message/handlers/stabilization/tests/mod.rs
@@ -437,6 +437,6 @@ async fn test_triple_desc_ordered_nodes_stabilization(
 }
 
 async fn run_stabilization_once(swarm: Arc<Swarm>) -> Result<()> {
-    let stab = swarm.stabilizer();
+    let stab = swarm.stabilizer()?;
     stab.notify_predecessor().await
 }

--- a/crates/core/src/message/handlers/stabilization/tests/mod.rs
+++ b/crates/core/src/message/handlers/stabilization/tests/mod.rs
@@ -303,6 +303,6 @@ async fn test_triple_desc_ordered_nodes_stabilization(
 }
 
 async fn run_stabilization_once(swarm: Arc<Swarm>) -> Result<()> {
-    let stab = swarm.stabilizer()?;
+    let stab = swarm.stabilizer();
     stab.notify_predecessor().await
 }

--- a/crates/core/src/message/handlers/storage/mod.rs
+++ b/crates/core/src/message/handlers/storage/mod.rs
@@ -95,7 +95,7 @@ async fn repair_observed_storage_misses(
         .dht
         .read_repair_entry(entry, &misses, redundancy)
         .await?;
-    run_storage_repair_transport_effects(transport, repair).await
+    send_storage_sync_actions(transport, repair, "storage_repair").await
 }
 
 /// Execute storage fetch actions for the Swarm-facing storage API.
@@ -118,7 +118,7 @@ async fn handle_storage_fetch_act(
                 .dht
                 .read_repair_entry(evidence.entry, &misses, redundancy)
                 .await?;
-            run_storage_repair_transport_effects(transport.clone(), repair).await?;
+            send_storage_sync_actions(transport.clone(), repair, "storage_repair").await?;
         }
         PeerRingAction::RemoteAction(next, dht_act) => {
             if let PeerRingRemoteAction::FindEntry(query) = dht_act {
@@ -209,21 +209,30 @@ async fn handle_placed_entry_operation(
     }
 }
 
-/// Execute copy-only storage repair actions at the Swarm API adapter boundary.
-async fn run_storage_repair_transport_effects(
+/// Send every storage-sync delivery of `act` at the transport boundary.
+async fn send_storage_sync_actions(
     transport: Arc<SwarmTransport>,
     act: PeerRingAction,
+    context: &'static str,
 ) -> Result<()> {
     for (delivery, has_next) in core_actor_steps(act.coalesced_storage_sync_deliveries()?) {
         let msg = SyncEntriesWithSuccessor::from_delivery(delivery);
-        transport
-            .send_storage_sync_or_defer(msg, "storage_repair")
-            .await?;
+        transport.send_storage_sync_or_defer(msg, context).await?;
         if has_next {
             yield_core_actor_step().await;
         }
     }
     Ok(())
+}
+
+/// Offer every live local entry placed beyond `head` to it as an ownership hand-off.
+///
+/// Pre: `head` is the current successor head, so the local placement interval is `(self, head]`.
+/// Post: every live local entry beyond that interval has been offered to `head`; local copies are
+/// removed only by the receiver's acknowledgement, so repeating this is idempotent.
+pub(crate) async fn hand_off_storage(transport: Arc<SwarmTransport>, head: Did) -> Result<()> {
+    let handoff = transport.dht.sync_entries_with_successor(head).await?;
+    send_storage_sync_actions(transport, handoff, "ownership_handoff").await
 }
 
 /// Execute storage search actions emitted by inbound message handlers.

--- a/crates/core/src/message/handlers/storage/mod.rs
+++ b/crates/core/src/message/handlers/storage/mod.rs
@@ -248,17 +248,11 @@ async fn handle_storage_search_act(
 ) -> Result<()> {
     match act {
         PeerRingAction::SomeEntry(evidence) => {
-            // A relay inbox is never fetched: its recipient drains it from local storage, so a
-            // lookup sees it as absent whoever asks.
-            let data = match evidence.entry.kind {
-                EntryKind::Data => vec![evidence.entry],
-                EntryKind::RelayMessage => Vec::new(),
-            };
             handler
                 .run_effects([CoreEffect::send_report_message(
                     ctx,
                     Message::FoundEntry(FoundEntry {
-                        data,
+                        data: vec![evidence.entry],
                         misses: evidence.misses,
                         resource,
                         redundancy,

--- a/crates/core/src/message/handlers/storage/mod.rs
+++ b/crates/core/src/message/handlers/storage/mod.rs
@@ -101,10 +101,11 @@ async fn repair_observed_storage_misses(
 /// Execute storage fetch actions for the Swarm-facing storage API.
 #[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_recursion(?Send))]
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_recursion)]
-async fn handle_storage_fetch_act<const REDUNDANT: u16>(
+async fn handle_storage_fetch_act(
     transport: Arc<SwarmTransport>,
     resource: Did,
     act: PeerRingAction,
+    redundancy: u16,
 ) -> Result<()> {
     match act {
         PeerRingAction::SomeEntry(evidence) => {
@@ -115,7 +116,7 @@ async fn handle_storage_fetch_act<const REDUNDANT: u16>(
             let misses = evidence.misses;
             let repair = transport
                 .dht
-                .read_repair_entry(evidence.entry, &misses, REDUNDANT)
+                .read_repair_entry(evidence.entry, &misses, redundancy)
                 .await?;
             run_storage_repair_transport_effects(transport.clone(), repair).await?;
         }
@@ -131,7 +132,7 @@ async fn handle_storage_fetch_act<const REDUNDANT: u16>(
                         Message::SearchEntry(SearchEntry {
                             resource: query.resource,
                             placement: query.placement,
-                            redundancy: REDUNDANT,
+                            redundancy,
                         }),
                         next,
                     )
@@ -140,14 +141,14 @@ async fn handle_storage_fetch_act<const REDUNDANT: u16>(
         }
         PeerRingAction::MultiActions(acts) => {
             for (act, has_next) in core_actor_steps(acts) {
-                handle_storage_fetch_act::<REDUNDANT>(transport.clone(), resource, act).await?;
+                handle_storage_fetch_act(transport.clone(), resource, act, redundancy).await?;
                 if has_next {
                     yield_core_actor_step().await;
                 }
             }
         }
         PeerRingAction::EntryMisses(misses) => {
-            transport.observe_storage_misses(resource, REDUNDANT, misses)?;
+            transport.observe_storage_misses(resource, redundancy, misses)?;
         }
         act => finish_storage_action(act)?,
     }
@@ -284,9 +285,32 @@ async fn operate_storage_entry<const REDUNDANT: u16>(
     operation: EntryOperation,
 ) -> Result<()> {
     swarm.transport.ensure_storage_redundancy::<REDUNDANT>()?;
-    let action =
-        <PeerRing as ChordStorage<_, REDUNDANT>>::entry_operate(&swarm.dht, operation).await?;
-    handle_storage_store_act(swarm.transport.clone(), action).await
+    operate_entry(swarm.transport.clone(), operation).await
+}
+
+/// Apply `operation` under the transport's configured redundancy: locally where this node is
+/// an accepted placement and by `OperateEntry` toward every remote one.
+pub(crate) async fn operate_entry(
+    transport: Arc<SwarmTransport>,
+    operation: EntryOperation,
+) -> Result<()> {
+    let action = transport
+        .dht
+        .entry_operate_with_redundancy(operation, transport.storage_redundancy())
+        .await?;
+    handle_storage_store_act(transport, action).await
+}
+
+/// Fetch `entry_key` under the transport's configured redundancy: a local hit is copied into
+/// the cache, a miss queries the responsible owners.
+pub(crate) async fn fetch_entry(transport: Arc<SwarmTransport>, entry_key: Did) -> Result<()> {
+    let redundancy = transport.storage_redundancy();
+    transport.start_storage_lookup(entry_key, redundancy)?;
+    let act = transport
+        .dht
+        .entry_lookup_for_fetch(entry_key, redundancy)
+        .await?;
+    handle_storage_fetch_act(transport, entry_key, act, redundancy).await
 }
 
 fn next_hop_for_sync_entries(
@@ -344,14 +368,7 @@ impl<const REDUNDANT: u16> ChordStorageInterface<REDUNDANT> for Swarm {
     /// otherwise query the responsible remote node.
     async fn storage_fetch(&self, entry_key: Did) -> Result<()> {
         self.transport.ensure_storage_redundancy::<REDUNDANT>()?;
-        self.transport.start_storage_lookup(entry_key, REDUNDANT)?;
-        // If peer found that data is on it's localstore, copy it to the cache
-        let act = self
-            .dht
-            .entry_lookup_for_fetch::<REDUNDANT>(entry_key)
-            .await?;
-        handle_storage_fetch_act::<REDUNDANT>(self.transport.clone(), entry_key, act).await?;
-        Ok(())
+        fetch_entry(self.transport.clone(), entry_key).await
     }
 
     /// Store Entry, `TryInto<Entry>` is implemented for alot of types

--- a/crates/core/src/message/handlers/storage/mod.rs
+++ b/crates/core/src/message/handlers/storage/mod.rs
@@ -95,7 +95,7 @@ async fn repair_observed_storage_misses(
         .dht
         .read_repair_entry(entry, &misses, redundancy)
         .await?;
-    send_storage_sync_actions(transport, repair, "storage_repair").await
+    run_storage_repair_transport_effects(transport, repair).await
 }
 
 /// Execute storage fetch actions for the Swarm-facing storage API.
@@ -118,7 +118,7 @@ async fn handle_storage_fetch_act(
                 .dht
                 .read_repair_entry(evidence.entry, &misses, redundancy)
                 .await?;
-            send_storage_sync_actions(transport.clone(), repair, "storage_repair").await?;
+            run_storage_repair_transport_effects(transport.clone(), repair).await?;
         }
         PeerRingAction::RemoteAction(next, dht_act) => {
             if let PeerRingRemoteAction::FindEntry(query) = dht_act {
@@ -209,30 +209,21 @@ async fn handle_placed_entry_operation(
     }
 }
 
-/// Send every storage-sync delivery of `act` at the transport boundary.
-async fn send_storage_sync_actions(
+/// Execute copy-only storage repair actions at the Swarm API adapter boundary.
+async fn run_storage_repair_transport_effects(
     transport: Arc<SwarmTransport>,
     act: PeerRingAction,
-    context: &'static str,
 ) -> Result<()> {
     for (delivery, has_next) in core_actor_steps(act.coalesced_storage_sync_deliveries()?) {
         let msg = SyncEntriesWithSuccessor::from_delivery(delivery);
-        transport.send_storage_sync_or_defer(msg, context).await?;
+        transport
+            .send_storage_sync_or_defer(msg, "storage_repair")
+            .await?;
         if has_next {
             yield_core_actor_step().await;
         }
     }
     Ok(())
-}
-
-/// Offer every live local entry placed beyond `head` to it as an ownership hand-off.
-///
-/// Pre: `head` is the current successor head, so the local placement interval is `(self, head]`.
-/// Post: every live local entry beyond that interval has been offered to `head`; local copies are
-/// removed only by the receiver's acknowledgement, so repeating this is idempotent.
-pub(crate) async fn hand_off_storage(transport: Arc<SwarmTransport>, head: Did) -> Result<()> {
-    let handoff = transport.dht.sync_entries_with_successor(head).await?;
-    send_storage_sync_actions(transport, handoff, "ownership_handoff").await
 }
 
 /// Execute storage search actions emitted by inbound message handlers.

--- a/crates/core/src/message/handlers/storage/mod.rs
+++ b/crates/core/src/message/handlers/storage/mod.rs
@@ -38,6 +38,7 @@ use crate::message::MessageVerificationExt;
 use crate::message::PayloadSender;
 use crate::swarm::transport::SwarmTransport;
 use crate::swarm::Swarm;
+use crate::utils::get_epoch_ms;
 
 /// ChordStorageInterface should imply necessary method for DHT storage
 #[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
@@ -163,7 +164,7 @@ pub(super) async fn handle_storage_store_act(
     match act {
         PeerRingAction::RemoteAction(target, PeerRingRemoteAction::FindEntryForOperate(op)) => {
             transport
-                .send_message(Message::OperateEntry(op), target)
+                .send_message(Message::OperateEntry(*op), target)
                 .await?;
         }
         PeerRingAction::MultiActions(acts) => {
@@ -184,12 +185,13 @@ async fn operate_entry_at_placement(
     placement: Did,
     op: EntryOperation,
 ) -> Result<()> {
-    let op = op.stamped(dht.did)?;
-    let this = match dht.storage.get(&placement.to_string()).await? {
+    let now_ms = get_epoch_ms();
+    let op = op.stamped_at(now_ms, dht.did)?;
+    let this = match dht.live_storage_entry(placement, now_ms).await? {
         Some(this) => this,
         None => op.clone().gen_default_entry()?,
     };
-    let entry = this.operate(op, dht.did)?;
+    let entry = this.operate_at(now_ms, op, dht.did)?;
     dht.join_storage_entry(placement, entry).await?;
     Ok(())
 }

--- a/crates/core/src/message/handlers/storage/mod.rs
+++ b/crates/core/src/message/handlers/storage/mod.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 
-use crate::dht::entry::inbox::inbox_destination;
 use crate::dht::entry::Entry;
 use crate::dht::entry::EntryKind;
 use crate::dht::entry::EntryOperation;
@@ -249,14 +248,10 @@ async fn handle_storage_search_act(
 ) -> Result<()> {
     match act {
         PeerRingAction::SomeEntry(evidence) => {
-            // A relay inbox is readable by its recipient alone.
+            // A relay inbox is never fetched: its recipient drains it from local storage, so a
+            // lookup sees it as absent whoever asks.
             let data = match evidence.entry.kind {
                 EntryKind::Data => vec![evidence.entry],
-                EntryKind::RelayMessage
-                    if ctx.transaction.signer() == inbox_destination(evidence.entry.did) =>
-                {
-                    vec![evidence.entry]
-                }
                 EntryKind::RelayMessage => Vec::new(),
             };
             handler
@@ -482,10 +477,12 @@ impl HandleMsg<SyncEntriesWithSuccessor> for MessageHandler {
                 .await;
         }
 
-        let origin = ctx.relay.try_origin_sender()?;
+        // The sender is the transaction signer, the one origin the transport authenticated; the
+        // relay path is peer-declared and forwards unchanged, so it names nobody.
+        let sender = ctx.transaction.signer();
         let acks = self
             .transport
-            .persist_storage_sync_entries(msg, origin)
+            .persist_storage_sync_entries(msg, sender)
             .await?;
         if msg.purpose.permits_source_cleanup() {
             if let Err(e) =

--- a/crates/core/src/message/handlers/storage/mod.rs
+++ b/crates/core/src/message/handlers/storage/mod.rs
@@ -186,14 +186,8 @@ async fn operate_entry_at_placement(
     op: EntryOperation,
 ) -> Result<()> {
     let now_ms = get_epoch_ms();
-    let op = op.stamped_at(now_ms, dht.did)?;
-    let this = match dht.live_storage_entry(placement, now_ms).await? {
-        Some(this) => this,
-        None => op.clone().gen_default_entry()?,
-    };
-    let entry = this.operate_at(now_ms, op, dht.did)?;
-    dht.join_storage_entry(placement, entry).await?;
-    Ok(())
+    dht.operate_storage_entry(now_ms, placement, op.stamped(now_ms, dht.did)?)
+        .await
 }
 
 async fn handle_placed_entry_operation(

--- a/crates/core/src/message/handlers/storage/mod.rs
+++ b/crates/core/src/message/handlers/storage/mod.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 
+use crate::dht::entry::inbox::inbox_destination;
 use crate::dht::entry::Entry;
 use crate::dht::entry::EntryKind;
 use crate::dht::entry::EntryOperation;
@@ -185,9 +186,10 @@ async fn operate_entry_at_placement(
     dht: &PeerRing,
     placement: Did,
     op: EntryOperation,
+    writer: Did,
 ) -> Result<()> {
     let now_ms = get_epoch_ms();
-    dht.operate_storage_entry(now_ms, placement, op.stamped(now_ms, dht.did)?)
+    dht.operate_storage_entry(now_ms, placement, op.stamped(now_ms, dht.did)?, writer)
         .await
 }
 
@@ -198,9 +200,18 @@ async fn handle_placed_entry_operation(
 ) -> Result<()> {
     msg.validate_placement(handler.transport.storage_redundancy())?;
 
-    match handler.dht.find_storage_owner(msg.placement)? {
+    match handler
+        .dht
+        .find_storage_owner_for(msg.placement, msg.op.entry().kind)?
+    {
         PeerRingAction::Some(_) => {
-            operate_entry_at_placement(&handler.dht, msg.placement, msg.op.clone()).await
+            operate_entry_at_placement(
+                &handler.dht,
+                msg.placement,
+                msg.op.clone(),
+                ctx.transaction.signer(),
+            )
+            .await
         }
         PeerRingAction::RemoteAction(next, PeerRingRemoteAction::FindSuccessor(_)) => {
             reset_storage_relay_destination(handler, ctx, next).await
@@ -238,11 +249,21 @@ async fn handle_storage_search_act(
 ) -> Result<()> {
     match act {
         PeerRingAction::SomeEntry(evidence) => {
+            // A relay inbox is readable by its recipient alone.
+            let data = match evidence.entry.kind {
+                EntryKind::Data => vec![evidence.entry],
+                EntryKind::RelayMessage
+                    if ctx.transaction.signer() == inbox_destination(evidence.entry.did) =>
+                {
+                    vec![evidence.entry]
+                }
+                EntryKind::RelayMessage => Vec::new(),
+            };
             handler
                 .run_effects([CoreEffect::send_report_message(
                     ctx,
                     Message::FoundEntry(FoundEntry {
-                        data: vec![evidence.entry],
+                        data,
                         misses: evidence.misses,
                         resource,
                         redundancy,
@@ -280,7 +301,7 @@ async fn handle_storage_search_act(
     }
 }
 
-async fn operate_storage_entry<const REDUNDANT: u16>(
+async fn operate_entry_under_redundancy<const REDUNDANT: u16>(
     swarm: &Swarm,
     operation: EntryOperation,
 ) -> Result<()> {
@@ -299,18 +320,6 @@ pub(crate) async fn operate_entry(
         .entry_operate_with_redundancy(operation, transport.storage_redundancy())
         .await?;
     handle_storage_store_act(transport, action).await
-}
-
-/// Fetch `entry_key` under the transport's configured redundancy: a local hit is copied into
-/// the cache, a miss queries the responsible owners.
-pub(crate) async fn fetch_entry(transport: Arc<SwarmTransport>, entry_key: Did) -> Result<()> {
-    let redundancy = transport.storage_redundancy();
-    transport.start_storage_lookup(entry_key, redundancy)?;
-    let act = transport
-        .dht
-        .entry_lookup_for_fetch(entry_key, redundancy)
-        .await?;
-    handle_storage_fetch_act(transport, entry_key, act, redundancy).await
 }
 
 fn next_hop_for_sync_entries(
@@ -368,32 +377,39 @@ impl<const REDUNDANT: u16> ChordStorageInterface<REDUNDANT> for Swarm {
     /// otherwise query the responsible remote node.
     async fn storage_fetch(&self, entry_key: Did) -> Result<()> {
         self.transport.ensure_storage_redundancy::<REDUNDANT>()?;
-        fetch_entry(self.transport.clone(), entry_key).await
+        let transport = self.transport.clone();
+        let redundancy = transport.storage_redundancy();
+        transport.start_storage_lookup(entry_key, redundancy)?;
+        let act = transport
+            .dht
+            .entry_lookup_for_fetch(entry_key, redundancy)
+            .await?;
+        handle_storage_fetch_act(transport, entry_key, act, redundancy).await
     }
 
     /// Store Entry, `TryInto<Entry>` is implemented for alot of types
     async fn storage_store(&self, entry: Entry) -> Result<()> {
-        operate_storage_entry::<REDUNDANT>(self, EntryOperation::Overwrite(entry)).await
+        operate_entry_under_redundancy::<REDUNDANT>(self, EntryOperation::Overwrite(entry)).await
     }
 
     async fn storage_append_data(&self, topic: &str, data: Encoded) -> Result<()> {
         let entry: Entry = (topic.to_string(), data).try_into()?;
-        operate_storage_entry::<REDUNDANT>(self, EntryOperation::Extend(entry)).await
+        operate_entry_under_redundancy::<REDUNDANT>(self, EntryOperation::Extend(entry)).await
     }
 
     async fn storage_touch_data(&self, topic: &str, data: Encoded) -> Result<()> {
         let entry: Entry = (topic.to_string(), data).try_into()?;
-        operate_storage_entry::<REDUNDANT>(self, EntryOperation::Touch(entry)).await
+        operate_entry_under_redundancy::<REDUNDANT>(self, EntryOperation::Touch(entry)).await
     }
 
     async fn storage_tombstone_data(&self, topic: &str, data: Encoded) -> Result<()> {
         let entry: Entry = (topic.to_string(), data).try_into()?;
-        operate_storage_entry::<REDUNDANT>(self, EntryOperation::Tombstone(entry)).await
+        operate_entry_under_redundancy::<REDUNDANT>(self, EntryOperation::Tombstone(entry)).await
     }
 
     async fn storage_compact_data(&self, topic: &str, removals: Vec<Encoded>) -> Result<()> {
         let entry = Entry::new(Entry::gen_did(topic)?, removals, EntryKind::Data);
-        operate_storage_entry::<REDUNDANT>(self, EntryOperation::CompactData(entry)).await
+        operate_entry_under_redundancy::<REDUNDANT>(self, EntryOperation::CompactData(entry)).await
     }
 }
 
@@ -466,7 +482,11 @@ impl HandleMsg<SyncEntriesWithSuccessor> for MessageHandler {
                 .await;
         }
 
-        let acks = self.transport.persist_storage_sync_entries(msg).await?;
+        let origin = ctx.relay.try_origin_sender()?;
+        let acks = self
+            .transport
+            .persist_storage_sync_entries(msg, origin)
+            .await?;
         if msg.purpose.permits_source_cleanup() {
             if let Err(e) =
                 report_synced_entries(self, ctx, msg.purpose, msg.destination, acks).await

--- a/crates/core/src/message/handlers/storage/tests/test_repair.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_repair.rs
@@ -96,7 +96,7 @@ async fn test_leave_dht_defers_repair_until_maintenance_runs() -> Result<()> {
         None
     );
 
-    node.swarm.stabilizer()?.stabilize().await?;
+    node.swarm.stabilizer().stabilize().await?;
 
     assert!(!node.swarm.transport.storage_repair_requested());
     assert_eq!(

--- a/crates/core/src/message/handlers/storage/tests/test_repair.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_repair.rs
@@ -96,7 +96,7 @@ async fn test_leave_dht_defers_repair_until_maintenance_runs() -> Result<()> {
         None
     );
 
-    node.swarm.stabilizer().stabilize().await?;
+    node.swarm.stabilizer()?.stabilize().await?;
 
     assert!(!node.swarm.transport.storage_repair_requested());
     assert_eq!(

--- a/crates/core/src/message/handlers/storage/tests/test_repair.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_repair.rs
@@ -28,6 +28,7 @@ use crate::message::Encoder;
 use crate::message::HandleMsg;
 use crate::message::MessageHandler;
 use crate::message::MessagePayload;
+use crate::message::MessageSigner;
 use crate::message::MessageVerificationExt;
 use crate::session::SessionSk;
 use crate::storage::MemStorage;
@@ -41,6 +42,7 @@ use crate::tests::default::prepare_node;
 use crate::tests::default::wait_for_msgs;
 use crate::tests::default::Node;
 use crate::tests::manually_establish_connection;
+use crate::tests::TEST_NETWORK_ID;
 
 #[tokio::test]
 async fn test_storage_repair_request_after_claim_remains_pending() -> Result<()> {
@@ -74,7 +76,7 @@ async fn test_leave_dht_defers_repair_until_maintenance_runs() -> Result<()> {
     let node = Node::new(swarm);
     let departed = Did::from(100u32);
     node.dht().successors().update(departed)?;
-    let entry = Entry::new(key.address().into(), vec![], EntryKind::Data);
+    let entry = crate::tests::live_entry(key.address().into(), vec![], EntryKind::Data);
     let placement_keys = entry.did.rotate_affine(2)?;
     node.dht()
         .storage
@@ -134,7 +136,7 @@ async fn test_found_entry_read_repair_backpressure_is_deferred() -> Result<()> {
             resource: entry.did,
             redundancy: 2,
         }),
-        node2.swarm.transport.session_sk(),
+        node2.swarm.transport.message_signer(),
         node1.did(),
         node1.did(),
     )?;
@@ -199,7 +201,7 @@ async fn test_placed_entry_operation_rejects_non_affine_placement() -> Result<()
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let topic = "reject misplaced remote storage operation".to_string();
-    let entry: Entry = topic.try_into()?;
+    let entry: Entry = crate::tests::live(topic.try_into()?);
     let invalid_placement = non_affine_placement(entry.did, 2)?;
     let msg = PlacedEntryOperation {
         placement: invalid_placement,
@@ -208,7 +210,7 @@ async fn test_placed_entry_operation_rejects_non_affine_placement() -> Result<()
     let sender_session = SessionSk::new_with_seckey(&SecretKey::random())?;
     let context = MessagePayload::new_send(
         Message::OperateEntry(msg.clone()),
-        &sender_session,
+        MessageSigner::new(&sender_session, TEST_NETWORK_ID),
         node.did(),
         node.did(),
     )?;
@@ -312,7 +314,7 @@ async fn test_local_hit_read_repair_sends_no_search_for_unknown_replicas() -> Re
         .build(),
     );
     let node = Node::new(swarm);
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         key.address().into(),
         vec!["local".to_string().encode()?],
         EntryKind::Data,
@@ -339,7 +341,7 @@ async fn test_local_hit_read_repair_sends_no_search_for_unknown_replicas() -> Re
 async fn test_found_entry_repairs_buffered_misses_only() -> Result<()> {
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         Did::from(10u32),
         vec!["repair".to_string().encode()?],
         EntryKind::Data,
@@ -361,7 +363,7 @@ async fn test_found_entry_repairs_buffered_misses_only() -> Result<()> {
             resource: entry.did,
             redundancy: 2,
         }),
-        &context_session,
+        MessageSigner::new(&context_session, TEST_NETWORK_ID),
         node.did(),
         node.did(),
     )?;
@@ -400,12 +402,12 @@ async fn test_found_entry_rejects_multiple_entries() -> Result<()> {
     let node = prepare_node(SecretKey::random()).await;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let resource = Did::from(10u32);
-    let first = Entry::new(
+    let first = crate::tests::live_entry(
         resource,
         vec!["first".to_string().encode()?],
         EntryKind::Data,
     );
-    let second = Entry::new(
+    let second = crate::tests::live_entry(
         resource,
         vec!["second".to_string().encode()?],
         EntryKind::Data,
@@ -419,7 +421,7 @@ async fn test_found_entry_rejects_multiple_entries() -> Result<()> {
             resource,
             redundancy: 2,
         }),
-        &context_session,
+        MessageSigner::new(&context_session, TEST_NETWORK_ID),
         node.did(),
         node.did(),
     )?;
@@ -446,7 +448,7 @@ async fn test_found_entry_rejects_redundancy_outside_local_protocol_mode() -> Re
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let resource = Did::from(10u32);
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         resource,
         vec!["wrong redundancy".to_string().encode()?],
         EntryKind::Data,
@@ -460,7 +462,7 @@ async fn test_found_entry_rejects_redundancy_outside_local_protocol_mode() -> Re
             resource,
             redundancy: 3,
         }),
-        &context_session,
+        MessageSigner::new(&context_session, TEST_NETWORK_ID),
         node.did(),
         node.did(),
     )?;
@@ -491,7 +493,7 @@ async fn test_found_entry_rejects_response_without_active_lookup() -> Result<()>
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let resource = Did::from(10u32);
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         resource,
         vec!["unsolicited".to_string().encode()?],
         EntryKind::Data,
@@ -505,7 +507,7 @@ async fn test_found_entry_rejects_response_without_active_lookup() -> Result<()>
             resource,
             redundancy: 2,
         }),
-        &context_session,
+        MessageSigner::new(&context_session, TEST_NETWORK_ID),
         node.did(),
         node.did(),
     )?;
@@ -532,7 +534,7 @@ async fn test_found_entry_rejects_resource_mismatch_without_cache_write() -> Res
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let resource = Did::from(10u32);
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         Did::from(11u32),
         vec!["wrong resource".to_string().encode()?],
         EntryKind::Data,
@@ -546,7 +548,7 @@ async fn test_found_entry_rejects_resource_mismatch_without_cache_write() -> Res
             resource,
             redundancy: 2,
         }),
-        &context_session,
+        MessageSigner::new(&context_session, TEST_NETWORK_ID),
         node.did(),
         node.did(),
     )?;
@@ -611,7 +613,7 @@ async fn test_storage_fetch_starts_fresh_observation_round() -> Result<()> {
 async fn test_expired_storage_response_does_not_update_cache_or_repair() -> Result<()> {
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         Did::from(10u32),
         vec!["fresh".to_string().encode()?],
         EntryKind::Data,
@@ -631,7 +633,7 @@ async fn test_expired_storage_response_does_not_update_cache_or_repair() -> Resu
             resource: entry.did,
             redundancy: 2,
         }),
-        &context_session,
+        MessageSigner::new(&context_session, TEST_NETWORK_ID),
         node.did(),
         node.did(),
     )?;

--- a/crates/core/src/message/handlers/storage/tests/test_repair.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_repair.rs
@@ -41,6 +41,7 @@ use crate::tests::default::dummy_hooks::PendingSendGuard;
 use crate::tests::default::prepare_node;
 use crate::tests::default::wait_for_msgs;
 use crate::tests::default::Node;
+use crate::tests::live_entry;
 use crate::tests::manually_establish_connection;
 use crate::tests::TEST_NETWORK_ID;
 
@@ -76,7 +77,7 @@ async fn test_leave_dht_defers_repair_until_maintenance_runs() -> Result<()> {
     let node = Node::new(swarm);
     let departed = Did::from(100u32);
     node.dht().successors().update(departed)?;
-    let entry = crate::tests::live_entry(key.address().into(), vec![], EntryKind::Data);
+    let entry = live_entry(key.address().into(), vec![], EntryKind::Data);
     let placement_keys = entry.did.rotate_affine(2)?;
     node.dht()
         .storage
@@ -314,7 +315,7 @@ async fn test_local_hit_read_repair_sends_no_search_for_unknown_replicas() -> Re
         .build(),
     );
     let node = Node::new(swarm);
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         key.address().into(),
         vec!["local".to_string().encode()?],
         EntryKind::Data,
@@ -341,7 +342,7 @@ async fn test_local_hit_read_repair_sends_no_search_for_unknown_replicas() -> Re
 async fn test_found_entry_repairs_buffered_misses_only() -> Result<()> {
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         Did::from(10u32),
         vec!["repair".to_string().encode()?],
         EntryKind::Data,
@@ -402,12 +403,12 @@ async fn test_found_entry_rejects_multiple_entries() -> Result<()> {
     let node = prepare_node(SecretKey::random()).await;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let resource = Did::from(10u32);
-    let first = crate::tests::live_entry(
+    let first = live_entry(
         resource,
         vec!["first".to_string().encode()?],
         EntryKind::Data,
     );
-    let second = crate::tests::live_entry(
+    let second = live_entry(
         resource,
         vec!["second".to_string().encode()?],
         EntryKind::Data,
@@ -448,7 +449,7 @@ async fn test_found_entry_rejects_redundancy_outside_local_protocol_mode() -> Re
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let resource = Did::from(10u32);
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         resource,
         vec!["wrong redundancy".to_string().encode()?],
         EntryKind::Data,
@@ -493,7 +494,7 @@ async fn test_found_entry_rejects_response_without_active_lookup() -> Result<()>
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let resource = Did::from(10u32);
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         resource,
         vec!["unsolicited".to_string().encode()?],
         EntryKind::Data,
@@ -534,7 +535,7 @@ async fn test_found_entry_rejects_resource_mismatch_without_cache_write() -> Res
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let resource = Did::from(10u32);
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         Did::from(11u32),
         vec!["wrong resource".to_string().encode()?],
         EntryKind::Data,
@@ -613,7 +614,7 @@ async fn test_storage_fetch_starts_fresh_observation_round() -> Result<()> {
 async fn test_expired_storage_response_does_not_update_cache_or_repair() -> Result<()> {
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         Did::from(10u32),
         vec!["fresh".to_string().encode()?],
         EntryKind::Data,

--- a/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
@@ -32,6 +32,7 @@ use crate::message::PayloadSender;
 use crate::tests::default::assert_no_more_msg;
 use crate::tests::default::prepare_node;
 use crate::tests::default::wait_for_msgs;
+use crate::tests::live_entry;
 use crate::tests::manually_establish_connection;
 
 #[tokio::test]
@@ -48,7 +49,7 @@ async fn test_sync_entries_handler_reports_persisted_entries() -> Result<()> {
 
     let receiver_handler =
         MessageHandler::new(receiver.swarm.transport.clone(), Arc::new(NoopCallback));
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         Did::from(10u32),
         vec!["handler acked".to_string().encode()?],
         EntryKind::Data,
@@ -104,12 +105,12 @@ async fn test_sync_entries_handler_reports_persisted_entries() -> Result<()> {
 #[tokio::test]
 async fn test_persist_synced_entries_skips_a_relay_carrier_from_a_stranger() -> Result<()> {
     let receiver = prepare_node(SecretKey::random()).await;
-    let topic = crate::tests::live_entry(
+    let topic = live_entry(
         Did::from(10u32),
         vec!["acked".to_string().encode()?],
         EntryKind::Data,
     );
-    let inbox = crate::tests::live_entry(Did::from(20u32), Vec::new(), EntryKind::RelayMessage);
+    let inbox = live_entry(Did::from(20u32), Vec::new(), EntryKind::RelayMessage);
     let sync_msg = SyncEntriesWithSuccessor {
         purpose: StorageSyncPurpose::OwnershipHandoff,
         destination: StorageSyncDestination::PhysicalOwner(receiver.did()),
@@ -139,7 +140,7 @@ async fn test_persist_synced_entries_skips_a_relay_carrier_from_a_stranger() -> 
 #[tokio::test]
 async fn test_persist_synced_entries_returns_acks_for_owned_entries() -> Result<()> {
     let receiver = prepare_node(SecretKey::random()).await;
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         Did::from(10u32),
         vec!["acked".to_string().encode()?],
         EntryKind::Data,
@@ -196,7 +197,7 @@ async fn test_sync_entries_handler_skips_entries_owned_by_another_virtual_owner(
             if owner == sender.did() && key == placement_key
     ));
 
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         Did::from(10u32),
         vec!["wrong owner".to_string().encode()?],
         EntryKind::Data,

--- a/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
@@ -117,7 +117,7 @@ async fn test_persist_synced_entries_returns_acks_for_owned_entries() -> Result<
     let acks = receiver
         .swarm
         .transport
-        .persist_storage_sync_entries(&sync_msg)
+        .persist_storage_sync_entries(&sync_msg, Did::from(1u32))
         .await?;
 
     assert_eq!(acks, vec![SyncedEntryAck::new(

--- a/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
@@ -7,7 +7,6 @@ use super::test_support::physical_sync_route_next_hop;
 use super::test_support::prepare_node_with_virtual_nodes;
 use super::test_support::storage_sync_route_next_hop;
 use super::test_support::NoopCallback;
-use crate::dht::entry::inbox::HeldMessage;
 use crate::dht::entry::Entry;
 use crate::dht::entry::EntryKind;
 use crate::dht::entry::PlacedEntry;
@@ -18,6 +17,7 @@ use crate::dht::Chord;
 use crate::dht::Did;
 use crate::dht::PeerRingAction;
 use crate::dht::PeerRingRemoteAction;
+use crate::dht::StorageKey;
 use crate::dht::StorageSyncDestination;
 use crate::dht::StorageSyncPurpose;
 use crate::ecc::tests::gen_ordered_keys;
@@ -30,17 +30,14 @@ use crate::message::Encoder;
 use crate::message::HandleMsg;
 use crate::message::MessageHandler;
 use crate::message::MessagePayload;
-use crate::message::MessageSigner;
 use crate::message::PayloadSender;
 use crate::session::SessionSk;
 use crate::tests::default::assert_no_more_msg;
 use crate::tests::default::prepare_node;
 use crate::tests::default::wait_for_msgs;
-use crate::tests::live;
+use crate::tests::held_inbox_for;
 use crate::tests::live_entry;
 use crate::tests::manually_establish_connection;
-use crate::tests::TEST_NETWORK_ID;
-use crate::utils::get_epoch_ms;
 
 #[tokio::test]
 async fn test_sync_entries_handler_reports_persisted_entries() -> Result<()> {
@@ -107,21 +104,16 @@ async fn test_sync_entries_handler_reports_persisted_entries() -> Result<()> {
 }
 
 /// A witnessed inbox carrier for `destination`, held now by a fresh session.
-fn held_inbox_for(destination: Did) -> Result<Entry> {
-    let sender = SessionSk::new_with_seckey(&SecretKey::random())?;
-    let holder = SessionSk::new_with_seckey(&SecretKey::random())?;
-    let payload = MessagePayload::new_send(
-        Message::custom(b"held")?,
-        MessageSigner::new(&sender, TEST_NETWORK_ID),
+fn inbox_held_by_a_stranger(destination: Did) -> Result<Entry> {
+    held_inbox_for(
         destination,
-        destination,
-    )?;
-    let held = HeldMessage::hold(
-        payload,
-        MessageSigner::new(&holder, TEST_NETWORK_ID),
-        get_epoch_ms(),
-    )?;
-    Ok(live(Entry::inbox_delta(&held)?))
+        &SessionSk::new_with_seckey(&SecretKey::random())?,
+    )
+}
+
+/// The slot of the inbox carrier `inbox`.
+fn inbox_slot(inbox: &Entry) -> String {
+    StorageKey::new(EntryKind::RelayMessage, inbox.did).to_string()
 }
 
 /// Relocation law: a relay carrier is accepted from the receiver's predecessor and skipped
@@ -139,7 +131,7 @@ async fn test_persist_synced_entries_relocates_a_relay_carrier_from_the_predeces
         vec!["acked".to_string().encode()?],
         EntryKind::Data,
     );
-    let inbox = held_inbox_for(receiver.did())?;
+    let inbox = inbox_held_by_a_stranger(receiver.did())?;
     let sync_msg = SyncEntriesWithSuccessor {
         purpose: StorageSyncPurpose::OwnershipHandoff,
         destination: StorageSyncDestination::PhysicalOwner(receiver.did()),
@@ -158,10 +150,7 @@ async fn test_persist_synced_entries_relocates_a_relay_carrier_from_the_predeces
         topic.did,
         topic.clone().try_into_storage_entry()?
     )]);
-    assert_eq!(
-        receiver.dht().storage.get(&inbox.did.to_string()).await?,
-        None
-    );
+    assert_eq!(receiver.dht().storage.get(&inbox_slot(&inbox)).await?, None);
 
     let from_predecessor = receiver
         .swarm
@@ -172,7 +161,7 @@ async fn test_persist_synced_entries_relocates_a_relay_carrier_from_the_predeces
     assert!(receiver
         .dht()
         .storage
-        .get(&inbox.did.to_string())
+        .get(&inbox_slot(&inbox))
         .await?
         .is_some());
     Ok(())
@@ -191,7 +180,7 @@ async fn test_sync_entries_handler_ignores_a_forged_relay_origin_for_a_relay_car
     let predecessor: Did = SecretKey::random().address().into();
     *receiver.dht().lock_predecessor()? = Some(predecessor);
 
-    let inbox = held_inbox_for(receiver.did())?;
+    let inbox = inbox_held_by_a_stranger(receiver.did())?;
     let sync_msg = SyncEntriesWithSuccessor {
         purpose: StorageSyncPurpose::OwnershipHandoff,
         destination: StorageSyncDestination::PhysicalOwner(receiver.did()),
@@ -209,10 +198,7 @@ async fn test_sync_entries_handler_ignores_a_forged_relay_origin_for_a_relay_car
         MessageHandler::new(receiver.swarm.transport.clone(), Arc::new(NoopCallback));
     receiver_handler.handle(&context, &sync_msg).await?;
 
-    assert_eq!(
-        receiver.dht().storage.get(&inbox.did.to_string()).await?,
-        None
-    );
+    assert_eq!(receiver.dht().storage.get(&inbox_slot(&inbox)).await?, None);
     Ok(())
 }
 

--- a/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
@@ -112,8 +112,8 @@ fn inbox_held_by_a_stranger(destination: Did) -> Result<Entry> {
 }
 
 /// The slot of the inbox carrier `inbox`.
-fn inbox_slot(inbox: &Entry) -> String {
-    StorageKey::new(EntryKind::RelayMessage, inbox.did).to_string()
+fn inbox_slot(inbox: &Entry) -> StorageKey {
+    StorageKey::new(EntryKind::RelayMessage, inbox.did)
 }
 
 /// Relocation law: a relay carrier is accepted from the receiver's predecessor and skipped
@@ -150,7 +150,14 @@ async fn test_persist_synced_entries_relocates_a_relay_carrier_from_the_predeces
         topic.did,
         topic.clone().try_into_storage_entry()?
     )]);
-    assert_eq!(receiver.dht().storage.get(&inbox_slot(&inbox)).await?, None);
+    assert_eq!(
+        receiver
+            .dht()
+            .storage
+            .get(&inbox_slot(&inbox).to_string())
+            .await?,
+        None
+    );
 
     let from_predecessor = receiver
         .swarm
@@ -161,7 +168,7 @@ async fn test_persist_synced_entries_relocates_a_relay_carrier_from_the_predeces
     assert!(receiver
         .dht()
         .storage
-        .get(&inbox_slot(&inbox))
+        .get(&inbox_slot(&inbox).to_string())
         .await?
         .is_some());
     Ok(())
@@ -198,7 +205,14 @@ async fn test_sync_entries_handler_ignores_a_forged_relay_origin_for_a_relay_car
         MessageHandler::new(receiver.swarm.transport.clone(), Arc::new(NoopCallback));
     receiver_handler.handle(&context, &sync_msg).await?;
 
-    assert_eq!(receiver.dht().storage.get(&inbox_slot(&inbox)).await?, None);
+    assert_eq!(
+        receiver
+            .dht()
+            .storage
+            .get(&inbox_slot(&inbox).to_string())
+            .await?,
+        None
+    );
     Ok(())
 }
 

--- a/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
@@ -7,6 +7,8 @@ use super::test_support::physical_sync_route_next_hop;
 use super::test_support::prepare_node_with_virtual_nodes;
 use super::test_support::storage_sync_route_next_hop;
 use super::test_support::NoopCallback;
+use crate::dht::entry::inbox::HeldMessage;
+use crate::dht::entry::Entry;
 use crate::dht::entry::EntryKind;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::SyncedEntryAck;
@@ -28,12 +30,17 @@ use crate::message::Encoder;
 use crate::message::HandleMsg;
 use crate::message::MessageHandler;
 use crate::message::MessagePayload;
+use crate::message::MessageSigner;
 use crate::message::PayloadSender;
+use crate::session::SessionSk;
 use crate::tests::default::assert_no_more_msg;
 use crate::tests::default::prepare_node;
 use crate::tests::default::wait_for_msgs;
+use crate::tests::live;
 use crate::tests::live_entry;
 use crate::tests::manually_establish_connection;
+use crate::tests::TEST_NETWORK_ID;
+use crate::utils::get_epoch_ms;
 
 #[tokio::test]
 async fn test_sync_entries_handler_reports_persisted_entries() -> Result<()> {
@@ -99,18 +106,40 @@ async fn test_sync_entries_handler_reports_persisted_entries() -> Result<()> {
     Ok(())
 }
 
-/// Relocation law: a relay carrier offered by anyone but the receiver's predecessor is skipped
-/// without an acknowledgement, and the data entries sharing its batch are still accepted; the
-/// carrier is not invalid, only not this receiver's to take yet.
+/// A witnessed inbox carrier for `destination`, held now by a fresh session.
+fn held_inbox_for(destination: Did) -> Result<Entry> {
+    let sender = SessionSk::new_with_seckey(&SecretKey::random())?;
+    let holder = SessionSk::new_with_seckey(&SecretKey::random())?;
+    let payload = MessagePayload::new_send(
+        Message::custom(b"held")?,
+        MessageSigner::new(&sender, TEST_NETWORK_ID),
+        destination,
+        destination,
+    )?;
+    let held = HeldMessage::hold(
+        payload,
+        MessageSigner::new(&holder, TEST_NETWORK_ID),
+        get_epoch_ms(),
+    )?;
+    Ok(live(Entry::inbox_delta(&held)?))
+}
+
+/// Relocation law: a relay carrier is accepted from the receiver's predecessor and skipped
+/// without an acknowledgement from anyone else, while the data entries sharing its batch are
+/// accepted either way; the carrier is not invalid, only not this receiver's to take yet.
 #[tokio::test]
-async fn test_persist_synced_entries_skips_a_relay_carrier_from_a_stranger() -> Result<()> {
+async fn test_persist_synced_entries_relocates_a_relay_carrier_from_the_predecessor_alone(
+) -> Result<()> {
     let receiver = prepare_node(SecretKey::random()).await;
+    let predecessor: Did = SecretKey::random().address().into();
+    let stranger: Did = SecretKey::random().address().into();
+    *receiver.dht().lock_predecessor()? = Some(predecessor);
     let topic = live_entry(
         Did::from(10u32),
         vec!["acked".to_string().encode()?],
         EntryKind::Data,
     );
-    let inbox = live_entry(Did::from(20u32), Vec::new(), EntryKind::RelayMessage);
+    let inbox = held_inbox_for(receiver.did())?;
     let sync_msg = SyncEntriesWithSuccessor {
         purpose: StorageSyncPurpose::OwnershipHandoff,
         destination: StorageSyncDestination::PhysicalOwner(receiver.did()),
@@ -120,16 +149,66 @@ async fn test_persist_synced_entries_skips_a_relay_carrier_from_a_stranger() -> 
         ],
     };
 
-    let acks = receiver
+    let from_stranger = receiver
         .swarm
         .transport
-        .persist_storage_sync_entries(&sync_msg, Did::from(1u32))
+        .persist_storage_sync_entries(&sync_msg, stranger)
         .await?;
-
-    assert_eq!(acks, vec![SyncedEntryAck::new(
+    assert_eq!(from_stranger, vec![SyncedEntryAck::new(
         topic.did,
         topic.clone().try_into_storage_entry()?
     )]);
+    assert_eq!(
+        receiver.dht().storage.get(&inbox.did.to_string()).await?,
+        None
+    );
+
+    let from_predecessor = receiver
+        .swarm
+        .transport
+        .persist_storage_sync_entries(&sync_msg, predecessor)
+        .await?;
+    assert_eq!(from_predecessor.len(), 2);
+    assert!(receiver
+        .dht()
+        .storage
+        .get(&inbox.did.to_string())
+        .await?
+        .is_some());
+    Ok(())
+}
+
+/// The relocation sender is the authenticated transaction signer: a relay path that names the
+/// receiver's predecessor as its origin is peer-declared and proves nothing.
+#[tokio::test]
+async fn test_sync_entries_handler_ignores_a_forged_relay_origin_for_a_relay_carrier() -> Result<()>
+{
+    let attacker = prepare_node(SecretKey::random()).await;
+    let receiver = prepare_node(SecretKey::random()).await;
+    manually_establish_connection(&attacker.swarm, &receiver.swarm).await;
+    wait_for_msgs([&attacker, &receiver]).await;
+    assert_no_more_msg([&attacker, &receiver]).await;
+    let predecessor: Did = SecretKey::random().address().into();
+    *receiver.dht().lock_predecessor()? = Some(predecessor);
+
+    let inbox = held_inbox_for(receiver.did())?;
+    let sync_msg = SyncEntriesWithSuccessor {
+        purpose: StorageSyncPurpose::OwnershipHandoff,
+        destination: StorageSyncDestination::PhysicalOwner(receiver.did()),
+        data: vec![PlacedEntry::new(inbox.did, inbox.clone())],
+    };
+    let mut context = MessagePayload::new_send(
+        Message::SyncEntriesWithSuccessor(sync_msg.clone()),
+        attacker.swarm.transport.message_signer(),
+        receiver.did(),
+        receiver.did(),
+    )?;
+    context.relay.path = vec![predecessor, attacker.did()];
+
+    let receiver_handler =
+        MessageHandler::new(receiver.swarm.transport.clone(), Arc::new(NoopCallback));
+    receiver_handler.handle(&context, &sync_msg).await?;
+
     assert_eq!(
         receiver.dht().storage.get(&inbox.did.to_string()).await?,
         None

--- a/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
@@ -98,6 +98,44 @@ async fn test_sync_entries_handler_reports_persisted_entries() -> Result<()> {
     Ok(())
 }
 
+/// Relocation law: a relay carrier offered by anyone but the receiver's predecessor is skipped
+/// without an acknowledgement, and the data entries sharing its batch are still accepted; the
+/// carrier is not invalid, only not this receiver's to take yet.
+#[tokio::test]
+async fn test_persist_synced_entries_skips_a_relay_carrier_from_a_stranger() -> Result<()> {
+    let receiver = prepare_node(SecretKey::random()).await;
+    let topic = crate::tests::live_entry(
+        Did::from(10u32),
+        vec!["acked".to_string().encode()?],
+        EntryKind::Data,
+    );
+    let inbox = crate::tests::live_entry(Did::from(20u32), Vec::new(), EntryKind::RelayMessage);
+    let sync_msg = SyncEntriesWithSuccessor {
+        purpose: StorageSyncPurpose::OwnershipHandoff,
+        destination: StorageSyncDestination::PhysicalOwner(receiver.did()),
+        data: vec![
+            PlacedEntry::new(inbox.did, inbox.clone()),
+            PlacedEntry::new(topic.did, topic.clone()),
+        ],
+    };
+
+    let acks = receiver
+        .swarm
+        .transport
+        .persist_storage_sync_entries(&sync_msg, Did::from(1u32))
+        .await?;
+
+    assert_eq!(acks, vec![SyncedEntryAck::new(
+        topic.did,
+        topic.clone().try_into_storage_entry()?
+    )]);
+    assert_eq!(
+        receiver.dht().storage.get(&inbox.did.to_string()).await?,
+        None
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_persist_synced_entries_returns_acks_for_owned_entries() -> Result<()> {
     let receiver = prepare_node(SecretKey::random()).await;

--- a/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_storage_sync_report.rs
@@ -7,7 +7,6 @@ use super::test_support::physical_sync_route_next_hop;
 use super::test_support::prepare_node_with_virtual_nodes;
 use super::test_support::storage_sync_route_next_hop;
 use super::test_support::NoopCallback;
-use crate::dht::entry::Entry;
 use crate::dht::entry::EntryKind;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::SyncedEntryAck;
@@ -49,7 +48,7 @@ async fn test_sync_entries_handler_reports_persisted_entries() -> Result<()> {
 
     let receiver_handler =
         MessageHandler::new(receiver.swarm.transport.clone(), Arc::new(NoopCallback));
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         Did::from(10u32),
         vec!["handler acked".to_string().encode()?],
         EntryKind::Data,
@@ -67,7 +66,7 @@ async fn test_sync_entries_handler_reports_persisted_entries() -> Result<()> {
     };
     let context = MessagePayload::new_send(
         Message::SyncEntriesWithSuccessor(sync_msg.clone()),
-        sender.swarm.transport.session_sk(),
+        sender.swarm.transport.message_signer(),
         receiver.did(),
         receiver.did(),
     )?;
@@ -102,7 +101,7 @@ async fn test_sync_entries_handler_reports_persisted_entries() -> Result<()> {
 #[tokio::test]
 async fn test_persist_synced_entries_returns_acks_for_owned_entries() -> Result<()> {
     let receiver = prepare_node(SecretKey::random()).await;
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         Did::from(10u32),
         vec!["acked".to_string().encode()?],
         EntryKind::Data,
@@ -159,7 +158,7 @@ async fn test_sync_entries_handler_skips_entries_owned_by_another_virtual_owner(
             if owner == sender.did() && key == placement_key
     ));
 
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         Did::from(10u32),
         vec!["wrong owner".to_string().encode()?],
         EntryKind::Data,
@@ -177,7 +176,7 @@ async fn test_sync_entries_handler_skips_entries_owned_by_another_virtual_owner(
     };
     let context = MessagePayload::new_send(
         Message::SyncEntriesWithSuccessor(sync_msg.clone()),
-        sender.swarm.transport.session_sk(),
+        sender.swarm.transport.message_signer(),
         receiver.did(),
         receiver.did(),
     )?;
@@ -255,7 +254,7 @@ async fn test_sync_entries_physical_destination_routes_by_physical_did_not_stora
     };
     let context = MessagePayload::new_send(
         Message::SyncEntriesWithSuccessor(msg.clone()),
-        node.swarm.transport.session_sk(),
+        node.swarm.transport.message_signer(),
         node.did(),
         destination,
     )?;

--- a/crates/core/src/message/handlers/storage/tests/test_support.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_support.rs
@@ -23,6 +23,7 @@ use crate::message::types::SyncEntriesWithSuccessorReport;
 use crate::message::Encoder;
 use crate::message::MessagePayload;
 use crate::message::MessageRelay;
+use crate::message::MessageSigner;
 use crate::message::PayloadSender;
 use crate::message::Transaction;
 use crate::session::SessionSk;
@@ -219,7 +220,7 @@ async fn test_matching_payload_restores_current_message_when_predicate_panics() 
 fn test_payload(node: &Node, data: &[u8]) -> Result<MessagePayload> {
     MessagePayload::new_send(
         Message::custom(data)?,
-        node.swarm.transport.session_sk(),
+        node.swarm.transport.message_signer(),
         node.did(),
         node.did(),
     )
@@ -233,7 +234,7 @@ pub(super) fn next_generated_key(keys: &mut impl Iterator<Item = SecretKey>) -> 
 pub(super) fn storage_sync_report_payload(
     request: &MessagePayload,
     report: SyncEntriesWithSuccessorReport,
-    signer: &SessionSk,
+    signer: MessageSigner<'_>,
     next_hop: Did,
     destination: Did,
 ) -> Result<MessagePayload> {
@@ -361,7 +362,7 @@ pub(super) fn install_two_node_chord_view(first: &Node, second: &Node) -> Result
 pub(super) fn split_redundant_entry(nodes: &[&Node]) -> Result<(Entry, Did, Did, usize, usize)> {
     for attempt in 0..512 {
         let topic = format!("split remote replica placement {attempt}");
-        let entry: Entry = topic.try_into()?;
+        let entry: Entry = crate::tests::live(topic.try_into()?);
         let mut placements = entry.did.rotate_affine(2)?.into_iter();
         let primary = placements
             .next()

--- a/crates/core/src/message/handlers/storage/tests/test_support.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_support.rs
@@ -234,7 +234,7 @@ pub(super) fn next_generated_key(keys: &mut impl Iterator<Item = SecretKey>) -> 
 pub(super) fn storage_sync_report_payload(
     request: &MessagePayload,
     report: SyncEntriesWithSuccessorReport,
-    signer: MessageSigner<'_>,
+    signer: MessageSigner<&SessionSk>,
     next_hop: Did,
     destination: Did,
 ) -> Result<MessagePayload> {

--- a/crates/core/src/message/handlers/storage/tests/test_sync_ack.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_sync_ack.rs
@@ -4,7 +4,6 @@ use super::test_support::next_payload_for_tx;
 use super::test_support::non_affine_placement;
 use super::test_support::storage_sync_report_payload;
 use super::test_support::NoopCallback;
-use crate::dht::entry::Entry;
 use crate::dht::entry::EntryKind;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::SyncedEntryAck;
@@ -32,9 +31,9 @@ async fn test_sync_entries_report_handler_deletes_only_acked_keys() -> Result<()
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let acked_key = Did::from(100u32);
     let pending_key = Did::from(120u32);
-    let acked_entry = Entry::new(Did::from(10u32), vec![], EntryKind::Data);
+    let acked_entry = crate::tests::live_entry(Did::from(10u32), vec![], EntryKind::Data);
     let acked_storage_entry = acked_entry.clone().try_into_storage_entry()?;
-    let pending_entry = Entry::new(Did::from(20u32), vec![], EntryKind::Data);
+    let pending_entry = crate::tests::live_entry(Did::from(20u32), vec![], EntryKind::Data);
     let sync_msg = SyncEntriesWithSuccessor {
         purpose: StorageSyncPurpose::OwnershipHandoff,
         destination: StorageSyncDestination::PhysicalOwner(node.did()),
@@ -42,7 +41,7 @@ async fn test_sync_entries_report_handler_deletes_only_acked_keys() -> Result<()
     };
     let request = MessagePayload::new_send(
         Message::SyncEntriesWithSuccessor(sync_msg.clone()),
-        node.swarm.transport.session_sk(),
+        node.swarm.transport.message_signer(),
         node.did(),
         node.did(),
     )?;
@@ -71,7 +70,7 @@ async fn test_sync_entries_report_handler_deletes_only_acked_keys() -> Result<()
     let context = storage_sync_report_payload(
         &request,
         report.clone(),
-        node.swarm.transport.session_sk(),
+        node.swarm.transport.message_signer(),
         node.did(),
         node.did(),
     )?;
@@ -91,7 +90,7 @@ async fn test_sync_entries_report_handler_rejects_untracked_acks() -> Result<()>
     let node = prepare_node(SecretKey::random()).await;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let acked_key = Did::from(100u32);
-    let acked_entry = Entry::new(Did::from(10u32), vec![], EntryKind::Data);
+    let acked_entry = crate::tests::live_entry(Did::from(10u32), vec![], EntryKind::Data);
     let acked_storage_entry = acked_entry.clone().try_into_storage_entry()?;
     node.dht()
         .storage
@@ -105,7 +104,7 @@ async fn test_sync_entries_report_handler_rejects_untracked_acks() -> Result<()>
     };
     let request = MessagePayload::new_send(
         Message::SyncEntriesWithSuccessor(sync_msg.clone()),
-        node.swarm.transport.session_sk(),
+        node.swarm.transport.message_signer(),
         node.did(),
         node.did(),
     )?;
@@ -118,7 +117,7 @@ async fn test_sync_entries_report_handler_rejects_untracked_acks() -> Result<()>
     let context = storage_sync_report_payload(
         &request,
         report.clone(),
-        node.swarm.transport.session_sk(),
+        node.swarm.transport.message_signer(),
         node.did(),
         node.did(),
     )?;
@@ -153,7 +152,7 @@ async fn test_sync_entries_report_handler_forwards_before_pending_capability_che
     };
     let request = MessagePayload::new_send(
         Message::SyncEntriesWithSuccessor(sync_msg.clone()),
-        sender.swarm.transport.session_sk(),
+        sender.swarm.transport.message_signer(),
         receiver.did(),
         receiver.did(),
     )?;
@@ -166,7 +165,7 @@ async fn test_sync_entries_report_handler_forwards_before_pending_capability_che
     let context = storage_sync_report_payload(
         &request,
         report.clone(),
-        receiver.swarm.transport.session_sk(),
+        receiver.swarm.transport.message_signer(),
         relay.did(),
         sender.did(),
     )?;
@@ -194,7 +193,7 @@ async fn test_sync_entries_report_handler_forwards_before_pending_capability_che
 async fn test_additive_repair_sync_cannot_create_pending_cleanup_capability() -> Result<()> {
     let node = prepare_node(SecretKey::random()).await;
     let placement_key = Did::from(100u32);
-    let entry = Entry::new(Did::from(100u32), vec![], EntryKind::Data);
+    let entry = crate::tests::live_entry(Did::from(100u32), vec![], EntryKind::Data);
     let sync_msg = SyncEntriesWithSuccessor {
         purpose: StorageSyncPurpose::AdditiveRepair,
         destination: StorageSyncDestination::PhysicalOwner(node.did()),
@@ -202,7 +201,7 @@ async fn test_additive_repair_sync_cannot_create_pending_cleanup_capability() ->
     };
     let request = MessagePayload::new_send(
         Message::SyncEntriesWithSuccessor(sync_msg.clone()),
-        node.swarm.transport.session_sk(),
+        node.swarm.transport.message_signer(),
         node.did(),
         node.did(),
     )?;
@@ -226,7 +225,7 @@ async fn test_additive_repair_sync_cannot_create_pending_cleanup_capability() ->
 #[tokio::test]
 async fn test_send_storage_sync_applies_local_destination_without_transport_send() -> Result<()> {
     let node = prepare_node(SecretKey::random()).await;
-    let entry = Entry::new(Did::from(100u32), vec![], EntryKind::Data);
+    let entry = crate::tests::live_entry(Did::from(100u32), vec![], EntryKind::Data);
     let placement_key = entry.did;
     let stored_entry = entry.clone().try_into_storage_entry()?;
     let sync_msg = SyncEntriesWithSuccessor {
@@ -248,9 +247,9 @@ async fn test_send_storage_sync_applies_local_destination_without_transport_send
 #[tokio::test]
 async fn test_local_storage_sync_validates_entire_batch_before_persisting() -> Result<()> {
     let node = prepare_node(SecretKey::random()).await;
-    let valid_entry = Entry::new(Did::from(101u32), vec![], EntryKind::Data);
+    let valid_entry = crate::tests::live_entry(Did::from(101u32), vec![], EntryKind::Data);
     let valid_key = valid_entry.did;
-    let invalid_entry = Entry::new(Did::from(102u32), vec![], EntryKind::Data);
+    let invalid_entry = crate::tests::live_entry(Did::from(102u32), vec![], EntryKind::Data);
     let invalid_key = non_affine_placement(invalid_entry.did, node.swarm.storage_redundancy())?;
     let sync_msg = SyncEntriesWithSuccessor {
         purpose: StorageSyncPurpose::AdditiveRepair,
@@ -288,7 +287,7 @@ async fn test_sync_entries_report_handler_rejects_wrong_physical_receiver() -> R
     let receiver = prepare_node(SecretKey::random()).await;
     let handler = MessageHandler::new(sender.swarm.transport.clone(), Arc::new(NoopCallback));
     let acked_key = Did::from(100u32);
-    let acked_entry = Entry::new(Did::from(10u32), vec![], EntryKind::Data);
+    let acked_entry = crate::tests::live_entry(Did::from(10u32), vec![], EntryKind::Data);
     let acked_storage_entry = acked_entry.clone().try_into_storage_entry()?;
     sender
         .dht()
@@ -303,7 +302,7 @@ async fn test_sync_entries_report_handler_rejects_wrong_physical_receiver() -> R
     };
     let request = MessagePayload::new_send(
         Message::SyncEntriesWithSuccessor(sync_msg.clone()),
-        sender.swarm.transport.session_sk(),
+        sender.swarm.transport.message_signer(),
         receiver.did(),
         receiver.did(),
     )?;
@@ -323,7 +322,7 @@ async fn test_sync_entries_report_handler_rejects_wrong_physical_receiver() -> R
     let context = storage_sync_report_payload(
         &request,
         report.clone(),
-        sender.swarm.transport.session_sk(),
+        sender.swarm.transport.message_signer(),
         sender.did(),
         sender.did(),
     )?;
@@ -348,7 +347,7 @@ async fn test_sync_entries_report_handler_rejects_unproven_placement_receiver() 
     let final_receiver = prepare_node(SecretKey::random()).await;
     let handler = MessageHandler::new(sender.swarm.transport.clone(), Arc::new(NoopCallback));
     let placement_key = Did::from(100u32);
-    let acked_entry = Entry::new(Did::from(10u32), vec![], EntryKind::Data);
+    let acked_entry = crate::tests::live_entry(Did::from(10u32), vec![], EntryKind::Data);
     let acked_storage_entry = acked_entry.clone().try_into_storage_entry()?;
     sender
         .dht()
@@ -363,7 +362,7 @@ async fn test_sync_entries_report_handler_rejects_unproven_placement_receiver() 
     };
     let request = MessagePayload::new_send(
         Message::SyncEntriesWithSuccessor(sync_msg.clone()),
-        sender.swarm.transport.session_sk(),
+        sender.swarm.transport.message_signer(),
         route_next_hop.did(),
         sync_msg.destination.did(),
     )?;
@@ -383,7 +382,7 @@ async fn test_sync_entries_report_handler_rejects_unproven_placement_receiver() 
     let context = storage_sync_report_payload(
         &request,
         report.clone(),
-        final_receiver.swarm.transport.session_sk(),
+        final_receiver.swarm.transport.message_signer(),
         sender.did(),
         sender.did(),
     )?;

--- a/crates/core/src/message/handlers/storage/tests/test_sync_ack.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_sync_ack.rs
@@ -23,6 +23,7 @@ use crate::message::PayloadSender;
 use crate::tests::default::assert_no_more_msg;
 use crate::tests::default::prepare_node;
 use crate::tests::default::wait_for_msgs;
+use crate::tests::live_entry;
 use crate::tests::manually_establish_connection;
 
 #[tokio::test]
@@ -31,9 +32,9 @@ async fn test_sync_entries_report_handler_deletes_only_acked_keys() -> Result<()
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let acked_key = Did::from(100u32);
     let pending_key = Did::from(120u32);
-    let acked_entry = crate::tests::live_entry(Did::from(10u32), vec![], EntryKind::Data);
+    let acked_entry = live_entry(Did::from(10u32), vec![], EntryKind::Data);
     let acked_storage_entry = acked_entry.clone().try_into_storage_entry()?;
-    let pending_entry = crate::tests::live_entry(Did::from(20u32), vec![], EntryKind::Data);
+    let pending_entry = live_entry(Did::from(20u32), vec![], EntryKind::Data);
     let sync_msg = SyncEntriesWithSuccessor {
         purpose: StorageSyncPurpose::OwnershipHandoff,
         destination: StorageSyncDestination::PhysicalOwner(node.did()),
@@ -90,7 +91,7 @@ async fn test_sync_entries_report_handler_rejects_untracked_acks() -> Result<()>
     let node = prepare_node(SecretKey::random()).await;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let acked_key = Did::from(100u32);
-    let acked_entry = crate::tests::live_entry(Did::from(10u32), vec![], EntryKind::Data);
+    let acked_entry = live_entry(Did::from(10u32), vec![], EntryKind::Data);
     let acked_storage_entry = acked_entry.clone().try_into_storage_entry()?;
     node.dht()
         .storage
@@ -193,7 +194,7 @@ async fn test_sync_entries_report_handler_forwards_before_pending_capability_che
 async fn test_additive_repair_sync_cannot_create_pending_cleanup_capability() -> Result<()> {
     let node = prepare_node(SecretKey::random()).await;
     let placement_key = Did::from(100u32);
-    let entry = crate::tests::live_entry(Did::from(100u32), vec![], EntryKind::Data);
+    let entry = live_entry(Did::from(100u32), vec![], EntryKind::Data);
     let sync_msg = SyncEntriesWithSuccessor {
         purpose: StorageSyncPurpose::AdditiveRepair,
         destination: StorageSyncDestination::PhysicalOwner(node.did()),
@@ -225,7 +226,7 @@ async fn test_additive_repair_sync_cannot_create_pending_cleanup_capability() ->
 #[tokio::test]
 async fn test_send_storage_sync_applies_local_destination_without_transport_send() -> Result<()> {
     let node = prepare_node(SecretKey::random()).await;
-    let entry = crate::tests::live_entry(Did::from(100u32), vec![], EntryKind::Data);
+    let entry = live_entry(Did::from(100u32), vec![], EntryKind::Data);
     let placement_key = entry.did;
     let stored_entry = entry.clone().try_into_storage_entry()?;
     let sync_msg = SyncEntriesWithSuccessor {
@@ -247,9 +248,9 @@ async fn test_send_storage_sync_applies_local_destination_without_transport_send
 #[tokio::test]
 async fn test_local_storage_sync_validates_entire_batch_before_persisting() -> Result<()> {
     let node = prepare_node(SecretKey::random()).await;
-    let valid_entry = crate::tests::live_entry(Did::from(101u32), vec![], EntryKind::Data);
+    let valid_entry = live_entry(Did::from(101u32), vec![], EntryKind::Data);
     let valid_key = valid_entry.did;
-    let invalid_entry = crate::tests::live_entry(Did::from(102u32), vec![], EntryKind::Data);
+    let invalid_entry = live_entry(Did::from(102u32), vec![], EntryKind::Data);
     let invalid_key = non_affine_placement(invalid_entry.did, node.swarm.storage_redundancy())?;
     let sync_msg = SyncEntriesWithSuccessor {
         purpose: StorageSyncPurpose::AdditiveRepair,
@@ -287,7 +288,7 @@ async fn test_sync_entries_report_handler_rejects_wrong_physical_receiver() -> R
     let receiver = prepare_node(SecretKey::random()).await;
     let handler = MessageHandler::new(sender.swarm.transport.clone(), Arc::new(NoopCallback));
     let acked_key = Did::from(100u32);
-    let acked_entry = crate::tests::live_entry(Did::from(10u32), vec![], EntryKind::Data);
+    let acked_entry = live_entry(Did::from(10u32), vec![], EntryKind::Data);
     let acked_storage_entry = acked_entry.clone().try_into_storage_entry()?;
     sender
         .dht()
@@ -347,7 +348,7 @@ async fn test_sync_entries_report_handler_rejects_unproven_placement_receiver() 
     let final_receiver = prepare_node(SecretKey::random()).await;
     let handler = MessageHandler::new(sender.swarm.transport.clone(), Arc::new(NoopCallback));
     let placement_key = Did::from(100u32);
-    let acked_entry = crate::tests::live_entry(Did::from(10u32), vec![], EntryKind::Data);
+    let acked_entry = live_entry(Did::from(10u32), vec![], EntryKind::Data);
     let acked_storage_entry = acked_entry.clone().try_into_storage_entry()?;
     sender
         .dht()

--- a/crates/core/src/message/handlers/storage/tests/test_sync_receive.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_sync_receive.rs
@@ -9,7 +9,6 @@ use super::test_support::prepare_node_with_storage_redundancy;
 use super::test_support::remote_storage_placement_after;
 use super::test_support::NoopCallback;
 use crate::consts::ENTRY_DATA_MAX_LEN;
-use crate::dht::entry::Entry;
 use crate::dht::entry::EntryKind;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::SyncedEntryAck;
@@ -30,6 +29,7 @@ use crate::message::Encoder;
 use crate::message::HandleMsg;
 use crate::message::MessageHandler;
 use crate::message::MessagePayload;
+use crate::message::MessageSigner;
 use crate::message::PayloadSender;
 use crate::session::SessionSk;
 use crate::swarm::transport::StorageSyncBatch;
@@ -38,6 +38,7 @@ use crate::tests::default::assert_no_more_msg;
 use crate::tests::default::prepare_node;
 use crate::tests::default::wait_for_msgs;
 use crate::tests::manually_establish_connection;
+use crate::tests::TEST_NETWORK_ID;
 
 #[test]
 fn test_finish_storage_action_accepts_empty_action() -> Result<()> {
@@ -64,7 +65,7 @@ async fn test_sync_entries_handler_stores_entry_at_placement_key() -> Result<()>
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let resource_id = Did::from(10u32);
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         resource_id,
         vec!["placed".to_string().encode()?],
         EntryKind::Data,
@@ -80,7 +81,7 @@ async fn test_sync_entries_handler_stores_entry_at_placement_key() -> Result<()>
     let context_session = SessionSk::new_with_seckey(&context_key)?;
     let context = MessagePayload::new_send(
         Message::custom(b"sync context")?,
-        &context_session,
+        MessageSigner::new(&context_session, TEST_NETWORK_ID),
         node.did(),
         node.did(),
     )?;
@@ -108,7 +109,7 @@ async fn test_sync_entries_handler_stores_entry_at_placement_key() -> Result<()>
 async fn test_sync_entries_handler_caps_inbound_entry_payloads() -> Result<()> {
     let node = prepare_node(SecretKey::random()).await;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         Did::from(10u32),
         (0..ENTRY_DATA_MAX_LEN + 3)
             .map(|i| format!("payload{i}").encode())
@@ -120,7 +121,7 @@ async fn test_sync_entries_handler_caps_inbound_entry_payloads() -> Result<()> {
     let context_session = SessionSk::new_with_seckey(&context_key)?;
     let context = MessagePayload::new_send(
         Message::custom(b"sync context")?,
-        &context_session,
+        MessageSigner::new(&context_session, TEST_NETWORK_ID),
         node.did(),
         node.did(),
     )?;
@@ -154,12 +155,12 @@ async fn test_sync_entries_handler_caps_inbound_entry_payloads() -> Result<()> {
 async fn test_sync_entries_handler_rejects_non_affine_placement_before_writing() -> Result<()> {
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
-    let valid_entry = Entry::new(
+    let valid_entry = crate::tests::live_entry(
         Did::from(20u32),
         vec!["valid".to_string().encode()?],
         EntryKind::Data,
     );
-    let invalid_entry = Entry::new(
+    let invalid_entry = crate::tests::live_entry(
         Did::from(10u32),
         vec!["invalid".to_string().encode()?],
         EntryKind::Data,
@@ -170,7 +171,7 @@ async fn test_sync_entries_handler_rejects_non_affine_placement_before_writing()
     let context_session = SessionSk::new_with_seckey(&context_key)?;
     let context = MessagePayload::new_send(
         Message::custom(b"sync context")?,
-        &context_session,
+        MessageSigner::new(&context_session, TEST_NETWORK_ID),
         node.did(),
         node.did(),
     )?;
@@ -204,12 +205,12 @@ async fn test_sync_entries_handler_rejects_non_affine_placement_before_writing()
 #[tokio::test]
 async fn test_storage_sync_batch_persists_one_entry_per_step_after_validation() -> Result<()> {
     let node = prepare_node(SecretKey::random()).await;
-    let first = Entry::new(
+    let first = crate::tests::live_entry(
         Did::from(31u32),
         vec!["first".to_string().encode()?],
         EntryKind::Data,
     );
-    let second = Entry::new(
+    let second = crate::tests::live_entry(
         Did::from(32u32),
         vec!["second".to_string().encode()?],
         EntryKind::Data,
@@ -288,7 +289,7 @@ async fn test_sync_entries_handler_accepts_placement_destination_on_local_branch
         node1.dht().find_storage_owner(placement_key)?,
         PeerRingAction::Some(witness) if witness == node2.did() && witness != node1.did()
     ));
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         placement_key,
         vec!["routed repair".to_string().encode()?],
         EntryKind::Data,
@@ -301,7 +302,7 @@ async fn test_sync_entries_handler_accepts_placement_destination_on_local_branch
     };
     let context = MessagePayload::new_send(
         Message::SyncEntriesWithSuccessor(msg.clone()),
-        node2.swarm.transport.session_sk(),
+        node2.swarm.transport.message_signer(),
         node1.did(),
         placement_key,
     )?;
@@ -347,7 +348,7 @@ async fn test_additive_repair_sync_persists_without_cleanup_report() -> Result<(
         receiver.dht().find_storage_owner(placement_key)?,
         PeerRingAction::Some(owner) if owner == receiver.did()
     ));
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         placement_key,
         vec!["repair copy".to_string().encode()?],
         EntryKind::Data,
@@ -360,7 +361,7 @@ async fn test_additive_repair_sync_persists_without_cleanup_report() -> Result<(
     };
     let context = MessagePayload::new_send(
         Message::SyncEntriesWithSuccessor(sync_msg.clone()),
-        sender.swarm.transport.session_sk(),
+        sender.swarm.transport.message_signer(),
         receiver.did(),
         receiver.did(),
     )?;
@@ -391,7 +392,7 @@ async fn test_sync_entries_handler_rejects_mismatched_placement_destination() ->
 
     let destination_key = receiver.did();
     let mismatched_key = sender.did();
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         Did::from(10u32),
         vec!["mismatched placement".to_string().encode()?],
         EntryKind::Data,
@@ -403,7 +404,7 @@ async fn test_sync_entries_handler_rejects_mismatched_placement_destination() ->
     };
     let context = MessagePayload::new_send(
         Message::SyncEntriesWithSuccessor(sync_msg.clone()),
-        sender.swarm.transport.session_sk(),
+        sender.swarm.transport.message_signer(),
         receiver.did(),
         destination_key,
     )?;
@@ -441,7 +442,7 @@ async fn test_sync_entries_handler_rejects_physical_destination_for_unowned_plac
     install_two_node_chord_view(&sender, &receiver)?;
 
     let placement_key = remote_storage_placement_after(&receiver, sender.did())?;
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         Did::from(10u32),
         vec!["wrong physical owner".to_string().encode()?],
         EntryKind::Data,
@@ -453,7 +454,7 @@ async fn test_sync_entries_handler_rejects_physical_destination_for_unowned_plac
     };
     let context = MessagePayload::new_send(
         Message::SyncEntriesWithSuccessor(sync_msg.clone()),
-        sender.swarm.transport.session_sk(),
+        sender.swarm.transport.message_signer(),
         receiver.did(),
         receiver.did(),
     )?;
@@ -495,7 +496,7 @@ async fn test_sync_entries_handler_acks_local_branch_with_successor_witness() ->
         PeerRingAction::Some(witness) if witness == sender.did() && witness != receiver.did()
     ));
 
-    let entry = Entry::new(
+    let entry = crate::tests::live_entry(
         placement_key,
         vec!["successor witness owner".to_string().encode()?],
         EntryKind::Data,
@@ -508,7 +509,7 @@ async fn test_sync_entries_handler_acks_local_branch_with_successor_witness() ->
     };
     let context = MessagePayload::new_send(
         Message::SyncEntriesWithSuccessor(sync_msg.clone()),
-        sender.swarm.transport.session_sk(),
+        sender.swarm.transport.message_signer(),
         receiver.did(),
         receiver.did(),
     )?;

--- a/crates/core/src/message/handlers/storage/tests/test_sync_receive.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_sync_receive.rs
@@ -37,8 +37,10 @@ use crate::swarm::transport::StorageSyncBatchStep;
 use crate::tests::default::assert_no_more_msg;
 use crate::tests::default::prepare_node;
 use crate::tests::default::wait_for_msgs;
+use crate::tests::live_entry;
 use crate::tests::manually_establish_connection;
 use crate::tests::TEST_NETWORK_ID;
+use crate::utils::get_epoch_ms;
 
 #[test]
 fn test_finish_storage_action_accepts_empty_action() -> Result<()> {
@@ -65,7 +67,7 @@ async fn test_sync_entries_handler_stores_entry_at_placement_key() -> Result<()>
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
     let resource_id = Did::from(10u32);
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         resource_id,
         vec!["placed".to_string().encode()?],
         EntryKind::Data,
@@ -109,7 +111,7 @@ async fn test_sync_entries_handler_stores_entry_at_placement_key() -> Result<()>
 async fn test_sync_entries_handler_caps_inbound_entry_payloads() -> Result<()> {
     let node = prepare_node(SecretKey::random()).await;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         Did::from(10u32),
         (0..ENTRY_DATA_MAX_LEN + 3)
             .map(|i| format!("payload{i}").encode())
@@ -155,12 +157,12 @@ async fn test_sync_entries_handler_caps_inbound_entry_payloads() -> Result<()> {
 async fn test_sync_entries_handler_rejects_non_affine_placement_before_writing() -> Result<()> {
     let node = prepare_node_with_storage_redundancy(SecretKey::random(), 2)?;
     let handler = MessageHandler::new(node.swarm.transport.clone(), Arc::new(NoopCallback));
-    let valid_entry = crate::tests::live_entry(
+    let valid_entry = live_entry(
         Did::from(20u32),
         vec!["valid".to_string().encode()?],
         EntryKind::Data,
     );
-    let invalid_entry = crate::tests::live_entry(
+    let invalid_entry = live_entry(
         Did::from(10u32),
         vec!["invalid".to_string().encode()?],
         EntryKind::Data,
@@ -205,12 +207,12 @@ async fn test_sync_entries_handler_rejects_non_affine_placement_before_writing()
 #[tokio::test]
 async fn test_storage_sync_batch_persists_one_entry_per_step_after_validation() -> Result<()> {
     let node = prepare_node(SecretKey::random()).await;
-    let first = crate::tests::live_entry(
+    let first = live_entry(
         Did::from(31u32),
         vec!["first".to_string().encode()?],
         EntryKind::Data,
     );
-    let second = crate::tests::live_entry(
+    let second = live_entry(
         Did::from(32u32),
         vec!["second".to_string().encode()?],
         EntryKind::Data,
@@ -227,7 +229,7 @@ async fn test_storage_sync_batch_persists_one_entry_per_step_after_validation() 
             PlacedEntry::new(second_key, second),
         ],
     };
-    let mut batch = StorageSyncBatch::new(&msg, Did::from(1u32));
+    let mut batch = StorageSyncBatch::new(&msg, Did::from(1u32), get_epoch_ms());
 
     assert!(matches!(
         batch.step(&node.swarm.transport).await?,
@@ -289,7 +291,7 @@ async fn test_sync_entries_handler_accepts_placement_destination_on_local_branch
         node1.dht().find_storage_owner(placement_key)?,
         PeerRingAction::Some(witness) if witness == node2.did() && witness != node1.did()
     ));
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         placement_key,
         vec!["routed repair".to_string().encode()?],
         EntryKind::Data,
@@ -348,7 +350,7 @@ async fn test_additive_repair_sync_persists_without_cleanup_report() -> Result<(
         receiver.dht().find_storage_owner(placement_key)?,
         PeerRingAction::Some(owner) if owner == receiver.did()
     ));
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         placement_key,
         vec!["repair copy".to_string().encode()?],
         EntryKind::Data,
@@ -392,7 +394,7 @@ async fn test_sync_entries_handler_rejects_mismatched_placement_destination() ->
 
     let destination_key = receiver.did();
     let mismatched_key = sender.did();
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         Did::from(10u32),
         vec!["mismatched placement".to_string().encode()?],
         EntryKind::Data,
@@ -442,7 +444,7 @@ async fn test_sync_entries_handler_rejects_physical_destination_for_unowned_plac
     install_two_node_chord_view(&sender, &receiver)?;
 
     let placement_key = remote_storage_placement_after(&receiver, sender.did())?;
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         Did::from(10u32),
         vec!["wrong physical owner".to_string().encode()?],
         EntryKind::Data,
@@ -496,7 +498,7 @@ async fn test_sync_entries_handler_acks_local_branch_with_successor_witness() ->
         PeerRingAction::Some(witness) if witness == sender.did() && witness != receiver.did()
     ));
 
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         placement_key,
         vec!["successor witness owner".to_string().encode()?],
         EntryKind::Data,

--- a/crates/core/src/message/handlers/storage/tests/test_sync_receive.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_sync_receive.rs
@@ -227,7 +227,7 @@ async fn test_storage_sync_batch_persists_one_entry_per_step_after_validation() 
             PlacedEntry::new(second_key, second),
         ],
     };
-    let mut batch = StorageSyncBatch::new(&msg);
+    let mut batch = StorageSyncBatch::new(&msg, Did::from(1u32));
 
     assert!(matches!(
         batch.step(&node.swarm.transport).await?,

--- a/crates/core/src/message/mod.rs
+++ b/crates/core/src/message/mod.rs
@@ -36,7 +36,10 @@ pub use handlers::HandleMsg;
 pub use handlers::MessageHandler;
 
 mod protocols;
+pub use protocols::DomainTag;
 pub use protocols::MessageRelay;
+pub use protocols::MessageSigner;
 pub use protocols::MessageVerification;
 pub use protocols::MessageVerificationExt;
 pub use protocols::ReportReturnPolicy;
+pub use protocols::SigningDomain;

--- a/crates/core/src/message/payload/mod.rs
+++ b/crates/core/src/message/payload/mod.rs
@@ -16,7 +16,9 @@ use serde::Serialize;
 use super::encoder::Decoder;
 use super::encoder::Encoded;
 use super::encoder::Encoder;
+use super::protocols::DomainTag;
 use super::protocols::MessageRelay;
+use super::protocols::MessageSigner;
 use super::protocols::MessageVerification;
 use super::protocols::MessageVerificationExt;
 use super::protocols::ReportReturnPolicy;
@@ -27,7 +29,14 @@ use crate::dht::PeerRingAction;
 use crate::ecc::keccak256;
 use crate::error::Error;
 use crate::error::Result;
-use crate::session::SessionSk;
+
+/// Message family of the [`Transaction`] signature: the origin's authorship of a message.
+const TRANSACTION_DOMAIN_TAG: DomainTag =
+    DomainTag::new("rings-core:message-verification:transaction:v1");
+/// Message family of the [`MessagePayload`] signature: one hop's authorship of a forwarded
+/// envelope. Distinct from [`TRANSACTION_DOMAIN_TAG`] so the two signatures over the same
+/// transaction hash are never interchangeable.
+const PAYLOAD_DOMAIN_TAG: DomainTag = DomainTag::new("rings-core:message-verification:payload:v1");
 
 /// Compresses the given data byte slice using the gzip algorithm with the specified compression level.
 pub fn encode_data_gzip(data: &Bytes, level: u8) -> Result<Bytes> {
@@ -141,23 +150,17 @@ impl fmt::Debug for MessagePayload {
 
 impl Transaction {
     /// Wrap data. Will serialize by [rings_codec::serialize]
-    /// then sign [MessageVerification] by session_sk.
+    /// then sign [MessageVerification] by `signer`.
     pub fn new<T>(
         destination: Did,
         tx_id: uuid::Uuid,
         data: T,
-        session_sk: &SessionSk,
+        signer: MessageSigner<'_>,
     ) -> Result<Self>
     where
         T: Serialize,
     {
-        Self::new_with_report_return(
-            destination,
-            tx_id,
-            data,
-            ReportReturnPolicy::Path,
-            session_sk,
-        )
+        Self::new_with_report_return(destination, tx_id, data, ReportReturnPolicy::Path, signer)
     }
 
     /// Wrap data with an explicit report-return policy.
@@ -166,15 +169,15 @@ impl Transaction {
         tx_id: uuid::Uuid,
         data: T,
         report_return: ReportReturnPolicy,
-        session_sk: &SessionSk,
+        signer: MessageSigner<'_>,
     ) -> Result<Self>
     where
         T: Serialize,
     {
-        report_return.validate_authorized_by(session_sk.account_did())?;
+        report_return.validate_authorized_by(signer.account_did())?;
         let data = rings_codec::serialize(&data).map_err(Error::CodecSerialize)?;
         let msg_hash = hash_transaction(destination, tx_id, report_return, &data);
-        let verification = MessageVerification::new(&msg_hash, session_sk)?;
+        let verification = signer.sign(TRANSACTION_DOMAIN_TAG, &msg_hash)?;
         Ok(Self {
             destination,
             tx_id,
@@ -193,10 +196,10 @@ impl Transaction {
 
 impl MessagePayload {
     /// Create new `MessagePayload`.
-    /// Need [Transaction], [SessionSk] and [MessageRelay].
+    /// Need [Transaction], [MessageSigner] and [MessageRelay].
     pub fn new(
         transaction: Transaction,
-        session_sk: &SessionSk,
+        signer: MessageSigner<'_>,
         relay: MessageRelay,
     ) -> Result<Self> {
         let msg_hash = hash_transaction(
@@ -205,7 +208,7 @@ impl MessagePayload {
             transaction.report_return,
             &transaction.data,
         );
-        let verification = MessageVerification::new(&msg_hash, session_sk)?;
+        let verification = signer.sign(PAYLOAD_DOMAIN_TAG, &msg_hash)?;
         Ok(Self {
             transaction,
             relay,
@@ -216,7 +219,7 @@ impl MessagePayload {
     /// Helps to create sending message from data.
     pub fn new_send<T>(
         data: T,
-        session_sk: &SessionSk,
+        signer: MessageSigner<'_>,
         next_hop: Did,
         destination: Did,
     ) -> Result<Self>
@@ -224,13 +227,13 @@ impl MessagePayload {
         T: Serialize,
     {
         let tx_id = crate::utils::new_uuid();
-        let transaction = Transaction::new(destination, tx_id, data, session_sk)?;
+        let transaction = Transaction::new(destination, tx_id, data, signer)?;
         let relay = MessageRelay::new(
-            vec![session_sk.account_did()],
+            vec![signer.account_did()],
             next_hop,
             transaction.destination,
         );
-        Self::new(transaction, session_sk, relay)
+        Self::new(transaction, signer, relay)
     }
 
     /// Deserializes a `MessagePayload` instance from the Rings wire encoding.
@@ -263,6 +266,8 @@ impl MessagePayload {
 }
 
 impl MessageVerificationExt for Transaction {
+    const DOMAIN_TAG: DomainTag = TRANSACTION_DOMAIN_TAG;
+
     fn verification_data(&self) -> Result<Vec<u8>> {
         self.report_return.validate_authorized_by(self.signer())?;
         Ok(hash_transaction(self.destination, self.tx_id, self.report_return, &self.data).to_vec())
@@ -274,6 +279,8 @@ impl MessageVerificationExt for Transaction {
 }
 
 impl MessageVerificationExt for MessagePayload {
+    const DOMAIN_TAG: DomainTag = PAYLOAD_DOMAIN_TAG;
+
     fn verification_data(&self) -> Result<Vec<u8>> {
         self.transaction.verification_data()
     }
@@ -300,8 +307,8 @@ impl Decoder for MessagePayload {
 #[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
 pub trait PayloadSender {
-    /// Get the session sk
-    fn session_sk(&self) -> &SessionSk;
+    /// The authority that signs every payload this sender emits.
+    fn message_signer(&self) -> MessageSigner<'_>;
 
     /// Get access to DHT.
     fn dht(&self) -> Arc<PeerRing>;
@@ -344,7 +351,7 @@ pub trait PayloadSender {
     where
         T: Serialize + Send,
     {
-        let payload = MessagePayload::new_send(msg, self.session_sk(), next_hop, destination)?;
+        let payload = MessagePayload::new_send(msg, self.message_signer(), next_hop, destination)?;
         let tx_id = payload.transaction.tx_id;
         self.send_payload(payload).await?;
         Ok(tx_id)
@@ -362,19 +369,15 @@ pub trait PayloadSender {
         T: Serialize + Send,
     {
         let tx_id = crate::utils::new_uuid();
-        let transaction = Transaction::new_with_report_return(
-            destination,
-            tx_id,
-            msg,
-            report_return,
-            self.session_sk(),
-        )?;
+        let signer = self.message_signer();
+        let transaction =
+            Transaction::new_with_report_return(destination, tx_id, msg, report_return, signer)?;
         let relay = MessageRelay::new(
-            vec![self.session_sk().account_did()],
+            vec![signer.account_did()],
             next_hop,
             transaction.destination,
         );
-        let payload = MessagePayload::new(transaction, self.session_sk(), relay)?;
+        let payload = MessagePayload::new(transaction, signer, relay)?;
         self.send_payload(payload).await?;
         Ok(tx_id)
     }
@@ -425,21 +428,19 @@ pub trait PayloadSender {
             .relay
             .report(self.dht().did, policy, routed_next_hop)?;
 
-        let transaction = Transaction::new(
-            relay.destination,
-            payload.transaction.tx_id,
-            msg,
-            self.session_sk(),
-        )?;
+        let signer = self.message_signer();
+        let transaction =
+            Transaction::new(relay.destination, payload.transaction.tx_id, msg, signer)?;
 
-        let pl = MessagePayload::new(transaction, self.session_sk(), relay)?;
+        let pl = MessagePayload::new(transaction, signer, relay)?;
         self.send_payload(pl).await
     }
 
     /// Forward a payload message by relay.
     /// It just create a new payload, cloned data, resigned with session and send
     async fn forward_by_relay(&self, payload: &MessagePayload, relay: MessageRelay) -> Result<()> {
-        let new_pl = MessagePayload::new(payload.transaction.clone(), self.session_sk(), relay)?;
+        let new_pl =
+            MessagePayload::new(payload.transaction.clone(), self.message_signer(), relay)?;
         self.send_payload(new_pl).await
     }
 

--- a/crates/core/src/message/payload/mod.rs
+++ b/crates/core/src/message/payload/mod.rs
@@ -26,17 +26,19 @@ use crate::dht::Chord;
 use crate::dht::Did;
 use crate::dht::PeerRing;
 use crate::dht::PeerRingAction;
+use crate::domain_tag;
 use crate::ecc::keccak256;
 use crate::error::Error;
 use crate::error::Result;
+use crate::session::SessionSk;
 
 /// Message family of the [`Transaction`] signature: the origin's authorship of a message.
 const TRANSACTION_DOMAIN_TAG: DomainTag =
-    DomainTag::new("rings-core:message-verification:transaction:v1");
+    domain_tag!("rings-core:message-verification:transaction:v1");
 /// Message family of the [`MessagePayload`] signature: one hop's authorship of a forwarded
 /// envelope. Distinct from [`TRANSACTION_DOMAIN_TAG`] so the two signatures over the same
 /// transaction hash are never interchangeable.
-const PAYLOAD_DOMAIN_TAG: DomainTag = DomainTag::new("rings-core:message-verification:payload:v1");
+const PAYLOAD_DOMAIN_TAG: DomainTag = domain_tag!("rings-core:message-verification:payload:v1");
 
 /// Compresses the given data byte slice using the gzip algorithm with the specified compression level.
 pub fn encode_data_gzip(data: &Bytes, level: u8) -> Result<Bytes> {
@@ -155,7 +157,7 @@ impl Transaction {
         destination: Did,
         tx_id: uuid::Uuid,
         data: T,
-        signer: MessageSigner<'_>,
+        signer: MessageSigner<&SessionSk>,
     ) -> Result<Self>
     where
         T: Serialize,
@@ -169,7 +171,7 @@ impl Transaction {
         tx_id: uuid::Uuid,
         data: T,
         report_return: ReportReturnPolicy,
-        signer: MessageSigner<'_>,
+        signer: MessageSigner<&SessionSk>,
     ) -> Result<Self>
     where
         T: Serialize,
@@ -199,7 +201,7 @@ impl MessagePayload {
     /// Need [Transaction], [MessageSigner] and [MessageRelay].
     pub fn new(
         transaction: Transaction,
-        signer: MessageSigner<'_>,
+        signer: MessageSigner<&SessionSk>,
         relay: MessageRelay,
     ) -> Result<Self> {
         let msg_hash = hash_transaction(
@@ -219,7 +221,7 @@ impl MessagePayload {
     /// Helps to create sending message from data.
     pub fn new_send<T>(
         data: T,
-        signer: MessageSigner<'_>,
+        signer: MessageSigner<&SessionSk>,
         next_hop: Did,
         destination: Did,
     ) -> Result<Self>
@@ -308,7 +310,7 @@ impl Decoder for MessagePayload {
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
 pub trait PayloadSender {
     /// The authority that signs every payload this sender emits.
-    fn message_signer(&self) -> MessageSigner<'_>;
+    fn message_signer(&self) -> MessageSigner<&SessionSk>;
 
     /// Get access to DHT.
     fn dht(&self) -> Arc<PeerRing>;

--- a/crates/core/src/message/payload/test_payload.rs
+++ b/crates/core/src/message/payload/test_payload.rs
@@ -3,6 +3,8 @@ use rand::Rng;
 use super::*;
 use crate::ecc::SecretKey;
 use crate::message::Message;
+use crate::session::SessionSk;
+use crate::tests::TEST_NETWORK_ID;
 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct TestData {
@@ -27,7 +29,13 @@ where T: Serialize + DeserializeOwned {
     let key = SecretKey::random();
     let destination = SecretKey::random().address().into();
     let session_sk = SessionSk::new_with_seckey(&key).unwrap();
-    MessagePayload::new_send(data, &session_sk, next_hop, destination).unwrap()
+    MessagePayload::new_send(
+        data,
+        MessageSigner::new(&session_sk, TEST_NETWORK_ID),
+        next_hop,
+        destination,
+    )
+    .unwrap()
 }
 
 #[test]
@@ -36,7 +44,7 @@ fn test_new_then_verify() {
     let did2 = key2.address().into();
 
     let payload = new_test_payload(did2);
-    assert!(payload.verify());
+    assert!(payload.verify(TEST_NETWORK_ID));
 }
 
 #[test]
@@ -57,13 +65,21 @@ fn test_relay_destination_predicates_name_forwarding_state() -> Result<()> {
     let local: Did = local_key.address().into();
     let remote: Did = SecretKey::random().address().into();
 
-    let local_payload =
-        MessagePayload::new_send(Message::custom(b"local")?, &session_sk, local, local)?;
+    let local_payload = MessagePayload::new_send(
+        Message::custom(b"local")?,
+        MessageSigner::new(&session_sk, TEST_NETWORK_ID),
+        local,
+        local,
+    )?;
     assert!(local_payload.is_relay_destination_for(local));
     assert!(!local_payload.should_forward_from(local));
 
-    let remote_payload =
-        MessagePayload::new_send(Message::custom(b"remote")?, &session_sk, remote, remote)?;
+    let remote_payload = MessagePayload::new_send(
+        Message::custom(b"remote")?,
+        MessageSigner::new(&session_sk, TEST_NETWORK_ID),
+        remote,
+        remote,
+    )?;
     assert!(!remote_payload.is_relay_destination_for(local));
     assert!(remote_payload.should_forward_from(local));
 
@@ -84,12 +100,12 @@ fn test_report_return_policy_is_signed_by_transaction() -> Result<()> {
         ReportReturnPolicy::Routed {
             destination: sender,
         },
-        &session_sk,
+        MessageSigner::new(&session_sk, TEST_NETWORK_ID),
     )?;
-    assert!(transaction.verify());
+    assert!(transaction.verify(TEST_NETWORK_ID));
 
     transaction.report_return = ReportReturnPolicy::Path;
-    assert!(!transaction.verify());
+    assert!(!transaction.verify(TEST_NETWORK_ID));
     Ok(())
 }
 
@@ -108,7 +124,7 @@ fn test_routed_report_return_destination_must_match_signer() -> Result<()> {
             ReportReturnPolicy::Routed {
                 destination: unrelated_return,
             },
-            &session_sk,
+            MessageSigner::new(&session_sk, TEST_NETWORK_ID),
         ),
         Err(Error::InvalidMessage(_))
     ));
@@ -260,4 +276,27 @@ fn test_wire_size_matches_every_message_discriminant_and_signature_width() -> Re
         }
     }
     Ok(())
+}
+
+/// Domain separation: the transaction and payload signatures cover the same hash under distinct
+/// tags, so one can never stand in for the other.
+#[test]
+fn test_transaction_and_payload_signatures_are_not_interchangeable() {
+    let next_hop = SecretKey::random().address().into();
+    let mut payload = new_test_payload(next_hop);
+    assert!(payload.verify(TEST_NETWORK_ID));
+    assert!(payload.transaction.verify(TEST_NETWORK_ID));
+
+    payload.verification = payload.transaction.verification.clone();
+    assert!(!payload.verify(TEST_NETWORK_ID));
+}
+
+/// Overlay binding: both signatures verify only under the overlay they were issued for.
+#[test]
+fn test_payload_signed_for_another_overlay_is_rejected() {
+    let next_hop = SecretKey::random().address().into();
+    let payload = new_test_payload(next_hop);
+
+    assert!(!payload.verify(TEST_NETWORK_ID + 1));
+    assert!(!payload.transaction.verify(TEST_NETWORK_ID + 1));
 }

--- a/crates/core/src/message/protocols/mod.rs
+++ b/crates/core/src/message/protocols/mod.rs
@@ -3,5 +3,8 @@ mod verify;
 
 pub use self::relay::MessageRelay;
 pub use self::relay::ReportReturnPolicy;
+pub use self::verify::DomainTag;
+pub use self::verify::MessageSigner;
 pub use self::verify::MessageVerification;
 pub use self::verify::MessageVerificationExt;
+pub use self::verify::SigningDomain;

--- a/crates/core/src/message/protocols/verify.rs
+++ b/crates/core/src/message/protocols/verify.rs
@@ -12,9 +12,15 @@
 //! integers are big-endian, and `len(tag)` is one byte. The length prefix makes the tag component
 //! prefix-free, so transcripts of distinct domains never collide for any `m`. Binding `network_id`
 //! makes a signature non-portable across overlays that share a session key; binding the tag makes
-//! it non-portable across message families that share a signing surface. Both bindings are
-//! verified by the receiver against *its own* domain, never against a value carried in the
-//! message.
+//! it non-portable across message families that share a signing surface.
+//!
+//! Authority: every signature is issued by a [`MessageSigner`], a session key paired with the
+//! overlay it acts in, and every verification is performed against the *receiver's* domain, never
+//! against a value carried in the message. A type that embeds a verification implements
+//! [`MessageVerificationExt`] with its own [`DomainTag`] and verifies under the receiver's
+//! `network_id`.
+
+use std::borrow::Borrow;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -31,20 +37,19 @@ use crate::utils::get_epoch_ms;
 /// Name of one signed message family; the first component of a [`SigningDomain`].
 ///
 /// Law: `label.len() <= u8::MAX`, so the label fits its one-byte length prefix in the
-/// transcript. The bound is checked when a tag is constructed, at compile time for `const` tags.
+/// transcript. Construct tags with [`domain_tag!`](crate::domain_tag), which checks the law at
+/// compile time; [`DomainTag::new`] is the total form for labels known only at runtime.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DomainTag(&'static str);
 
 impl DomainTag {
-    /// Name a message family.
-    ///
-    /// Panics at compile time when a `const` label is longer than `u8::MAX` bytes.
-    pub const fn new(label: &'static str) -> Self {
-        assert!(
-            label.len() <= u8::MAX as usize,
-            "domain tag label must fit its one-byte length prefix"
-        );
-        Self(label)
+    /// Name a message family, or `None` when `label` does not fit its length prefix.
+    pub const fn new(label: &'static str) -> Option<Self> {
+        if label.len() <= u8::MAX as usize {
+            Some(Self(label))
+        } else {
+            None
+        }
     }
 
     /// The label bytes.
@@ -56,6 +61,24 @@ impl DomainTag {
     const fn len_byte(self) -> u8 {
         self.0.len() as u8
     }
+}
+
+/// Name a message family from a literal, rejecting at compile time a label longer than the
+/// one-byte length prefix allows.
+#[macro_export]
+macro_rules! domain_tag {
+    ($label:literal) => {{
+        const _: () = assert!(
+            $label.len() <= u8::MAX as usize,
+            "domain tag label must fit its one-byte length prefix"
+        );
+        const TAG: $crate::message::DomainTag = match $crate::message::DomainTag::new($label) {
+            Some(tag) => tag,
+            // Excluded by the assertion above.
+            None => unreachable!(),
+        };
+        TAG
+    }};
 }
 
 /// The message family and overlay a signature transcript is bound to.
@@ -106,16 +129,24 @@ impl SigningDomain {
 ///
 /// Signing is the map `(session_sk, network_id) × (tag, data) → MessageVerification`. This
 /// type fixes the first component, so message constructors take one authority instead of a key
-/// and an overlay that could be paired inconsistently.
-#[derive(Clone, Copy)]
-pub struct MessageSigner<'a> {
-    session_sk: &'a SessionSk,
+/// and an overlay that could be paired inconsistently. `S` is how the key is held: a borrowed
+/// authority `MessageSigner<&SessionSk>` is `Copy` and is what signing functions take; an owned
+/// authority `MessageSigner<SessionSk>` is what long-lived runtimes store, so the pairing is
+/// never split across two fields.
+///
+/// Law: copying or cloning an authority is semantically invisible, since it names the same key
+/// and the same overlay.
+#[derive(Clone, Copy, Debug)]
+pub struct MessageSigner<S> {
+    session_sk: S,
     network_id: u32,
 }
 
-impl<'a> MessageSigner<'a> {
+impl<S> MessageSigner<S>
+where S: Borrow<SessionSk>
+{
     /// Let `session_sk` sign on behalf of the overlay `network_id`.
-    pub const fn new(session_sk: &'a SessionSk, network_id: u32) -> Self {
+    pub const fn new(session_sk: S, network_id: u32) -> Self {
         Self {
             session_sk,
             network_id,
@@ -123,27 +154,43 @@ impl<'a> MessageSigner<'a> {
     }
 
     /// The session key.
-    pub const fn session_sk(self) -> &'a SessionSk {
-        self.session_sk
+    pub fn session_sk(&self) -> &SessionSk {
+        self.session_sk.borrow()
     }
 
     /// The overlay this authority signs for.
-    pub const fn network_id(self) -> u32 {
+    pub const fn network_id(&self) -> u32 {
         self.network_id
     }
 
     /// The account DID that authorized the session key.
-    pub fn account_did(self) -> Did {
-        self.session_sk.account_did()
+    pub fn account_did(&self) -> Did {
+        self.session_sk().account_did()
     }
 
-    /// Sign `data` as a member of the message family `tag` inside this overlay.
-    pub fn sign(self, tag: DomainTag, data: &[u8]) -> Result<MessageVerification> {
-        MessageVerification::new(
-            SigningDomain::new(tag, self.network_id),
-            data,
-            self.session_sk,
-        )
+    /// This authority borrowing its key: the form signing functions take.
+    pub fn by_ref(&self) -> MessageSigner<&SessionSk> {
+        MessageSigner::new(self.session_sk(), self.network_id)
+    }
+
+    /// This authority owning a copy of its key: the form long-lived runtimes store.
+    pub fn to_owned(&self) -> MessageSigner<SessionSk> {
+        MessageSigner::new(self.session_sk().clone(), self.network_id)
+    }
+
+    /// Sign `data` as a member of the message family `tag` inside this overlay, stamped with
+    /// the current time and the default TTL.
+    pub fn sign(&self, tag: DomainTag, data: &[u8]) -> Result<MessageVerification> {
+        let domain = SigningDomain::new(tag, self.network_id);
+        let ts_ms = get_epoch_ms();
+        let ttl_ms = DEFAULT_TTL_MS;
+        let msg = domain.transcript(data, ts_ms, ttl_ms);
+        Ok(MessageVerification {
+            session: self.session_sk().session(),
+            sig: self.session_sk().sign(&msg)?,
+            ttl_ms,
+            ts_ms,
+        })
     }
 }
 
@@ -162,21 +209,6 @@ pub struct MessageVerification {
 }
 
 impl MessageVerification {
-    /// Sign `data` under `domain` with the [SessionSk], stamped with the current time and the
-    /// default TTL.
-    pub fn new(domain: SigningDomain, data: &[u8], session_sk: &SessionSk) -> Result<Self> {
-        let ts_ms = get_epoch_ms();
-        let ttl_ms = DEFAULT_TTL_MS;
-        let msg = domain.transcript(data, ts_ms, ttl_ms);
-        let verification = MessageVerification {
-            session: session_sk.session(),
-            sig: session_sk.sign(&msg)?,
-            ttl_ms,
-            ts_ms,
-        };
-        Ok(verification)
-    }
-
     /// Verify the signature over `data` under the receiver's `domain`.
     pub fn verify(&self, domain: SigningDomain, data: &[u8]) -> bool {
         let msg = domain.transcript(data, self.ts_ms, self.ttl_ms);
@@ -262,8 +294,8 @@ mod tests {
     use super::*;
     use crate::ecc::SecretKey;
 
-    const FIXTURE_TAG: DomainTag = DomainTag::new("rings-core:test:fixture:v1");
-    const OTHER_TAG: DomainTag = DomainTag::new("rings-core:test:other:v1");
+    const FIXTURE_TAG: DomainTag = domain_tag!("rings-core:test:fixture:v1");
+    const OTHER_TAG: DomainTag = domain_tag!("rings-core:test:other:v1");
     const NETWORK_ID: u32 = 7;
 
     struct VerifiedFixture {
@@ -286,11 +318,15 @@ mod tests {
         SigningDomain::new(FIXTURE_TAG, NETWORK_ID)
     }
 
+    fn fixture_signer(session_sk: &SessionSk) -> MessageSigner<&SessionSk> {
+        MessageSigner::new(session_sk, NETWORK_ID)
+    }
+
     #[test]
     fn test_expiration_handles_timestamp_below_tolerance_without_underflow() -> Result<()> {
         let key = SecretKey::random();
         let session_sk = SessionSk::new_with_seckey(&key)?;
-        let mut verification = MessageVerification::new(fixture_domain(), &[], &session_sk)?;
+        let mut verification = fixture_signer(&session_sk).sign(FIXTURE_TAG, &[])?;
         verification.ts_ms = 0;
         let fixture = VerifiedFixture { verification };
 
@@ -355,12 +391,21 @@ mod tests {
         assert_eq!(transcript, expected);
     }
 
+    /// Law: a label longer than the one-byte length prefix is not a tag.
+    #[test]
+    fn test_domain_tag_rejects_label_beyond_length_prefix() {
+        const LONG: &str = "rings-core:test:long-label:v1 - 0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
+        assert!(LONG.len() > usize::from(u8::MAX));
+        assert!(DomainTag::new(LONG).is_none());
+        assert!(DomainTag::new("rings-core:test:short:v1").is_some());
+    }
+
     /// Law: a signature issued for overlay `n` does not verify under overlay `n' != n`.
     #[test]
     fn test_signature_is_bound_to_the_overlay() -> Result<()> {
         let key = SecretKey::random();
         let session_sk = SessionSk::new_with_seckey(&key)?;
-        let verification = MessageVerification::new(fixture_domain(), b"data", &session_sk)?;
+        let verification = fixture_signer(&session_sk).sign(FIXTURE_TAG, b"data")?;
 
         assert!(verification.verify(fixture_domain(), b"data"));
         assert!(!verification.verify(SigningDomain::new(FIXTURE_TAG, NETWORK_ID + 1), b"data"));
@@ -372,7 +417,7 @@ mod tests {
     fn test_signature_is_bound_to_the_message_family() -> Result<()> {
         let key = SecretKey::random();
         let session_sk = SessionSk::new_with_seckey(&key)?;
-        let verification = MessageVerification::new(fixture_domain(), b"data", &session_sk)?;
+        let verification = fixture_signer(&session_sk).sign(FIXTURE_TAG, b"data")?;
 
         assert!(!verification.verify(SigningDomain::new(OTHER_TAG, NETWORK_ID), b"data"));
         Ok(())
@@ -384,7 +429,7 @@ mod tests {
     fn test_ext_verify_uses_type_tag_and_receiver_overlay() -> Result<()> {
         let key = SecretKey::random();
         let session_sk = SessionSk::new_with_seckey(&key)?;
-        let signer = MessageSigner::new(&session_sk, NETWORK_ID);
+        let signer = fixture_signer(&session_sk);
         let fixture = VerifiedFixture {
             verification: signer.sign(FIXTURE_TAG, &[])?,
         };
@@ -396,6 +441,20 @@ mod tests {
             verification: signer.sign(OTHER_TAG, &[])?,
         };
         assert!(!mislabeled.verify(NETWORK_ID));
+        Ok(())
+    }
+
+    /// Law: the owned and borrowed forms of one authority sign identically verifiable proofs.
+    #[test]
+    fn test_owned_and_borrowed_authorities_are_the_same_signer() -> Result<()> {
+        let key = SecretKey::random();
+        let session_sk = SessionSk::new_with_seckey(&key)?;
+        let owned = fixture_signer(&session_sk).to_owned();
+        let proof = owned.by_ref().sign(FIXTURE_TAG, b"data")?;
+
+        assert_eq!(owned.network_id(), NETWORK_ID);
+        assert_eq!(owned.account_did(), session_sk.account_did());
+        assert!(proof.verify(fixture_domain(), b"data"));
         Ok(())
     }
 }

--- a/crates/core/src/message/protocols/verify.rs
+++ b/crates/core/src/message/protocols/verify.rs
@@ -1,6 +1,20 @@
 #![deny(missing_docs)]
 
 //! Implementation of Message Verification.
+//!
+//! A [`MessageVerification`] is a session signature over a *domain-separated* transcript:
+//!
+//! ```text
+//! transcript(d, ts, ttl, m) = len(tag(d)) || tag(d) || network_id(d) || ts || ttl || m
+//! ```
+//!
+//! where `d : SigningDomain = (tag, network_id)` names the message family and the overlay, all
+//! integers are big-endian, and `len(tag)` is one byte. The length prefix makes the tag component
+//! prefix-free, so transcripts of distinct domains never collide for any `m`. Binding `network_id`
+//! makes a signature non-portable across overlays that share a session key; binding the tag makes
+//! it non-portable across message families that share a signing surface. Both bindings are
+//! verified by the receiver against *its own* domain, never against a value carried in the
+//! message.
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -13,6 +27,125 @@ use crate::error::Result;
 use crate::session::Session;
 use crate::session::SessionSk;
 use crate::utils::get_epoch_ms;
+
+/// Name of one signed message family; the first component of a [`SigningDomain`].
+///
+/// Law: `label.len() <= u8::MAX`, so the label fits its one-byte length prefix in the
+/// transcript. The bound is checked when a tag is constructed, at compile time for `const` tags.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DomainTag(&'static str);
+
+impl DomainTag {
+    /// Name a message family.
+    ///
+    /// Panics at compile time when a `const` label is longer than `u8::MAX` bytes.
+    pub const fn new(label: &'static str) -> Self {
+        assert!(
+            label.len() <= u8::MAX as usize,
+            "domain tag label must fit its one-byte length prefix"
+        );
+        Self(label)
+    }
+
+    /// The label bytes.
+    pub const fn as_bytes(self) -> &'static [u8] {
+        self.0.as_bytes()
+    }
+
+    /// The label as one byte, valid by the constructor law.
+    const fn len_byte(self) -> u8 {
+        self.0.len() as u8
+    }
+}
+
+/// The message family and overlay a signature transcript is bound to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SigningDomain {
+    tag: DomainTag,
+    network_id: u32,
+}
+
+impl SigningDomain {
+    /// Bind a message family to an overlay.
+    pub const fn new(tag: DomainTag, network_id: u32) -> Self {
+        Self { tag, network_id }
+    }
+
+    /// The message family.
+    pub const fn tag(self) -> DomainTag {
+        self.tag
+    }
+
+    /// The overlay.
+    pub const fn network_id(self) -> u32 {
+        self.network_id
+    }
+
+    /// The signed bytes for `data` stamped `(ts_ms, ttl_ms)` under this domain.
+    ///
+    /// Law (injectivity): `transcript(d, ts, ttl, m) = transcript(d', ts', ttl', m')` implies
+    /// `(d, ts, ttl, m) = (d', ts', ttl', m')`, because every component before `m` has a fixed
+    /// width or a length prefix.
+    fn transcript(self, data: &[u8], ts_ms: u128, ttl_ms: u64) -> Vec<u8> {
+        let tag = self.tag.as_bytes();
+        let mut msg = Vec::with_capacity(1 + tag.len() + 4 + 16 + 8 + data.len());
+
+        msg.push(self.tag.len_byte());
+        msg.extend_from_slice(tag);
+        msg.extend_from_slice(&self.network_id.to_be_bytes());
+        msg.extend_from_slice(&ts_ms.to_be_bytes());
+        msg.extend_from_slice(&ttl_ms.to_be_bytes());
+        msg.extend_from_slice(data);
+
+        msg
+    }
+}
+
+/// A session key acting inside one overlay: the authority that issues every
+/// [`MessageVerification`] a node signs.
+///
+/// Signing is the map `(session_sk, network_id) × (tag, data) → MessageVerification`. This
+/// type fixes the first component, so message constructors take one authority instead of a key
+/// and an overlay that could be paired inconsistently.
+#[derive(Clone, Copy)]
+pub struct MessageSigner<'a> {
+    session_sk: &'a SessionSk,
+    network_id: u32,
+}
+
+impl<'a> MessageSigner<'a> {
+    /// Let `session_sk` sign on behalf of the overlay `network_id`.
+    pub const fn new(session_sk: &'a SessionSk, network_id: u32) -> Self {
+        Self {
+            session_sk,
+            network_id,
+        }
+    }
+
+    /// The session key.
+    pub const fn session_sk(self) -> &'a SessionSk {
+        self.session_sk
+    }
+
+    /// The overlay this authority signs for.
+    pub const fn network_id(self) -> u32 {
+        self.network_id
+    }
+
+    /// The account DID that authorized the session key.
+    pub fn account_did(self) -> Did {
+        self.session_sk.account_did()
+    }
+
+    /// Sign `data` as a member of the message family `tag` inside this overlay.
+    pub fn sign(self, tag: DomainTag, data: &[u8]) -> Result<MessageVerification> {
+        MessageVerification::new(
+            SigningDomain::new(tag, self.network_id),
+            data,
+            self.session_sk,
+        )
+    }
+}
 
 /// Message Verification is based on session, and sig.
 /// it also included ttl time and created ts.
@@ -28,22 +161,13 @@ pub struct MessageVerification {
     pub sig: Vec<u8>,
 }
 
-fn pack_msg(data: &[u8], ts_ms: u128, ttl_ms: u64) -> Vec<u8> {
-    let mut msg = vec![];
-
-    msg.extend_from_slice(&ts_ms.to_be_bytes());
-    msg.extend_from_slice(&ttl_ms.to_be_bytes());
-    msg.extend_from_slice(data);
-
-    msg
-}
-
 impl MessageVerification {
-    /// Create a new MessageVerification. Should provide the data and the [SessionSk].
-    pub fn new(data: &[u8], session_sk: &SessionSk) -> Result<Self> {
+    /// Sign `data` under `domain` with the [SessionSk], stamped with the current time and the
+    /// default TTL.
+    pub fn new(domain: SigningDomain, data: &[u8], session_sk: &SessionSk) -> Result<Self> {
         let ts_ms = get_epoch_ms();
         let ttl_ms = DEFAULT_TTL_MS;
-        let msg = pack_msg(data, ts_ms, ttl_ms);
+        let msg = domain.transcript(data, ts_ms, ttl_ms);
         let verification = MessageVerification {
             session: session_sk.session(),
             sig: session_sk.sign(&msg)?,
@@ -53,9 +177,9 @@ impl MessageVerification {
         Ok(verification)
     }
 
-    /// Verify a MessageVerification
-    pub fn verify(&self, data: &[u8]) -> bool {
-        let msg = pack_msg(data, self.ts_ms, self.ttl_ms);
+    /// Verify the signature over `data` under the receiver's `domain`.
+    pub fn verify(&self, domain: SigningDomain, data: &[u8]) -> bool {
+        let msg = domain.transcript(data, self.ts_ms, self.ttl_ms);
 
         self.session
             .verify(&msg, &self.sig)
@@ -82,19 +206,23 @@ impl MessageVerification {
     }
 
     /// Verify the signature only when the verification timestamp is still live.
-    pub fn verify_unexpired(&self, data: &[u8]) -> bool {
+    pub fn verify_unexpired(&self, domain: SigningDomain, data: &[u8]) -> bool {
         if self.is_expired() {
             tracing::warn!("message expired");
             return false;
         }
 
-        self.verify(data)
+        self.verify(domain, data)
     }
 }
 
 /// This trait helps a struct with `MessageVerification` field to `verify` itself.
 /// It also provides a `signer` method to let receiver know who sent the message.
 pub trait MessageVerificationExt {
+    /// The message family this type is signed under. Paired with the receiver's overlay it
+    /// fixes the [`SigningDomain`] of [`Self::verification`].
+    const DOMAIN_TAG: DomainTag;
+
     /// Give the data to be verified.
     fn verification_data(&self) -> Result<Vec<u8>>;
 
@@ -106,8 +234,9 @@ pub trait MessageVerificationExt {
         self.verification().is_expired()
     }
 
-    /// Verifies that the message is not expired and that the signature is valid.
-    fn verify(&self) -> bool {
+    /// Verifies that the message is not expired and that the signature was issued for this
+    /// message family inside the overlay `network_id`.
+    fn verify(&self, network_id: u32) -> bool {
         if self.is_expired() {
             tracing::warn!("message expired");
             return false;
@@ -118,7 +247,8 @@ pub trait MessageVerificationExt {
             return false;
         };
 
-        self.verification().verify_unexpired(&data)
+        self.verification()
+            .verify_unexpired(SigningDomain::new(Self::DOMAIN_TAG, network_id), &data)
     }
 
     /// Get signer did from verification.
@@ -132,11 +262,17 @@ mod tests {
     use super::*;
     use crate::ecc::SecretKey;
 
+    const FIXTURE_TAG: DomainTag = DomainTag::new("rings-core:test:fixture:v1");
+    const OTHER_TAG: DomainTag = DomainTag::new("rings-core:test:other:v1");
+    const NETWORK_ID: u32 = 7;
+
     struct VerifiedFixture {
         verification: MessageVerification,
     }
 
     impl MessageVerificationExt for VerifiedFixture {
+        const DOMAIN_TAG: DomainTag = FIXTURE_TAG;
+
         fn verification_data(&self) -> Result<Vec<u8>> {
             Ok(Vec::new())
         }
@@ -146,11 +282,15 @@ mod tests {
         }
     }
 
+    fn fixture_domain() -> SigningDomain {
+        SigningDomain::new(FIXTURE_TAG, NETWORK_ID)
+    }
+
     #[test]
     fn test_expiration_handles_timestamp_below_tolerance_without_underflow() -> Result<()> {
         let key = SecretKey::random();
         let session_sk = SessionSk::new_with_seckey(&key)?;
-        let mut verification = MessageVerification::new(&[], &session_sk)?;
+        let mut verification = MessageVerification::new(fixture_domain(), &[], &session_sk)?;
         verification.ts_ms = 0;
         let fixture = VerifiedFixture { verification };
 
@@ -164,7 +304,7 @@ mod tests {
         ts_ms: u128,
         ttl_ms: u64,
     ) -> Result<MessageVerification> {
-        let msg = pack_msg(data, ts_ms, ttl_ms);
+        let msg = fixture_domain().transcript(data, ts_ms, ttl_ms);
         Ok(MessageVerification {
             session: session_sk.session(),
             ttl_ms,
@@ -180,7 +320,7 @@ mod tests {
         let proof = signed_verification(&[], &session_sk, get_epoch_ms(), MAX_TTL_MS + 1)?;
 
         assert!(proof.is_expired());
-        assert!(!proof.verify_unexpired(&[]));
+        assert!(!proof.verify_unexpired(fixture_domain(), &[]));
         Ok(())
     }
 
@@ -196,7 +336,66 @@ mod tests {
         )?;
 
         assert!(proof.is_expired());
-        assert!(!proof.verify_unexpired(&[]));
+        assert!(!proof.verify_unexpired(fixture_domain(), &[]));
+        Ok(())
+    }
+
+    /// Law: the transcript is the length-prefixed tag, the overlay, the stamp, then the data.
+    #[test]
+    fn test_transcript_layout_is_length_prefixed_tag_then_overlay_then_stamp() {
+        let transcript = fixture_domain().transcript(b"data", 3, 5);
+        let tag = FIXTURE_TAG.as_bytes();
+
+        let mut expected = vec![tag.len() as u8];
+        expected.extend_from_slice(tag);
+        expected.extend_from_slice(&NETWORK_ID.to_be_bytes());
+        expected.extend_from_slice(&3u128.to_be_bytes());
+        expected.extend_from_slice(&5u64.to_be_bytes());
+        expected.extend_from_slice(b"data");
+        assert_eq!(transcript, expected);
+    }
+
+    /// Law: a signature issued for overlay `n` does not verify under overlay `n' != n`.
+    #[test]
+    fn test_signature_is_bound_to_the_overlay() -> Result<()> {
+        let key = SecretKey::random();
+        let session_sk = SessionSk::new_with_seckey(&key)?;
+        let verification = MessageVerification::new(fixture_domain(), b"data", &session_sk)?;
+
+        assert!(verification.verify(fixture_domain(), b"data"));
+        assert!(!verification.verify(SigningDomain::new(FIXTURE_TAG, NETWORK_ID + 1), b"data"));
+        Ok(())
+    }
+
+    /// Law: a signature issued for message family `t` does not verify under `t' != t`.
+    #[test]
+    fn test_signature_is_bound_to_the_message_family() -> Result<()> {
+        let key = SecretKey::random();
+        let session_sk = SessionSk::new_with_seckey(&key)?;
+        let verification = MessageVerification::new(fixture_domain(), b"data", &session_sk)?;
+
+        assert!(!verification.verify(SigningDomain::new(OTHER_TAG, NETWORK_ID), b"data"));
+        Ok(())
+    }
+
+    /// Law: `MessageVerificationExt::verify` checks the type's own tag against the receiver's
+    /// overlay, so a fixture signed elsewhere is rejected even with identical data.
+    #[test]
+    fn test_ext_verify_uses_type_tag_and_receiver_overlay() -> Result<()> {
+        let key = SecretKey::random();
+        let session_sk = SessionSk::new_with_seckey(&key)?;
+        let signer = MessageSigner::new(&session_sk, NETWORK_ID);
+        let fixture = VerifiedFixture {
+            verification: signer.sign(FIXTURE_TAG, &[])?,
+        };
+
+        assert!(fixture.verify(NETWORK_ID));
+        assert!(!fixture.verify(NETWORK_ID + 1));
+
+        let mislabeled = VerifiedFixture {
+            verification: signer.sign(OTHER_TAG, &[])?,
+        };
+        assert!(!mislabeled.verify(NETWORK_ID));
         Ok(())
     }
 }

--- a/crates/core/src/message/protocols/verify.rs
+++ b/crates/core/src/message/protocols/verify.rs
@@ -29,6 +29,7 @@ use crate::consts::DEFAULT_TTL_MS;
 use crate::consts::MAX_TTL_MS;
 use crate::consts::TS_OFFSET_TOLERANCE_MS;
 use crate::dht::Did;
+use crate::ecc::PublicKey;
 use crate::error::Result;
 use crate::session::Session;
 use crate::session::SessionSk;
@@ -153,9 +154,13 @@ where S: Borrow<SessionSk>
         }
     }
 
-    /// The session key.
-    pub fn session_sk(&self) -> &SessionSk {
+    fn session_sk(&self) -> &SessionSk {
         self.session_sk.borrow()
+    }
+
+    /// The public key of the session this authority signs with.
+    pub fn session_public_key(&self) -> PublicKey<33> {
+        self.session_sk().session_public_key()
     }
 
     /// The overlay this authority signs for.

--- a/crates/core/src/message/protocols/verify.rs
+++ b/crates/core/src/message/protocols/verify.rs
@@ -109,7 +109,7 @@ impl SigningDomain {
     /// Law (injectivity): `transcript(d, ts, ttl, m) = transcript(d', ts', ttl', m')` implies
     /// `(d, ts, ttl, m) = (d', ts', ttl', m')`, because every component before `m` has a fixed
     /// width or a length prefix.
-    fn transcript(self, data: &[u8], ts_ms: u128, ttl_ms: u64) -> Vec<u8> {
+    pub(crate) fn transcript(self, data: &[u8], ts_ms: u128, ttl_ms: u64) -> Vec<u8> {
         let tag = self.tag.as_bytes();
         let mut msg = Vec::with_capacity(1 + tag.len() + 4 + 16 + 8 + data.len());
 
@@ -174,7 +174,7 @@ where S: Borrow<SessionSk>
     }
 
     /// This authority owning a copy of its key: the form long-lived runtimes store.
-    pub fn to_owned(&self) -> MessageSigner<SessionSk> {
+    pub fn owned(&self) -> MessageSigner<SessionSk> {
         MessageSigner::new(self.session_sk().clone(), self.network_id)
     }
 
@@ -209,12 +209,23 @@ pub struct MessageVerification {
 }
 
 impl MessageVerification {
-    /// Verify the signature over `data` under the receiver's `domain`.
+    /// Verify the signature over `data` under the receiver's `domain`, with the signing session
+    /// judged as of now.
     pub fn verify(&self, domain: SigningDomain, data: &[u8]) -> bool {
+        self.verify_at(domain, data, get_epoch_ms())
+    }
+
+    /// Verify the signature over `data` under the receiver's `domain`, with the signing session
+    /// judged as of the instant `at_ms`.
+    ///
+    /// Post: `true` implies the session was authorized and live at `at_ms` and signed the
+    /// transcript of `(domain, data, ts_ms, ttl_ms)`. Proof liveness is not judged here; see
+    /// [`Self::is_live_at`].
+    pub fn verify_at(&self, domain: SigningDomain, data: &[u8], at_ms: u128) -> bool {
         let msg = domain.transcript(data, self.ts_ms, self.ttl_ms);
 
         self.session
-            .verify(&msg, &self.sig)
+            .verify_at(&msg, &self.sig, at_ms)
             .map_err(|e| {
                 tracing::warn!("MessageVerification verify failed: {:?}", e);
             })
@@ -266,31 +277,34 @@ pub trait MessageVerificationExt {
         self.verification().is_expired()
     }
 
-    /// Verifies that the signature was issued for this message family inside the overlay
-    /// `network_id`, regardless of whether its proof is still live.
+    /// Verifies the message as of the instant `at_ms`: its proof was live then, its session was
+    /// authorized and live then, and the signature was issued for this message family inside
+    /// the overlay `network_id`.
     ///
-    /// Use this only where the message's own lifetime is governed elsewhere (a relay inbox holds
-    /// a message past its proof lifetime and bounds it by retention); every transport path uses
-    /// [`Self::verify`].
-    fn verify_signature(&self, network_id: u32) -> bool {
+    /// Every transport path judges as of now through [`Self::verify`]; a relay inbox judges a
+    /// held message as of the instant its holder received it, so a sender's session expiring
+    /// afterwards does not retroactively unverify a message that was valid when held.
+    fn verify_at(&self, network_id: u32, at_ms: u128) -> bool {
+        if !self.verification().is_live_at(at_ms) {
+            tracing::warn!("message proof not live at the judged instant");
+            return false;
+        }
         let Ok(data) = self.verification_data() else {
             tracing::warn!("MessageVerificationExt verify get verification_data failed");
             return false;
         };
 
-        self.verification()
-            .verify(SigningDomain::new(Self::DOMAIN_TAG, network_id), &data)
+        self.verification().verify_at(
+            SigningDomain::new(Self::DOMAIN_TAG, network_id),
+            &data,
+            at_ms,
+        )
     }
 
     /// Verifies that the message is not expired and that the signature was issued for this
-    /// message family inside the overlay `network_id`.
+    /// message family inside the overlay `network_id`, as of now.
     fn verify(&self, network_id: u32) -> bool {
-        if self.is_expired() {
-            tracing::warn!("message expired");
-            return false;
-        }
-
-        self.verify_signature(network_id)
+        self.verify_at(network_id, get_epoch_ms())
     }
 
     /// Get signer did from verification.
@@ -459,7 +473,7 @@ mod tests {
     fn test_owned_and_borrowed_authorities_are_the_same_signer() -> Result<()> {
         let key = SecretKey::random();
         let session_sk = SessionSk::new_with_seckey(&key)?;
-        let owned = fixture_signer(&session_sk).to_owned();
+        let owned = fixture_signer(&session_sk).owned();
         let proof = owned.by_ref().sign(FIXTURE_TAG, b"data")?;
 
         assert_eq!(owned.network_id(), NETWORK_ID);

--- a/crates/core/src/message/protocols/verify.rs
+++ b/crates/core/src/message/protocols/verify.rs
@@ -266,6 +266,22 @@ pub trait MessageVerificationExt {
         self.verification().is_expired()
     }
 
+    /// Verifies that the signature was issued for this message family inside the overlay
+    /// `network_id`, regardless of whether its proof is still live.
+    ///
+    /// Use this only where the message's own lifetime is governed elsewhere (a relay inbox holds
+    /// a message past its proof lifetime and bounds it by retention); every transport path uses
+    /// [`Self::verify`].
+    fn verify_signature(&self, network_id: u32) -> bool {
+        let Ok(data) = self.verification_data() else {
+            tracing::warn!("MessageVerificationExt verify get verification_data failed");
+            return false;
+        };
+
+        self.verification()
+            .verify(SigningDomain::new(Self::DOMAIN_TAG, network_id), &data)
+    }
+
     /// Verifies that the message is not expired and that the signature was issued for this
     /// message family inside the overlay `network_id`.
     fn verify(&self, network_id: u32) -> bool {
@@ -274,13 +290,7 @@ pub trait MessageVerificationExt {
             return false;
         }
 
-        let Ok(data) = self.verification_data() else {
-            tracing::warn!("MessageVerificationExt verify get verification_data failed");
-            return false;
-        };
-
-        self.verification()
-            .verify_unexpired(SigningDomain::new(Self::DOMAIN_TAG, network_id), &data)
+        self.verify_signature(network_id)
     }
 
     /// Get signer did from verification.

--- a/crates/core/src/message/protocols/verify.rs
+++ b/crates/core/src/message/protocols/verify.rs
@@ -44,13 +44,16 @@ use crate::utils::get_epoch_ms;
 pub struct DomainTag(&'static str);
 
 impl DomainTag {
-    /// Name a message family, or `None` when `label` does not fit its length prefix.
-    pub const fn new(label: &'static str) -> Option<Self> {
-        if label.len() <= u8::MAX as usize {
-            Some(Self(label))
-        } else {
-            None
-        }
+    /// Name a message family.
+    ///
+    /// Pre: `label.len() <= u8::MAX`, the length prefix's width; a longer label is a programming
+    /// error and is refused here, at compile time when the constructor runs in a `const`.
+    pub const fn new(label: &'static str) -> Self {
+        assert!(
+            label.len() <= u8::MAX as usize,
+            "domain tag label must fit its one-byte length prefix"
+        );
+        Self(label)
     }
 
     /// The label bytes.
@@ -64,20 +67,12 @@ impl DomainTag {
     }
 }
 
-/// Name a message family from a literal, rejecting at compile time a label longer than the
-/// one-byte length prefix allows.
+/// Name a message family from a literal in a `const`, so a label longer than the one-byte
+/// length prefix allows is refused at compile time.
 #[macro_export]
 macro_rules! domain_tag {
     ($label:literal) => {{
-        const _: () = assert!(
-            $label.len() <= u8::MAX as usize,
-            "domain tag label must fit its one-byte length prefix"
-        );
-        const TAG: $crate::message::DomainTag = match $crate::message::DomainTag::new($label) {
-            Some(tag) => tag,
-            // Excluded by the assertion above.
-            None => unreachable!(),
-        };
+        const TAG: $crate::message::DomainTag = $crate::message::DomainTag::new($label);
         TAG
     }};
 }
@@ -186,8 +181,13 @@ where S: Borrow<SessionSk>
     /// Sign `data` as a member of the message family `tag` inside this overlay, stamped with
     /// the current time and the default TTL.
     pub fn sign(&self, tag: DomainTag, data: &[u8]) -> Result<MessageVerification> {
+        self.sign_at(tag, data, get_epoch_ms())
+    }
+
+    /// Sign `data` as a member of the message family `tag` inside this overlay, stamped with
+    /// the instant `ts_ms` and the default TTL.
+    pub fn sign_at(&self, tag: DomainTag, data: &[u8], ts_ms: u128) -> Result<MessageVerification> {
         let domain = SigningDomain::new(tag, self.network_id);
-        let ts_ms = get_epoch_ms();
         let ttl_ms = DEFAULT_TTL_MS;
         let msg = domain.transcript(data, ts_ms, ttl_ms);
         Ok(MessageVerification {
@@ -253,14 +253,19 @@ impl MessageVerification {
             && now_ms <= self.ts_ms.saturating_add(self.ttl_ms as u128)
     }
 
-    /// Verify the signature only when the verification timestamp is still live.
-    pub fn verify_unexpired(&self, domain: SigningDomain, data: &[u8]) -> bool {
-        if self.is_expired() {
-            tracing::warn!("message expired");
+    /// Verify the signature only when the proof is live now.
+    pub fn verify_live(&self, domain: SigningDomain, data: &[u8]) -> bool {
+        self.verify_live_at(domain, data, get_epoch_ms())
+    }
+
+    /// Verify the signature as of `at_ms`, requiring the proof to have been live then: the one
+    /// composition of liveness, session validity, and signature every verifying path uses.
+    pub fn verify_live_at(&self, domain: SigningDomain, data: &[u8], at_ms: u128) -> bool {
+        if !self.is_live_at(at_ms) {
+            tracing::warn!("message proof not live at the judged instant");
             return false;
         }
-
-        self.verify(domain, data)
+        self.verify_at(domain, data, at_ms)
     }
 }
 
@@ -290,16 +295,12 @@ pub trait MessageVerificationExt {
     /// held message as of the instant its holder received it, so a sender's session expiring
     /// afterwards does not retroactively unverify a message that was valid when held.
     fn verify_at(&self, network_id: u32, at_ms: u128) -> bool {
-        if !self.verification().is_live_at(at_ms) {
-            tracing::warn!("message proof not live at the judged instant");
-            return false;
-        }
         let Ok(data) = self.verification_data() else {
             tracing::warn!("MessageVerificationExt verify get verification_data failed");
             return false;
         };
 
-        self.verification().verify_at(
+        self.verification().verify_live_at(
             SigningDomain::new(Self::DOMAIN_TAG, network_id),
             &data,
             at_ms,
@@ -379,18 +380,18 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_unexpired_rejects_ttl_above_max() -> Result<()> {
+    fn test_verify_live_rejects_ttl_above_max() -> Result<()> {
         let key = SecretKey::random();
         let session_sk = SessionSk::new_with_seckey(&key)?;
         let proof = signed_verification(&[], &session_sk, get_epoch_ms(), MAX_TTL_MS + 1)?;
 
         assert!(proof.is_expired());
-        assert!(!proof.verify_unexpired(fixture_domain(), &[]));
+        assert!(!proof.verify_live(fixture_domain(), &[]));
         Ok(())
     }
 
     #[test]
-    fn test_verify_unexpired_rejects_timestamp_beyond_future_tolerance() -> Result<()> {
+    fn test_verify_live_rejects_timestamp_beyond_future_tolerance() -> Result<()> {
         let key = SecretKey::random();
         let session_sk = SessionSk::new_with_seckey(&key)?;
         let proof = signed_verification(
@@ -401,7 +402,7 @@ mod tests {
         )?;
 
         assert!(proof.is_expired());
-        assert!(!proof.verify_unexpired(fixture_domain(), &[]));
+        assert!(!proof.verify_live(fixture_domain(), &[]));
         Ok(())
     }
 
@@ -422,11 +423,11 @@ mod tests {
 
     /// Law: a label longer than the one-byte length prefix is not a tag.
     #[test]
+    #[should_panic(expected = "domain tag label must fit its one-byte length prefix")]
     fn test_domain_tag_rejects_label_beyond_length_prefix() {
         const LONG: &str = "rings-core:test:long-label:v1 - 0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
         assert!(LONG.len() > usize::from(u8::MAX));
-        assert!(DomainTag::new(LONG).is_none());
-        assert!(DomainTag::new("rings-core:test:short:v1").is_some());
+        let _ = DomainTag::new(LONG);
     }
 
     /// Law: a signature issued for overlay `n` does not verify under overlay `n' != n`.

--- a/crates/core/src/message/types.rs
+++ b/crates/core/src/message/types.rs
@@ -587,7 +587,6 @@ mod tests {
 
     use super::*;
     use crate::chunk::ChunkMeta;
-    use crate::dht::entry::EntryCrdt;
     use crate::dht::entry::EntryKind;
     use crate::dht::entry::EntryOperation;
     use crate::ecc::SecretKey;
@@ -605,12 +604,7 @@ mod tests {
             Self {
                 did,
                 public_key: secret_key.pubkey(),
-                entry: Entry {
-                    did,
-                    data: Vec::new(),
-                    kind: EntryKind::Data,
-                    crdt: EntryCrdt::default(),
-                },
+                entry: Entry::new(did, Vec::new(), EntryKind::Data),
             }
         }
     }

--- a/crates/core/src/session/model.rs
+++ b/crates/core/src/session/model.rs
@@ -45,13 +45,22 @@ impl Session {
 
     /// Check whether the session has expired.
     pub fn is_expired(&self) -> bool {
-        let now = utils::get_epoch_ms();
-        now > self.ts_ms + self.ttl_ms as u128
+        self.is_expired_at(utils::get_epoch_ms())
+    }
+
+    /// Check whether the session had expired at the instant `at_ms`.
+    pub fn is_expired_at(&self, at_ms: u128) -> bool {
+        at_ms > self.ts_ms + self.ttl_ms as u128
     }
 
     /// Verify that the account authorized this unexpired session.
     pub fn verify_self(&self) -> Result<()> {
-        if self.is_expired() {
+        self.verify_self_at(utils::get_epoch_ms())
+    }
+
+    /// Verify that the account authorized this session and that it was live at `at_ms`.
+    pub fn verify_self_at(&self, at_ms: u128) -> Result<()> {
+        if self.is_expired_at(at_ms) {
             return Err(Error::SessionExpired);
         }
 
@@ -68,7 +77,13 @@ impl Session {
 
     /// Verify a message signed by this session key.
     pub fn verify(&self, msg: &[u8], sig: impl AsRef<[u8]>) -> Result<()> {
-        self.verify_self()?;
+        self.verify_at(msg, sig, utils::get_epoch_ms())
+    }
+
+    /// Verify a message signed by this session key as of the instant `at_ms`: the session must
+    /// have been live then, whatever it is now.
+    pub fn verify_at(&self, msg: &[u8], sig: impl AsRef<[u8]>, at_ms: u128) -> Result<()> {
+        self.verify_self_at(at_ms)?;
         if !signers::secp256k1::verify(msg, &self.session_id, sig) {
             return Err(Error::VerifySignatureFailed);
         }

--- a/crates/core/src/simulation.rs
+++ b/crates/core/src/simulation.rs
@@ -804,9 +804,14 @@ mod tests {
             ),
         ];
         for (sequence, (message, expected)) in fixtures.into_iter().enumerate() {
-            let wire = MessagePayload::new_send(message, MessageSigner::new(&session, 0), did, did)
-                .and_then(|payload| payload.to_wire())
-                .expect("payload must encode");
+            let wire = MessagePayload::new_send(
+                message,
+                MessageSigner::new(&session, crate::tests::TEST_NETWORK_ID),
+                did,
+                did,
+            )
+            .and_then(|payload| payload.to_wire())
+            .expect("payload must encode");
             assert_eq!(
                 inspect_message(sequence as u64, &wire)
                     .expect("payload must classify")

--- a/crates/core/src/simulation.rs
+++ b/crates/core/src/simulation.rs
@@ -758,6 +758,7 @@ mod tests {
     use crate::ecc::SecretKey;
     use crate::message::Message;
     use crate::message::MessagePayload;
+    use crate::message::MessageSigner;
     use crate::message::PeerLivenessProbe;
     use crate::message::SyncEntriesWithSuccessor;
     use crate::session::SessionSk;
@@ -803,7 +804,7 @@ mod tests {
             ),
         ];
         for (sequence, (message, expected)) in fixtures.into_iter().enumerate() {
-            let wire = MessagePayload::new_send(message, &session, did, did)
+            let wire = MessagePayload::new_send(message, MessageSigner::new(&session, 0), did, did)
                 .and_then(|payload| payload.to_wire())
                 .expect("payload must encode");
             assert_eq!(

--- a/crates/core/src/storage/file/mod.rs
+++ b/crates/core/src/storage/file/mod.rs
@@ -69,14 +69,14 @@ impl FileIndex {
 }
 
 /// StorageInstance struct
-pub struct SledStorage {
+pub struct FileStorage {
     root: PathBuf,
     capacity: u64,
     index: RwLock<FileIndex>,
 }
 
-impl SledStorage {
-    /// New SledStorage
+impl FileStorage {
+    /// New FileStorage
     /// * cap: max_size in bytes
     /// * path: db file location
     pub async fn new_with_cap_and_path<P>(cap: u32, path: P) -> Result<Self>
@@ -141,11 +141,11 @@ impl SledStorage {
     }
 
     fn read_index(&self) -> Result<RwLockReadGuard<'_, FileIndex>> {
-        self.index.read().map_err(|_| Error::StorageLockPoisoned)
+        self.index.read().map_err(|_| Error::LockPoisoned)
     }
 
     fn write_index(&self) -> Result<RwLockWriteGuard<'_, FileIndex>> {
-        self.index.write().map_err(|_| Error::StorageLockPoisoned)
+        self.index.write().map_err(|_| Error::LockPoisoned)
     }
 
     /// Remove the record stored as `name` and forget it.
@@ -184,7 +184,7 @@ fn remove_file_if_present(path: &Path) -> Result<()> {
 }
 
 #[async_trait]
-impl<V> KvStorageInterface<V> for SledStorage
+impl<V> KvStorageInterface<V> for FileStorage
 where V: Serialize + DeserializeOwned + Sync
 {
     async fn get(&self, key: &str) -> Result<Option<V>> {
@@ -283,9 +283,9 @@ fn entry_file_name(path: &Path) -> Option<&str> {
         .then_some(file_name)
 }
 
-impl std::fmt::Debug for SledStorage {
+impl std::fmt::Debug for FileStorage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SledStorage")
+        f.debug_struct("FileStorage")
             .field("capacity", &self.capacity)
             .field("root", &self.root)
             .finish()
@@ -293,4 +293,4 @@ impl std::fmt::Debug for SledStorage {
 }
 
 #[cfg(test)]
-mod test_sled;
+mod test_file;

--- a/crates/core/src/storage/file/mod.rs
+++ b/crates/core/src/storage/file/mod.rs
@@ -9,9 +9,10 @@
 //! the storage is opened, so lowering the configured capacity retires the oldest files.
 //!
 //! Index law: the in-memory index mirrors the directory. It is rebuilt from the directory on
-//! open (stale `.tmp` files from an interrupted write are removed then), every write updates it
-//! under the same lock only after the file system operation succeeded, and the directory is
-//! owned exclusively by this instance while it is open.
+//! open (stale `.tmp` files from an interrupted write are removed then), every write and every
+//! retirement updates it under the same lock only after the file system operation succeeded
+//! (so a file the file system refused to remove stays indexed and stays counted against the
+//! budget), and the directory is owned exclusively by this instance while it is open.
 //!
 //! Decode law: the store holds only records decodable as `V`. A record the current schema
 //! cannot decode (written by an earlier build) is retired on the read that discovers it and
@@ -60,11 +61,9 @@ impl FileIndex {
         self.used_bytes = self.used_bytes.saturating_add(len);
     }
 
-    /// Forget the least recently written file, returning its name.
-    fn retire_oldest(&mut self) -> Option<String> {
-        let (name, len) = self.files.pop_oldest()?;
-        self.used_bytes = self.used_bytes.saturating_sub(len);
-        Some(name)
+    /// The least recently written file, the next one the budget retires.
+    fn oldest(&self) -> Option<String> {
+        self.files.oldest().map(str::to_owned)
     }
 }
 
@@ -131,15 +130,60 @@ impl FileStorage {
     /// Retire least recently written files until `incoming` more bytes fit the budget.
     ///
     /// Pre: `incoming <= capacity`.
-    /// Post: `index.used_bytes + incoming <= capacity`.
+    /// Post: `Ok(())` implies `index.used_bytes + incoming <= capacity`; on `Err`, every file
+    /// the file system refused to remove is still indexed (the index law).
     fn retire_until_fits(&self, index: &mut FileIndex, incoming: u64) -> Result<()> {
         while index.used_bytes.saturating_add(incoming) > self.capacity {
-            let Some(name) = index.retire_oldest() else {
+            let Some(name) = index.oldest() else {
                 break;
             };
-            remove_file_if_present(&self.root.join(name))?;
+            self.retire_indexed(index, &name)?;
         }
         Ok(())
+    }
+
+    /// Remove the record stored as `name` from the directory, then forget it.
+    ///
+    /// Post: `name` is forgotten iff its file is gone.
+    fn retire_indexed(&self, index: &mut FileIndex, name: &str) -> Result<()> {
+        remove_file_if_present(&self.root.join(name))?;
+        index.forget(name);
+        Ok(())
+    }
+
+    /// Make the record written to `tmp_path` the stored record `name` of `required` bytes,
+    /// retiring other records as the budget demands.
+    ///
+    /// Post: on `Ok` the index records `name` as the newest file; on `Err` nothing was renamed,
+    /// every file still on disk is still indexed, and a previous record under `name` is still
+    /// on disk and indexed (re-recorded as the newest file, the one recency the index cannot
+    /// restore exactly).
+    fn commit_record(
+        &self,
+        index: &mut FileIndex,
+        name: String,
+        path: &Path,
+        tmp_path: &Path,
+        required: u64,
+    ) -> Result<()> {
+        // The rewritten key does not compete with itself for the budget.
+        let previous_len = index.files.get(&name).copied();
+        index.forget(&name);
+        let renamed = self
+            .retire_until_fits(index, required)
+            .and_then(|()| std::fs::rename(tmp_path, path).map_err(Error::ServiceIOError));
+        match renamed {
+            Ok(()) => {
+                index.record(name, required);
+                Ok(())
+            }
+            Err(error) => {
+                if let Some(previous_len) = previous_len {
+                    index.record(name, previous_len);
+                }
+                Err(error)
+            }
+        }
     }
 
     fn read_index(&self) -> Result<RwLockReadGuard<'_, FileIndex>> {
@@ -153,9 +197,7 @@ impl FileStorage {
     /// Remove the record stored as `name` and forget it.
     fn retire(&self, name: &str) -> Result<()> {
         let mut index = self.write_index()?;
-        remove_file_if_present(&self.root.join(name))?;
-        index.forget(name);
-        Ok(())
+        self.retire_indexed(&mut index, name)
     }
 
     /// Decode one record file, retiring it when the current schema cannot read it.
@@ -222,20 +264,11 @@ where V: Serialize + DeserializeOwned + Sync
         std::fs::create_dir_all(&self.root).map_err(Error::ServiceIOError)?;
         std::fs::write(&tmp_path, data).map_err(Error::ServiceIOError)?;
         tracing::debug!("Try inserting key: {:?}", key);
-        // The rewritten key does not compete with itself for the budget.
-        let previous_len = index.files.get(&name).copied();
-        index.forget(&name);
-        self.retire_until_fits(&mut index, required)?;
-        if let Err(error) = std::fs::rename(&tmp_path, &path) {
-            // The previous record is still on disk; keep the index faithful to it.
-            if let Some(previous_len) = previous_len {
-                index.record(name, previous_len);
-            }
+        let committed = self.commit_record(&mut index, name, &path, &tmp_path, required);
+        if committed.is_err() {
             remove_file_if_present(&tmp_path)?;
-            return Err(Error::ServiceIOError(error));
         }
-        index.record(name, required);
-        Ok(())
+        committed
     }
 
     async fn get_all(&self) -> Result<Vec<(String, V)>> {
@@ -267,8 +300,8 @@ where V: Serialize + DeserializeOwned + Sync
 
     async fn clear(&self) -> Result<()> {
         let mut index = self.write_index()?;
-        while let Some(name) = index.retire_oldest() {
-            remove_file_if_present(&self.root.join(name))?;
+        while let Some(name) = index.oldest() {
+            self.retire_indexed(&mut index, &name)?;
         }
         Ok(())
     }

--- a/crates/core/src/storage/file/mod.rs
+++ b/crates/core/src/storage/file/mod.rs
@@ -16,7 +16,9 @@
 //!
 //! Decode law: the store holds only records decodable as `V`. A record the current schema
 //! cannot decode (written by an earlier build) is retired on the read that discovers it and
-//! reported absent, so it neither serves stale data nor occupies the budget.
+//! reported absent, so it neither serves stale data nor occupies the budget. The retirement
+//! removes exactly the bytes the read observed: a record rewritten between the read and the
+//! retirement is the writer's, and stays.
 
 use std::path::Path;
 use std::path::PathBuf;
@@ -206,10 +208,26 @@ impl FileStorage {
         match rings_codec::deserialize::<(String, V)>(data) {
             Ok(record) => Ok(Some(record)),
             Err(_) => {
-                self.retire(name)?;
+                self.retire_observed(name, data)?;
                 Ok(None)
             }
         }
+    }
+
+    /// Retire the record stored as `name` iff its file still holds `observed`, the bytes a read
+    /// saw under the read guard. The read released that guard before deciding, so a `put` may
+    /// have replaced the record meanwhile; that record is the writer's to keep.
+    fn retire_observed(&self, name: &str, observed: &[u8]) -> Result<()> {
+        let mut index = self.write_index()?;
+        let current = match std::fs::read(self.root.join(name)) {
+            Ok(current) => current,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(Error::ServiceIOError(error)),
+        };
+        if current == observed {
+            self.retire_indexed(&mut index, name)?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/core/src/storage/file/mod.rs
+++ b/crates/core/src/storage/file/mod.rs
@@ -68,7 +68,7 @@ impl FileIndex {
     }
 }
 
-/// StorageInstance struct
+/// One file per key under a byte budget (see the module documentation for its laws).
 pub struct FileStorage {
     root: PathBuf,
     capacity: u64,
@@ -76,15 +76,17 @@ pub struct FileStorage {
 }
 
 impl FileStorage {
-    /// New FileStorage
-    /// * cap: max_size in bytes
-    /// * path: db file location
-    pub async fn new_with_cap_and_path<P>(cap: u32, path: P) -> Result<Self>
+    /// Open the store rooted at `path`, creating it if absent, under a budget of `capacity`
+    /// bytes.
+    ///
+    /// Post: the index mirrors the directory (stale `.tmp` files removed) and the budget law
+    /// holds, so lowering the configured capacity retires the oldest files at open.
+    pub async fn new_with_cap_and_path<P>(capacity: u32, path: P) -> Result<Self>
     where P: AsRef<std::path::Path> {
         std::fs::create_dir_all(path.as_ref()).map_err(Error::ServiceIOError)?;
         let storage = Self {
             root: path.as_ref().to_path_buf(),
-            capacity: u64::from(cap),
+            capacity: u64::from(capacity),
             index: RwLock::new(FileIndex::default()),
         };
         let mut index = storage.write_index()?;

--- a/crates/core/src/storage/file/test_file.rs
+++ b/crates/core/src/storage/file/test_file.rs
@@ -177,6 +177,56 @@ async fn test_refused_retirement_keeps_the_record_indexed() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+/// Decode law: a record the current schema cannot read is reported absent and retired on the
+/// read that discovers it, but only while the file still holds the bytes that read observed;
+/// a record rewritten meanwhile stays.
+#[tokio::test]
+async fn test_undecodable_record_is_retired_only_while_unchanged() {
+    let root = temp_root("undecodable");
+    std::fs::create_dir_all(&root).expect("root");
+    let name = file_name_for("a");
+    let garbage = b"not a record".to_vec();
+    std::fs::write(root.join(&name), &garbage).expect("write garbage");
+    let storage = FileStorage::new_with_cap_and_path(4096, &root)
+        .await
+        .expect("open");
+    assert_eq!(
+        <FileStorage as KvStorageInterface<String>>::count(&storage)
+            .await
+            .expect("count"),
+        1
+    );
+
+    // The bytes on disk are not the ones the read observed: the record is the writer's.
+    storage
+        .retire_observed(&name, b"what an earlier read saw")
+        .expect("retire nothing");
+    assert!(root.join(&name).exists());
+    assert_eq!(
+        <FileStorage as KvStorageInterface<String>>::count(&storage)
+            .await
+            .expect("count"),
+        1
+    );
+
+    // A read that observes the garbage retires it.
+    assert_eq!(
+        <FileStorage as KvStorageInterface<String>>::get(&storage, "a")
+            .await
+            .expect("get a"),
+        None
+    );
+    assert!(!root.join(&name).exists());
+    assert_eq!(
+        <FileStorage as KvStorageInterface<String>>::count(&storage)
+            .await
+            .expect("count"),
+        0
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
 /// Budget law across restarts: reopening rebuilds the index from the directory in modification
 /// order and restores a lowered budget by retiring the oldest files.
 #[tokio::test]

--- a/crates/core/src/storage/file/test_file.rs
+++ b/crates/core/src/storage/file/test_file.rs
@@ -133,6 +133,50 @@ async fn test_value_larger_than_budget_is_rejected_without_change() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+/// Index law under a refused removal: a record the file system will not remove (its path is
+/// occupied by a directory here) stays indexed and counted, the write that needed its bytes
+/// fails without changing the store, and the same write succeeds once the file is back.
+#[tokio::test]
+async fn test_refused_retirement_keeps_the_record_indexed() {
+    let root = temp_root("refused");
+    let one = record_len("a", "v");
+    let storage = FileStorage::new_with_cap_and_path(one, &root)
+        .await
+        .expect("open");
+    storage.put("a", &"v".to_string()).await.expect("put a");
+    let path = storage.root.join(file_name_for("a"));
+    let record = std::fs::read(&path).expect("read record a");
+    std::fs::remove_file(&path).expect("remove record a");
+    std::fs::create_dir(&path).expect("occupy record a's path");
+
+    assert!(matches!(
+        storage.put("b", &"v".to_string()).await,
+        Err(Error::ServiceIOError(_))
+    ));
+    assert_eq!(
+        <FileStorage as KvStorageInterface<String>>::count(&storage)
+            .await
+            .expect("count"),
+        1
+    );
+    assert_eq!(
+        <FileStorage as KvStorageInterface<String>>::get(&storage, "b")
+            .await
+            .expect("get b"),
+        None
+    );
+    let path_b = storage.root.join(file_name_for("b"));
+    assert!(!path_b.exists());
+    assert!(!path_b.with_extension("tmp").exists());
+
+    std::fs::remove_dir(&path).expect("release record a's path");
+    std::fs::write(&path, record).expect("restore record a");
+    storage.put("b", &"v".to_string()).await.expect("put b");
+    assert_eq!(stored_keys(&storage).await, ["b"]);
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
 /// Budget law across restarts: reopening rebuilds the index from the directory in modification
 /// order and restores a lowered budget by retiring the oldest files.
 #[tokio::test]

--- a/crates/core/src/storage/file/test_file.rs
+++ b/crates/core/src/storage/file/test_file.rs
@@ -8,81 +8,55 @@ struct TestStorageStruct {
     content: String,
 }
 
+/// Put, get, count, get_all, and clear agree on the stored records.
 #[tokio::test]
-async fn test_kv_storage_put_delete() {
-    let path = std::env::temp_dir().join(format!(
-        "rings-file-kv-{}",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    let storage = FileStorage::new_with_cap_and_path(4096, &path)
+async fn test_kv_storage_put_get_count_and_clear() {
+    let root = temp_root("put-get");
+    let storage = FileStorage::new_with_cap_and_path(4096, &root)
         .await
-        .unwrap();
-    let key1 = "test1".to_owned();
-    let data1 = TestStorageStruct {
-        content: "test1".to_string(),
-    };
-    storage.put(&key1, &data1).await.unwrap();
-    let count1 = <FileStorage as KvStorageInterface<TestStorageStruct>>::count::<'_, '_>(&storage)
-        .await
-        .unwrap();
-    assert!(count1 == 1, "expect count1.1 is {}, got {}", 1, count1);
-    let got_v1: TestStorageStruct = storage.get(&key1).await.unwrap().unwrap();
-    assert!(
-        got_v1.content.eq(data1.content.as_str()),
-        "expect value1 is {}, got {}",
-        data1.content,
-        got_v1.content
-    );
-
-    let key2 = "test2".to_owned();
-    let data2 = TestStorageStruct {
-        content: "test2".to_string(),
-    };
-
-    storage.put(&key2, &data2).await.unwrap();
-
-    let count_got_2 =
-        <FileStorage as KvStorageInterface<TestStorageStruct>>::count::<'_, '_>(&storage)
+        .expect("store opens");
+    let records = [
+        ("test1".to_owned(), "first".to_owned()),
+        ("test2".to_owned(), "second".to_owned()),
+    ];
+    for (key, content) in &records {
+        storage
+            .put(key, &TestStorageStruct {
+                content: content.clone(),
+            })
             .await
-            .unwrap();
-    assert!(count_got_2 == 2, "expect count 2, got {count_got_2}");
+            .expect("record stores");
+    }
 
-    let all_entries: Vec<(String, TestStorageStruct)> = storage.get_all().await.unwrap();
-    assert!(
-        all_entries.len() == 2,
-        "all_entries len expect 2, got {}",
-        all_entries.len()
-    );
-
-    let keys = [key1, key2];
-    let values = [data1.content, data2.content];
-
-    assert!(
-        all_entries
-            .iter()
-            .any(|(k, v)| { keys.contains(k) && values.contains(&v.content) }),
-        "not found items"
-    );
-    let data3: u64 = 101;
-    let key3 = "key3".to_owned();
-    storage.put(&key3, &data3).await.unwrap();
-    let got_d3: u64 = storage.get(&key3).await.unwrap().unwrap();
-    assert!(data3 == got_d3, "expect {data3}, got {got_d3}");
-
-    // Clear full db and check if it's count is zero now.
-    <FileStorage as KvStorageInterface<TestStorageStruct>>::clear::<'_, '_>(&storage)
+    let count = <FileStorage as KvStorageInterface<TestStorageStruct>>::count(&storage)
         .await
-        .unwrap();
-    let count1 = <FileStorage as KvStorageInterface<TestStorageStruct>>::count::<'_, '_>(&storage)
+        .expect("count reads");
+    assert_eq!(count, 2);
+    let first: TestStorageStruct = storage
+        .get("test1")
         .await
-        .unwrap();
-    assert!(count1 == 0, "expect count1 is 0, got {count1}");
+        .expect("record reads")
+        .expect("record present");
+    assert_eq!(first.content, "first");
+    let mut all: Vec<(String, String)> =
+        <FileStorage as KvStorageInterface<TestStorageStruct>>::get_all(&storage)
+            .await
+            .expect("records read")
+            .into_iter()
+            .map(|(key, value)| (key, value.content))
+            .collect();
+    all.sort();
+    assert_eq!(all, records);
 
+    <FileStorage as KvStorageInterface<TestStorageStruct>>::clear(&storage)
+        .await
+        .expect("store clears");
+    let count = <FileStorage as KvStorageInterface<TestStorageStruct>>::count(&storage)
+        .await
+        .expect("count reads");
+    assert_eq!(count, 0);
     drop(storage);
-    let _ = std::fs::remove_dir_all(path);
+    let _ = std::fs::remove_dir_all(root);
 }
 
 fn temp_root(label: &str) -> std::path::PathBuf {

--- a/crates/core/src/storage/file/test_file.rs
+++ b/crates/core/src/storage/file/test_file.rs
@@ -17,7 +17,7 @@ async fn test_kv_storage_put_delete() {
             .unwrap()
             .as_nanos()
     ));
-    let storage = SledStorage::new_with_cap_and_path(4096, &path)
+    let storage = FileStorage::new_with_cap_and_path(4096, &path)
         .await
         .unwrap();
     let key1 = "test1".to_owned();
@@ -25,7 +25,7 @@ async fn test_kv_storage_put_delete() {
         content: "test1".to_string(),
     };
     storage.put(&key1, &data1).await.unwrap();
-    let count1 = <SledStorage as KvStorageInterface<TestStorageStruct>>::count::<'_, '_>(&storage)
+    let count1 = <FileStorage as KvStorageInterface<TestStorageStruct>>::count::<'_, '_>(&storage)
         .await
         .unwrap();
     assert!(count1 == 1, "expect count1.1 is {}, got {}", 1, count1);
@@ -45,7 +45,7 @@ async fn test_kv_storage_put_delete() {
     storage.put(&key2, &data2).await.unwrap();
 
     let count_got_2 =
-        <SledStorage as KvStorageInterface<TestStorageStruct>>::count::<'_, '_>(&storage)
+        <FileStorage as KvStorageInterface<TestStorageStruct>>::count::<'_, '_>(&storage)
             .await
             .unwrap();
     assert!(count_got_2 == 2, "expect count 2, got {count_got_2}");
@@ -73,10 +73,10 @@ async fn test_kv_storage_put_delete() {
     assert!(data3 == got_d3, "expect {data3}, got {got_d3}");
 
     // Clear full db and check if it's count is zero now.
-    <SledStorage as KvStorageInterface<TestStorageStruct>>::clear::<'_, '_>(&storage)
+    <FileStorage as KvStorageInterface<TestStorageStruct>>::clear::<'_, '_>(&storage)
         .await
         .unwrap();
-    let count1 = <SledStorage as KvStorageInterface<TestStorageStruct>>::count::<'_, '_>(&storage)
+    let count1 = <FileStorage as KvStorageInterface<TestStorageStruct>>::count::<'_, '_>(&storage)
         .await
         .unwrap();
     assert!(count1 == 0, "expect count1 is 0, got {count1}");
@@ -101,8 +101,8 @@ fn record_len(key: &str, value: &str) -> u32 {
         .len() as u32
 }
 
-async fn stored_keys(storage: &SledStorage) -> Vec<String> {
-    let mut keys = <SledStorage as KvStorageInterface<String>>::get_all(storage)
+async fn stored_keys(storage: &FileStorage) -> Vec<String> {
+    let mut keys = <FileStorage as KvStorageInterface<String>>::get_all(storage)
         .await
         .expect("get_all")
         .into_iter()
@@ -118,7 +118,7 @@ async fn stored_keys(storage: &SledStorage) -> Vec<String> {
 async fn test_put_beyond_budget_retires_least_recently_written_keys() {
     let root = temp_root("budget");
     let one = record_len("a", "v");
-    let storage = SledStorage::new_with_cap_and_path(one * 2, &root)
+    let storage = FileStorage::new_with_cap_and_path(one * 2, &root)
         .await
         .expect("open");
 
@@ -130,7 +130,7 @@ async fn test_put_beyond_budget_retires_least_recently_written_keys() {
     storage.put("c", &"v".to_string()).await.expect("put c");
     assert_eq!(stored_keys(&storage).await, ["a", "c"]);
     assert_eq!(
-        <SledStorage as KvStorageInterface<String>>::get(&storage, "b")
+        <FileStorage as KvStorageInterface<String>>::get(&storage, "b")
             .await
             .expect("get b"),
         None
@@ -144,7 +144,7 @@ async fn test_put_beyond_budget_retires_least_recently_written_keys() {
 async fn test_value_larger_than_budget_is_rejected_without_change() {
     let root = temp_root("oversize");
     let one = record_len("a", "v");
-    let storage = SledStorage::new_with_cap_and_path(one, &root)
+    let storage = FileStorage::new_with_cap_and_path(one, &root)
         .await
         .expect("open");
     storage.put("a", &"v".to_string()).await.expect("put a");
@@ -166,7 +166,7 @@ async fn test_reopen_restores_budget_in_write_order() {
     let root = temp_root("reopen");
     let one = record_len("a", "v");
     {
-        let storage = SledStorage::new_with_cap_and_path(one * 3, &root)
+        let storage = FileStorage::new_with_cap_and_path(one * 3, &root)
             .await
             .expect("open");
         for (index, key) in ["a", "b", "c"].into_iter().enumerate() {
@@ -180,12 +180,12 @@ async fn test_reopen_restores_budget_in_write_order() {
         }
     }
 
-    let reopened = SledStorage::new_with_cap_and_path(one * 2, &root)
+    let reopened = FileStorage::new_with_cap_and_path(one * 2, &root)
         .await
         .expect("reopen");
     assert_eq!(stored_keys(&reopened).await, ["b", "c"]);
     assert_eq!(
-        <SledStorage as KvStorageInterface<String>>::count(&reopened)
+        <FileStorage as KvStorageInterface<String>>::count(&reopened)
             .await
             .expect("count"),
         2

--- a/crates/core/src/storage/memory.rs
+++ b/crates/core/src/storage/memory.rs
@@ -80,11 +80,11 @@ impl<V> MemStorage<V> {
     }
 
     fn read(&self) -> Result<RwLockReadGuard<'_, MemTable<V>>> {
-        self.table.read().map_err(|_| Error::StorageLockPoisoned)
+        self.table.read().map_err(|_| Error::LockPoisoned)
     }
 
     fn write(&self) -> Result<RwLockWriteGuard<'_, MemTable<V>>> {
-        self.table.write().map_err(|_| Error::StorageLockPoisoned)
+        self.table.write().map_err(|_| Error::LockPoisoned)
     }
 }
 

--- a/crates/core/src/storage/memory.rs
+++ b/crates/core/src/storage/memory.rs
@@ -1,25 +1,87 @@
-use async_trait::async_trait;
-use dashmap::DashMap;
+//! In-memory key value storage.
+//!
+//! Budget law: a storage built with [`MemStorage::bounded`] never holds more than `capacity`
+//! keys. When a `put` of a new key would exceed the bound, the least recently written keys are
+//! retired first, one per excess key, so the bound restores before the new key is stored. A
+//! `put` that rewrites an existing key never retires another key. A storage built with
+//! [`MemStorage::new`] is unbounded.
 
+use std::num::NonZeroU32;
+use std::sync::RwLock;
+use std::sync::RwLockReadGuard;
+use std::sync::RwLockWriteGuard;
+
+use async_trait::async_trait;
+
+use super::write_ordered::WriteOrderedMap;
+use crate::error::Error;
 use crate::error::Result;
 use crate::storage::KvStorageInterface;
 
-/// In-memory storage implementation backed by a concurrent map.
-#[derive(Debug, Default)]
-pub struct MemStorage<V>
-where V: Clone
-{
-    table: DashMap<String, V>,
+/// The table behind the lock together with its key budget.
+#[derive(Debug)]
+struct MemTable<V> {
+    slots: WriteOrderedMap<V>,
+    capacity: Option<NonZeroU32>,
 }
 
-impl<V> MemStorage<V>
-where V: Clone
-{
-    /// Create an empty memory storage table.
+impl<V> MemTable<V> {
+    fn new(capacity: Option<NonZeroU32>) -> Self {
+        Self {
+            slots: WriteOrderedMap::default(),
+            capacity,
+        }
+    }
+
+    /// Store `value` under `key`, restoring the key budget first.
+    ///
+    /// Post: `slots.len() <= capacity` when a bound is set.
+    fn put(&mut self, key: String, value: V) {
+        if let Some(capacity) = self.capacity.filter(|_| !self.slots.contains(&key)) {
+            let capacity = capacity.get() as usize;
+            while self.slots.len() >= capacity {
+                if self.slots.pop_oldest().is_none() {
+                    break;
+                }
+            }
+        }
+        self.slots.insert(key, value);
+    }
+}
+
+/// In-memory storage implementation ordered by write recency.
+#[derive(Debug)]
+pub struct MemStorage<V> {
+    table: RwLock<MemTable<V>>,
+}
+
+impl<V> Default for MemStorage<V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<V> MemStorage<V> {
+    /// Create an unbounded memory storage table.
     pub fn new() -> Self {
         Self {
-            table: DashMap::default(),
+            table: RwLock::new(MemTable::new(None)),
         }
+    }
+
+    /// Create a memory storage table holding at most `capacity` keys.
+    pub fn bounded(capacity: NonZeroU32) -> Self {
+        Self {
+            table: RwLock::new(MemTable::new(Some(capacity))),
+        }
+    }
+
+    fn read(&self) -> Result<RwLockReadGuard<'_, MemTable<V>>> {
+        self.table.read().map_err(|_| Error::DHTSyncLockError)
+    }
+
+    fn write(&self) -> Result<RwLockWriteGuard<'_, MemTable<V>>> {
+        self.table.write().map_err(|_| Error::DHTSyncLockError)
     }
 }
 
@@ -29,33 +91,35 @@ impl<V> KvStorageInterface<V> for MemStorage<V>
 where V: Clone + Send + Sync
 {
     async fn get(&self, key: &str) -> Result<Option<V>> {
-        Ok(self.table.get(&key.to_string()).map(|v| v.value().clone()))
+        Ok(self.read()?.slots.get(key).cloned())
     }
 
     async fn put(&self, key: &str, value: &V) -> Result<()> {
-        self.table.insert(key.to_string(), value.clone());
+        self.write()?.put(key.to_owned(), value.clone());
         Ok(())
     }
 
     async fn get_all(&self) -> Result<Vec<(String, V)>> {
-        Ok(self.table.clone().into_iter().collect())
+        Ok(self
+            .read()?
+            .slots
+            .iter()
+            .map(|(key, value)| (key.to_owned(), value.clone()))
+            .collect())
     }
 
     async fn remove(&self, key: &str) -> Result<()> {
-        match self.get(key).await? {
-            Some(_) => self.table.remove(key),
-            None => None,
-        };
+        self.write()?.slots.remove(key);
         Ok(())
     }
 
     async fn clear(&self) -> Result<()> {
-        self.table.clear();
+        self.write()?.slots.clear();
         Ok(())
     }
 
     async fn count(&self) -> Result<u32> {
-        Ok(self.table.len() as u32)
+        Ok(self.read()?.slots.len() as u32)
     }
 }
 
@@ -64,6 +128,10 @@ where V: Clone + Send + Sync
 mod tests {
     use super::*;
     use crate::ecc::SecretKey;
+
+    fn capacity(keys: u32) -> NonZeroU32 {
+        NonZeroU32::new(keys).expect("test capacity is non-zero")
+    }
 
     #[tokio::test]
     async fn test_memstorage_basic_interface_should_work() {
@@ -77,5 +145,49 @@ mod tests {
 
         store.put(&addr, &"value 2".to_string()).await.unwrap();
         assert_eq!(store.get(&addr).await.unwrap(), Some("value 2".into()));
+    }
+
+    /// Budget law: a new key beyond the bound retires the least recently written key.
+    #[tokio::test]
+    async fn test_bounded_put_retires_least_recently_written_key() -> Result<()> {
+        let store = MemStorage::bounded(capacity(2));
+        store.put("a", &1u8).await?;
+        store.put("b", &2u8).await?;
+        store.put("c", &3u8).await?;
+
+        assert_eq!(store.count().await?, 2);
+        assert_eq!(store.get("a").await?, None);
+        assert_eq!(store.get("b").await?, Some(2));
+        assert_eq!(store.get("c").await?, Some(3));
+        Ok(())
+    }
+
+    /// Budget law: rewriting a stored key retires nothing and makes it the newest key.
+    #[tokio::test]
+    async fn test_bounded_rewrite_keeps_other_keys_and_refreshes_recency() -> Result<()> {
+        let store = MemStorage::bounded(capacity(2));
+        store.put("a", &1u8).await?;
+        store.put("b", &2u8).await?;
+        store.put("a", &3u8).await?;
+        assert_eq!(store.count().await?, 2);
+        assert_eq!(store.get("b").await?, Some(2));
+
+        store.put("c", &4u8).await?;
+        assert_eq!(store.get("b").await?, None);
+        assert_eq!(store.get("a").await?, Some(3));
+        assert_eq!(store.get("c").await?, Some(4));
+        Ok(())
+    }
+
+    /// An unbounded storage never retires a key.
+    #[tokio::test]
+    async fn test_unbounded_storage_keeps_every_key() -> Result<()> {
+        let store = MemStorage::new();
+        for index in 0..64u8 {
+            store.put(&index.to_string(), &index).await?;
+        }
+        assert_eq!(store.count().await?, 64);
+        assert_eq!(store.get("0").await?, Some(0));
+        Ok(())
     }
 }

--- a/crates/core/src/storage/memory.rs
+++ b/crates/core/src/storage/memory.rs
@@ -33,8 +33,9 @@ impl<V> MemTable<V> {
         }
     }
 
-    /// Whether storing `key` would add a key that the bound must make room for.
-    fn bound_applies_to(&self, key: &str) -> Option<usize> {
+    /// The key budget storing `key` must first restore: the bound, when one is set and `key`
+    /// is new; a rewrite competes with no other key.
+    fn budget_to_restore_for(&self, key: &str) -> Option<usize> {
         let capacity = self.capacity?;
         (!self.slots.contains(key)).then_some(capacity.get() as usize)
     }
@@ -43,12 +44,9 @@ impl<V> MemTable<V> {
     ///
     /// Post: `slots.len() <= capacity` when a bound is set.
     fn put(&mut self, key: String, value: V) {
-        if let Some(capacity) = self.bound_applies_to(&key) {
-            while self.slots.len() >= capacity {
-                if self.slots.pop_oldest().is_none() {
-                    break;
-                }
-            }
+        if let Some(capacity) = self.budget_to_restore_for(&key) {
+            // `len >= capacity >= 1` guarantees an oldest key to retire.
+            while self.slots.len() >= capacity && self.slots.pop_oldest().is_some() {}
         }
         self.slots.insert(key, value);
     }
@@ -125,7 +123,7 @@ where V: Clone + Send + Sync
 
     async fn count(&self) -> Result<u32> {
         let count = self.read()?.slots.len();
-        u32::try_from(count).map_err(|_| Error::MessageSizeOverflow)
+        u32::try_from(count).map_err(|_| Error::StorageCountOverflow)
     }
 }
 

--- a/crates/core/src/storage/memory.rs
+++ b/crates/core/src/storage/memory.rs
@@ -33,12 +33,17 @@ impl<V> MemTable<V> {
         }
     }
 
+    /// Whether storing `key` would add a key that the bound must make room for.
+    fn bound_applies_to(&self, key: &str) -> Option<usize> {
+        let capacity = self.capacity?;
+        (!self.slots.contains(key)).then_some(capacity.get() as usize)
+    }
+
     /// Store `value` under `key`, restoring the key budget first.
     ///
     /// Post: `slots.len() <= capacity` when a bound is set.
     fn put(&mut self, key: String, value: V) {
-        if let Some(capacity) = self.capacity.filter(|_| !self.slots.contains(&key)) {
-            let capacity = capacity.get() as usize;
+        if let Some(capacity) = self.bound_applies_to(&key) {
             while self.slots.len() >= capacity {
                 if self.slots.pop_oldest().is_none() {
                     break;
@@ -77,11 +82,11 @@ impl<V> MemStorage<V> {
     }
 
     fn read(&self) -> Result<RwLockReadGuard<'_, MemTable<V>>> {
-        self.table.read().map_err(|_| Error::DHTSyncLockError)
+        self.table.read().map_err(|_| Error::StorageLockPoisoned)
     }
 
     fn write(&self) -> Result<RwLockWriteGuard<'_, MemTable<V>>> {
-        self.table.write().map_err(|_| Error::DHTSyncLockError)
+        self.table.write().map_err(|_| Error::StorageLockPoisoned)
     }
 }
 
@@ -119,7 +124,8 @@ where V: Clone + Send + Sync
     }
 
     async fn count(&self) -> Result<u32> {
-        Ok(self.read()?.slots.len() as u32)
+        let count = self.read()?.slots.len();
+        u32::try_from(count).map_err(|_| Error::MessageSizeOverflow)
     }
 }
 

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -1,13 +1,13 @@
 //! Module of MemStorage and PersistenceStorage
 
+#[cfg(not(all(feature = "wasm", target_family = "wasm")))]
+/// Persistent storage for native runtimes.
+pub mod file;
 #[cfg(all(feature = "wasm", target_family = "wasm"))]
 /// IndexedDB-backed storage for browser runtimes.
 pub mod idb;
 /// In-memory key value storage.
 pub mod memory;
-#[cfg(not(all(feature = "wasm", target_family = "wasm")))]
-/// Persistent storage for native runtimes.
-pub mod sled;
 mod write_ordered;
 
 use async_trait::async_trait;

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -8,6 +8,7 @@ pub mod memory;
 #[cfg(not(all(feature = "wasm", target_family = "wasm")))]
 /// Persistent storage for native runtimes.
 pub mod sled;
+mod write_ordered;
 
 use async_trait::async_trait;
 

--- a/crates/core/src/storage/sled/mod.rs
+++ b/crates/core/src/storage/sled/mod.rs
@@ -205,7 +205,7 @@ where V: Serialize + DeserializeOwned + Sync
 
     async fn put(&self, key: &str, value: &V) -> Result<()> {
         let data = rings_codec::serialize(&(key, value)).map_err(Error::CodecSerialize)?;
-        let required = u64::try_from(data.len()).map_err(|_| Error::MessageSizeOverflow)?;
+        let required = u64::try_from(data.len()).map_err(|_| Error::StorageCountOverflow)?;
         if required > self.capacity {
             return Err(Error::StorageValueExceedsCapacity {
                 required,
@@ -273,7 +273,7 @@ where V: Serialize + DeserializeOwned + Sync
 
     async fn count(&self) -> Result<u32> {
         let count = self.read_index()?.files.len();
-        u32::try_from(count).map_err(|_| Error::MessageSizeOverflow)
+        u32::try_from(count).map_err(|_| Error::StorageCountOverflow)
     }
 }
 

--- a/crates/core/src/storage/sled/mod.rs
+++ b/crates/core/src/storage/sled/mod.rs
@@ -1,10 +1,24 @@
 #![deny(missing_docs)]
 
-//! Persistent native key-value storage.
+//! Persistent native key-value storage: one file per key under a byte budget.
+//!
+//! Budget law: the bytes of every stored file sum to at most `capacity`. A `put` whose value
+//! would exceed the budget first retires the least recently written *other* keys until the
+//! value fits; a value larger than the whole budget is rejected with
+//! `Error::StorageValueExceedsCapacity` and changes nothing. The budget is also restored when
+//! the storage is opened, so lowering the configured capacity retires the oldest files.
+//!
+//! The in-memory index mirrors the directory: it is rebuilt from the directory on open and
+//! updated by every write under the same lock, and the directory is owned exclusively by this
+//! instance while it is open. A retired file that fails to delete is dropped from the index and
+//! reclaimed by the next open.
 
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::RwLock;
+use std::sync::RwLockReadGuard;
+use std::sync::RwLockWriteGuard;
+use std::time::SystemTime;
 
 use async_trait::async_trait;
 use itertools::Itertools;
@@ -13,17 +27,53 @@ use serde::Serialize;
 use sha1::Digest;
 use sha1::Sha1;
 
+use super::write_ordered::WriteOrderedMap;
 use crate::error::Error;
 use crate::error::Result;
 use crate::storage::KvStorageInterface;
 
+/// The on-disk state known to this instance: file lengths by file name, in write order.
+#[derive(Debug, Default)]
+struct FileIndex {
+    files: WriteOrderedMap<u64>,
+    used_bytes: u64,
+}
+
+impl FileIndex {
+    /// Forget `name`, releasing its bytes from the budget.
+    ///
+    /// Post: `used_bytes` no longer counts `name`.
+    fn forget(&mut self, name: &str) {
+        if let Some(len) = self.files.remove(name) {
+            self.used_bytes = self.used_bytes.saturating_sub(len);
+        }
+    }
+
+    /// Record `name` as the most recently written file of `len` bytes.
+    fn record(&mut self, name: String, len: u64) {
+        self.forget(&name);
+        self.files.insert(name, len);
+        self.used_bytes = self.used_bytes.saturating_add(len);
+    }
+
+    /// Forget the least recently written file, returning its name.
+    fn retire_oldest(&mut self) -> Option<String> {
+        let (name, len) = self.files.pop_oldest()?;
+        self.used_bytes = self.used_bytes.saturating_sub(len);
+        Some(name)
+    }
+
+    fn forget_all(&mut self) {
+        self.files.clear();
+        self.used_bytes = 0;
+    }
+}
+
 /// StorageInstance struct
-#[allow(dead_code)]
 pub struct SledStorage {
     root: PathBuf,
-    lock: RwLock<()>,
-    cap: u32,
-    path: String,
+    capacity: u64,
+    index: RwLock<FileIndex>,
 }
 
 impl SledStorage {
@@ -33,30 +83,84 @@ impl SledStorage {
     pub async fn new_with_cap_and_path<P>(cap: u32, path: P) -> Result<Self>
     where P: AsRef<std::path::Path> {
         std::fs::create_dir_all(path.as_ref()).map_err(Error::ServiceIOError)?;
-        Ok(Self {
+        let storage = Self {
             root: path.as_ref().to_path_buf(),
-            lock: RwLock::new(()),
-            cap,
-            path: path.as_ref().to_string_lossy().to_string(),
-        })
+            capacity: u64::from(cap),
+            index: RwLock::new(FileIndex::default()),
+        };
+        let mut index = storage.index.write().map_err(|_| Error::DHTSyncLockError)?;
+        *index = storage.scan_directory()?;
+        storage.retire_until_fits(&mut index, 0)?;
+        drop(index);
+        Ok(storage)
     }
 
     fn key_path(&self, key: &str) -> PathBuf {
-        let mut hasher = Sha1::new();
-        hasher.update(key.as_bytes());
-        self.root.join(hex::encode(hasher.finalize()))
+        self.root.join(file_name_for(key))
     }
 
-    fn entries(&self) -> Result<Vec<PathBuf>> {
-        match std::fs::read_dir(&self.root) {
-            Ok(entries) => Ok(entries
-                .flatten()
-                .map(|entry| entry.path())
-                .filter(|path| is_entry_path(path))
-                .collect_vec()),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
-            Err(error) => Err(Error::ServiceIOError(error)),
+    /// Rebuild the index from the directory, ordering files by their modification time so the
+    /// budget retires the oldest write first across restarts.
+    fn scan_directory(&self) -> Result<FileIndex> {
+        let entries = match std::fs::read_dir(&self.root) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(FileIndex::default());
+            }
+            Err(error) => return Err(Error::ServiceIOError(error)),
+        };
+        let mut files = Vec::new();
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(name) = entry_file_name(&path) else {
+                continue;
+            };
+            let metadata = std::fs::metadata(&path).map_err(Error::ServiceIOError)?;
+            let modified = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+            files.push((modified, name.to_owned(), metadata.len()));
         }
+        files.sort();
+        let mut index = FileIndex::default();
+        for (_, name, len) in files {
+            index.record(name, len);
+        }
+        Ok(index)
+    }
+
+    /// Retire least recently written files until `incoming` more bytes fit the budget.
+    ///
+    /// Pre: `incoming <= capacity`.
+    /// Post: `index.used_bytes + incoming <= capacity`.
+    fn retire_until_fits(&self, index: &mut FileIndex, incoming: u64) -> Result<()> {
+        while index.used_bytes.saturating_add(incoming) > self.capacity {
+            let Some(name) = index.retire_oldest() else {
+                break;
+            };
+            remove_file_if_present(&self.root.join(name))?;
+        }
+        Ok(())
+    }
+
+    fn read_index(&self) -> Result<RwLockReadGuard<'_, FileIndex>> {
+        self.index.read().map_err(|_| Error::DHTSyncLockError)
+    }
+
+    fn write_index(&self) -> Result<RwLockWriteGuard<'_, FileIndex>> {
+        self.index.write().map_err(|_| Error::DHTSyncLockError)
+    }
+}
+
+fn file_name_for(key: &str) -> String {
+    let mut hasher = Sha1::new();
+    hasher.update(key.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn remove_file_if_present(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(Error::ServiceIOError(error)),
     }
 }
 
@@ -65,7 +169,7 @@ impl<V> KvStorageInterface<V> for SledStorage
 where V: Serialize + DeserializeOwned + Sync
 {
     async fn get(&self, key: &str) -> Result<Option<V>> {
-        let _guard = self.lock.read().map_err(|_| Error::DHTSyncLockError)?;
+        let _guard = self.read_index()?;
         match std::fs::read(self.key_path(key)) {
             Ok(data) => {
                 let (stored_key, value): (String, V) =
@@ -82,64 +186,73 @@ where V: Serialize + DeserializeOwned + Sync
     }
 
     async fn put(&self, key: &str, value: &V) -> Result<()> {
-        let _guard = self.lock.write().map_err(|_| Error::DHTSyncLockError)?;
-        std::fs::create_dir_all(&self.root).map_err(Error::ServiceIOError)?;
         let data = rings_codec::serialize(&(key, value)).map_err(Error::CodecSerialize)?;
+        let required = data.len() as u64;
+        if required > self.capacity {
+            return Err(Error::StorageValueExceedsCapacity {
+                required,
+                capacity: self.capacity,
+            });
+        }
+        let mut index = self.write_index()?;
+        let name = file_name_for(key);
+        // The rewritten key does not compete with itself for the budget.
+        index.forget(&name);
+        self.retire_until_fits(&mut index, required)?;
+        std::fs::create_dir_all(&self.root).map_err(Error::ServiceIOError)?;
         tracing::debug!("Try inserting key: {:?}", key);
-        let path = self.key_path(key);
+        let path = self.root.join(&name);
         let tmp_path = path.with_extension("tmp");
         std::fs::write(&tmp_path, data).map_err(Error::ServiceIOError)?;
         std::fs::rename(tmp_path, path).map_err(Error::ServiceIOError)?;
+        index.record(name, required);
         Ok(())
     }
 
     async fn get_all(&self) -> Result<Vec<(String, V)>> {
-        let _guard = self.lock.read().map_err(|_| Error::DHTSyncLockError)?;
-        Ok(self
-            .entries()?
-            .into_iter()
-            .flat_map(|path| {
-                let data = std::fs::read(path).ok()?;
+        let index = self.read_index()?;
+        Ok(index
+            .files
+            .iter()
+            .flat_map(|(name, _)| {
+                let data = std::fs::read(self.root.join(name)).ok()?;
                 rings_codec::deserialize::<(String, V)>(&data).ok()
             })
             .collect_vec())
     }
 
     async fn remove(&self, key: &str) -> Result<()> {
-        let _guard = self.lock.write().map_err(|_| Error::DHTSyncLockError)?;
-        match std::fs::remove_file(self.key_path(key)) {
-            Ok(()) => Ok(()),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(error) => Err(Error::ServiceIOError(error)),
-        }
+        let mut index = self.write_index()?;
+        remove_file_if_present(&self.key_path(key))?;
+        index.forget(&file_name_for(key));
+        Ok(())
     }
 
     async fn clear(&self) -> Result<()> {
-        let _guard = self.lock.write().map_err(|_| Error::DHTSyncLockError)?;
-        for path in self.entries()? {
-            std::fs::remove_file(path).map_err(Error::ServiceIOError)?;
+        let mut index = self.write_index()?;
+        for (name, _) in index.files.iter() {
+            std::fs::remove_file(self.root.join(name)).map_err(Error::ServiceIOError)?;
         }
+        index.forget_all();
         Ok(())
     }
 
     async fn count(&self) -> Result<u32> {
-        let _guard = self.lock.read().map_err(|_| Error::DHTSyncLockError)?;
-        Ok(self.entries()?.len() as u32)
+        Ok(self.read_index()?.files.len() as u32)
     }
 }
 
-fn is_entry_path(path: &Path) -> bool {
-    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
-        return false;
-    };
-    file_name.len() == 40 && file_name.as_bytes().iter().all(u8::is_ascii_hexdigit)
+fn entry_file_name(path: &Path) -> Option<&str> {
+    let file_name = path.file_name().and_then(|name| name.to_str())?;
+    (file_name.len() == 40 && file_name.as_bytes().iter().all(u8::is_ascii_hexdigit))
+        .then_some(file_name)
 }
 
 impl std::fmt::Debug for SledStorage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SledStorage")
-            .field("cap", &self.cap)
-            .field("path", &self.path)
+            .field("capacity", &self.capacity)
+            .field("root", &self.root)
             .finish()
     }
 }

--- a/crates/core/src/storage/sled/mod.rs
+++ b/crates/core/src/storage/sled/mod.rs
@@ -8,10 +8,14 @@
 //! `Error::StorageValueExceedsCapacity` and changes nothing. The budget is also restored when
 //! the storage is opened, so lowering the configured capacity retires the oldest files.
 //!
-//! The in-memory index mirrors the directory: it is rebuilt from the directory on open and
-//! updated by every write under the same lock, and the directory is owned exclusively by this
-//! instance while it is open. A retired file that fails to delete is dropped from the index and
-//! reclaimed by the next open.
+//! Index law: the in-memory index mirrors the directory. It is rebuilt from the directory on
+//! open (stale `.tmp` files from an interrupted write are removed then), every write updates it
+//! under the same lock only after the file system operation succeeded, and the directory is
+//! owned exclusively by this instance while it is open.
+//!
+//! Decode law: the store holds only records decodable as `V`. A record the current schema
+//! cannot decode (written by an earlier build) is retired on the read that discovers it and
+//! reported absent, so it neither serves stale data nor occupies the budget.
 
 use std::path::Path;
 use std::path::PathBuf;
@@ -62,11 +66,6 @@ impl FileIndex {
         self.used_bytes = self.used_bytes.saturating_sub(len);
         Some(name)
     }
-
-    fn forget_all(&mut self) {
-        self.files.clear();
-        self.used_bytes = 0;
-    }
 }
 
 /// StorageInstance struct
@@ -88,15 +87,11 @@ impl SledStorage {
             capacity: u64::from(cap),
             index: RwLock::new(FileIndex::default()),
         };
-        let mut index = storage.index.write().map_err(|_| Error::DHTSyncLockError)?;
+        let mut index = storage.write_index()?;
         *index = storage.scan_directory()?;
         storage.retire_until_fits(&mut index, 0)?;
         drop(index);
         Ok(storage)
-    }
-
-    fn key_path(&self, key: &str) -> PathBuf {
-        self.root.join(file_name_for(key))
     }
 
     /// Rebuild the index from the directory, ordering files by their modification time so the
@@ -112,6 +107,10 @@ impl SledStorage {
         let mut files = Vec::new();
         for entry in entries.flatten() {
             let path = entry.path();
+            if path.extension().is_some_and(|extension| extension == "tmp") {
+                remove_file_if_present(&path)?;
+                continue;
+            }
             let Some(name) = entry_file_name(&path) else {
                 continue;
             };
@@ -142,11 +141,31 @@ impl SledStorage {
     }
 
     fn read_index(&self) -> Result<RwLockReadGuard<'_, FileIndex>> {
-        self.index.read().map_err(|_| Error::DHTSyncLockError)
+        self.index.read().map_err(|_| Error::StorageLockPoisoned)
     }
 
     fn write_index(&self) -> Result<RwLockWriteGuard<'_, FileIndex>> {
-        self.index.write().map_err(|_| Error::DHTSyncLockError)
+        self.index.write().map_err(|_| Error::StorageLockPoisoned)
+    }
+
+    /// Remove the record stored as `name` and forget it.
+    fn retire(&self, name: &str) -> Result<()> {
+        let mut index = self.write_index()?;
+        remove_file_if_present(&self.root.join(name))?;
+        index.forget(name);
+        Ok(())
+    }
+
+    /// Decode one record file, retiring it when the current schema cannot read it.
+    fn decode_record<V>(&self, name: &str, data: &[u8]) -> Result<Option<(String, V)>>
+    where V: DeserializeOwned {
+        match rings_codec::deserialize::<(String, V)>(data) {
+            Ok(record) => Ok(Some(record)),
+            Err(_) => {
+                self.retire(name)?;
+                Ok(None)
+            }
+        }
     }
 }
 
@@ -169,76 +188,92 @@ impl<V> KvStorageInterface<V> for SledStorage
 where V: Serialize + DeserializeOwned + Sync
 {
     async fn get(&self, key: &str) -> Result<Option<V>> {
-        let _guard = self.read_index()?;
-        match std::fs::read(self.key_path(key)) {
-            Ok(data) => {
-                let (stored_key, value): (String, V) =
-                    rings_codec::deserialize(&data).map_err(Error::CodecDeserialize)?;
-                if stored_key == key {
-                    Ok(Some(value))
-                } else {
-                    Ok(None)
-                }
+        let name = file_name_for(key);
+        let data = {
+            let _guard = self.read_index()?;
+            match std::fs::read(self.root.join(&name)) {
+                Ok(data) => data,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+                Err(error) => return Err(Error::ServiceIOError(error)),
             }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(error) => Err(Error::ServiceIOError(error)),
-        }
+        };
+        Ok(self
+            .decode_record::<V>(&name, &data)?
+            .filter(|(stored_key, _)| stored_key == key)
+            .map(|(_, value)| value))
     }
 
     async fn put(&self, key: &str, value: &V) -> Result<()> {
         let data = rings_codec::serialize(&(key, value)).map_err(Error::CodecSerialize)?;
-        let required = data.len() as u64;
+        let required = u64::try_from(data.len()).map_err(|_| Error::MessageSizeOverflow)?;
         if required > self.capacity {
             return Err(Error::StorageValueExceedsCapacity {
                 required,
                 capacity: self.capacity,
             });
         }
-        let mut index = self.write_index()?;
         let name = file_name_for(key);
-        // The rewritten key does not compete with itself for the budget.
-        index.forget(&name);
-        self.retire_until_fits(&mut index, required)?;
-        std::fs::create_dir_all(&self.root).map_err(Error::ServiceIOError)?;
-        tracing::debug!("Try inserting key: {:?}", key);
         let path = self.root.join(&name);
         let tmp_path = path.with_extension("tmp");
+        let mut index = self.write_index()?;
+        // The temporary file lives outside the index, so a failed write changes nothing.
+        std::fs::create_dir_all(&self.root).map_err(Error::ServiceIOError)?;
         std::fs::write(&tmp_path, data).map_err(Error::ServiceIOError)?;
-        std::fs::rename(tmp_path, path).map_err(Error::ServiceIOError)?;
+        tracing::debug!("Try inserting key: {:?}", key);
+        // The rewritten key does not compete with itself for the budget.
+        let previous_len = index.files.get(&name).copied();
+        index.forget(&name);
+        self.retire_until_fits(&mut index, required)?;
+        if let Err(error) = std::fs::rename(&tmp_path, &path) {
+            // The previous record is still on disk; keep the index faithful to it.
+            if let Some(previous_len) = previous_len {
+                index.record(name, previous_len);
+            }
+            remove_file_if_present(&tmp_path)?;
+            return Err(Error::ServiceIOError(error));
+        }
         index.record(name, required);
         Ok(())
     }
 
     async fn get_all(&self) -> Result<Vec<(String, V)>> {
-        let index = self.read_index()?;
-        Ok(index
-            .files
-            .iter()
-            .flat_map(|(name, _)| {
-                let data = std::fs::read(self.root.join(name)).ok()?;
-                rings_codec::deserialize::<(String, V)>(&data).ok()
-            })
-            .collect_vec())
+        let records = {
+            let index = self.read_index()?;
+            index
+                .files
+                .iter()
+                .map(|(name, _)| (name.to_owned(), std::fs::read(self.root.join(name))))
+                .collect_vec()
+        };
+        let mut decoded = Vec::with_capacity(records.len());
+        for (name, data) in records {
+            let data = match data {
+                Ok(data) => data,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(Error::ServiceIOError(error)),
+            };
+            if let Some(record) = self.decode_record::<V>(&name, &data)? {
+                decoded.push(record);
+            }
+        }
+        Ok(decoded)
     }
 
     async fn remove(&self, key: &str) -> Result<()> {
-        let mut index = self.write_index()?;
-        remove_file_if_present(&self.key_path(key))?;
-        index.forget(&file_name_for(key));
-        Ok(())
+        self.retire(&file_name_for(key))
     }
 
     async fn clear(&self) -> Result<()> {
         let mut index = self.write_index()?;
-        for (name, _) in index.files.iter() {
-            std::fs::remove_file(self.root.join(name)).map_err(Error::ServiceIOError)?;
+        while let Some(name) = index.retire_oldest() {
+            remove_file_if_present(&self.root.join(name))?;
         }
-        index.forget_all();
         Ok(())
     }
 
     async fn count(&self) -> Result<u32> {
-        Ok(self.read_index()?.files.len() as u32)
+        let count = self.read_index()?.files.len();
+        u32::try_from(count).map_err(|_| Error::MessageSizeOverflow)
     }
 }
 

--- a/crates/core/src/storage/sled/test_sled.rs
+++ b/crates/core/src/storage/sled/test_sled.rs
@@ -173,7 +173,7 @@ async fn test_reopen_restores_budget_in_write_order() {
             storage.put(key, &"v".to_string()).await.expect("put");
             let modified = std::time::SystemTime::UNIX_EPOCH
                 + std::time::Duration::from_secs(1_000 + index as u64);
-            std::fs::File::open(storage.key_path(key))
+            std::fs::File::open(storage.root.join(file_name_for(key)))
                 .expect("open file")
                 .set_modified(modified)
                 .expect("set modified");

--- a/crates/core/src/storage/sled/test_sled.rs
+++ b/crates/core/src/storage/sled/test_sled.rs
@@ -84,3 +84,112 @@ async fn test_kv_storage_put_delete() {
     drop(storage);
     let _ = std::fs::remove_dir_all(path);
 }
+
+fn temp_root(label: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "rings-file-kv-{label}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos()
+    ))
+}
+
+fn record_len(key: &str, value: &str) -> u32 {
+    rings_codec::serialize(&(key, value))
+        .expect("record serializes")
+        .len() as u32
+}
+
+async fn stored_keys(storage: &SledStorage) -> Vec<String> {
+    let mut keys = <SledStorage as KvStorageInterface<String>>::get_all(storage)
+        .await
+        .expect("get_all")
+        .into_iter()
+        .map(|(key, _)| key)
+        .collect::<Vec<_>>();
+    keys.sort();
+    keys
+}
+
+/// Budget law: a new key beyond the byte budget retires the least recently written keys until
+/// it fits, and a rewrite of a stored key does not compete with itself.
+#[tokio::test]
+async fn test_put_beyond_budget_retires_least_recently_written_keys() {
+    let root = temp_root("budget");
+    let one = record_len("a", "v");
+    let storage = SledStorage::new_with_cap_and_path(one * 2, &root)
+        .await
+        .expect("open");
+
+    storage.put("a", &"v".to_string()).await.expect("put a");
+    storage.put("b", &"v".to_string()).await.expect("put b");
+    storage.put("a", &"w".to_string()).await.expect("rewrite a");
+    assert_eq!(stored_keys(&storage).await, ["a", "b"]);
+
+    storage.put("c", &"v".to_string()).await.expect("put c");
+    assert_eq!(stored_keys(&storage).await, ["a", "c"]);
+    assert_eq!(
+        <SledStorage as KvStorageInterface<String>>::get(&storage, "b")
+            .await
+            .expect("get b"),
+        None
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+/// Budget law: a value larger than the whole budget is rejected and nothing is retired.
+#[tokio::test]
+async fn test_value_larger_than_budget_is_rejected_without_change() {
+    let root = temp_root("oversize");
+    let one = record_len("a", "v");
+    let storage = SledStorage::new_with_cap_and_path(one, &root)
+        .await
+        .expect("open");
+    storage.put("a", &"v".to_string()).await.expect("put a");
+
+    let oversize = "x".repeat(one as usize);
+    assert!(matches!(
+        storage.put("b", &oversize).await,
+        Err(Error::StorageValueExceedsCapacity { .. })
+    ));
+    assert_eq!(stored_keys(&storage).await, ["a"]);
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+/// Budget law across restarts: reopening rebuilds the index from the directory in modification
+/// order and restores a lowered budget by retiring the oldest files.
+#[tokio::test]
+async fn test_reopen_restores_budget_in_write_order() {
+    let root = temp_root("reopen");
+    let one = record_len("a", "v");
+    {
+        let storage = SledStorage::new_with_cap_and_path(one * 3, &root)
+            .await
+            .expect("open");
+        for (index, key) in ["a", "b", "c"].into_iter().enumerate() {
+            storage.put(key, &"v".to_string()).await.expect("put");
+            let modified = std::time::SystemTime::UNIX_EPOCH
+                + std::time::Duration::from_secs(1_000 + index as u64);
+            std::fs::File::open(storage.key_path(key))
+                .expect("open file")
+                .set_modified(modified)
+                .expect("set modified");
+        }
+    }
+
+    let reopened = SledStorage::new_with_cap_and_path(one * 2, &root)
+        .await
+        .expect("reopen");
+    assert_eq!(stored_keys(&reopened).await, ["b", "c"]);
+    assert_eq!(
+        <SledStorage as KvStorageInterface<String>>::count(&reopened)
+            .await
+            .expect("count"),
+        2
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/crates/core/src/storage/write_ordered.rs
+++ b/crates/core/src/storage/write_ordered.rs
@@ -7,8 +7,9 @@
 //!
 //! Invariant: `order` is the inverse of `written` restricted to `slots`, i.e.
 //! `order[slots[k].written] = k` for every stored `k`, and `written` is injective because it is
-//! drawn from a strictly increasing clock. Hence the least recently written key is the first
-//! key of `order`.
+//! drawn from a clock that strictly increases on every write. Hence the least recently written
+//! key is the first key of `order`. The clock saturates at `u64::MAX`, so the invariant is
+//! stated for fewer than `2^64` writes to one map, beyond any process lifetime.
 
 use std::collections::BTreeMap;
 

--- a/crates/core/src/storage/write_ordered.rs
+++ b/crates/core/src/storage/write_ordered.rs
@@ -76,6 +76,13 @@ impl<V> WriteOrderedMap<V> {
         Some(slot.value)
     }
 
+    /// The least recently written key, without removing it: what a backend that must succeed
+    /// at an external effect before forgetting a key (the file store) retires next.
+    #[cfg(not(all(feature = "wasm", target_family = "wasm")))]
+    pub(crate) fn oldest(&self) -> Option<&str> {
+        self.order.first_key_value().map(|(_, key)| key.as_str())
+    }
+
     /// Remove and return the least recently written key and its value.
     pub(crate) fn pop_oldest(&mut self) -> Option<(String, V)> {
         let (_, key) = self.order.pop_first()?;
@@ -113,6 +120,21 @@ mod tests {
         assert_eq!(map.pop_oldest(), Some(("b".to_owned(), 2)));
         assert_eq!(map.pop_oldest(), Some(("a".to_owned(), 3)));
         assert_eq!(map.pop_oldest(), None);
+    }
+
+    /// Law: `oldest` names the key `pop_oldest` would remove, and removes nothing.
+    #[cfg(not(all(feature = "wasm", target_family = "wasm")))]
+    #[test]
+    fn test_oldest_peeks_without_removing() {
+        let mut map = WriteOrderedMap::default();
+        assert_eq!(map.oldest(), None);
+        map.insert("a".to_owned(), 1);
+        map.insert("b".to_owned(), 2);
+
+        assert_eq!(map.oldest(), Some("a"));
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.pop_oldest(), Some(("a".to_owned(), 1)));
+        assert_eq!(map.oldest(), Some("b"));
     }
 
     /// Law: `order` and `slots` stay inverse under removal.

--- a/crates/core/src/storage/write_ordered.rs
+++ b/crates/core/src/storage/write_ordered.rs
@@ -1,0 +1,133 @@
+//! A string-keyed map that remembers the order in which keys were last written.
+//!
+//! Every bounded storage backend needs the same two facts about its keys: the value under a
+//! key, and which key was written least recently, so that a budget can be restored by retiring
+//! that key first. This map keeps both under one invariant instead of letting each backend
+//! maintain a parallel recency index.
+//!
+//! Invariant: `order` is the inverse of `written` restricted to `slots`, i.e.
+//! `order[slots[k].written] = k` for every stored `k`, and `written` is injective because it is
+//! drawn from a strictly increasing clock. Hence the least recently written key is the first
+//! key of `order`.
+
+use std::collections::BTreeMap;
+
+/// One stored value with the write sequence that placed it.
+#[derive(Debug)]
+struct Slot<V> {
+    written: u64,
+    value: V,
+}
+
+/// A map ordered by write recency.
+#[derive(Debug)]
+pub(crate) struct WriteOrderedMap<V> {
+    slots: BTreeMap<String, Slot<V>>,
+    order: BTreeMap<u64, String>,
+    clock: u64,
+}
+
+impl<V> Default for WriteOrderedMap<V> {
+    fn default() -> Self {
+        Self {
+            slots: BTreeMap::new(),
+            order: BTreeMap::new(),
+            clock: 0,
+        }
+    }
+}
+
+impl<V> WriteOrderedMap<V> {
+    /// The value stored under `key`.
+    pub(crate) fn get(&self, key: &str) -> Option<&V> {
+        self.slots.get(key).map(|slot| &slot.value)
+    }
+
+    /// Whether `key` is stored.
+    pub(crate) fn contains(&self, key: &str) -> bool {
+        self.slots.contains_key(key)
+    }
+
+    /// Number of stored keys.
+    pub(crate) fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// Store `value` under `key` as the most recently written key.
+    ///
+    /// Post: `key` is the last key of `order`; the previous value under `key`, if any, is
+    /// returned.
+    pub(crate) fn insert(&mut self, key: String, value: V) -> Option<V> {
+        let previous = self.remove(&key);
+        self.clock = self.clock.saturating_add(1);
+        self.order.insert(self.clock, key.clone());
+        self.slots.insert(key, Slot {
+            written: self.clock,
+            value,
+        });
+        previous
+    }
+
+    /// Remove `key`, returning its value.
+    pub(crate) fn remove(&mut self, key: &str) -> Option<V> {
+        let slot = self.slots.remove(key)?;
+        self.order.remove(&slot.written);
+        Some(slot.value)
+    }
+
+    /// Remove and return the least recently written key and its value.
+    pub(crate) fn pop_oldest(&mut self) -> Option<(String, V)> {
+        let (_, key) = self.order.pop_first()?;
+        let slot = self.slots.remove(&key)?;
+        Some((key, slot.value))
+    }
+
+    /// Every key and value, in key order.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&str, &V)> {
+        self.slots
+            .iter()
+            .map(|(key, slot)| (key.as_str(), &slot.value))
+    }
+
+    /// Remove every key.
+    pub(crate) fn clear(&mut self) {
+        self.slots.clear();
+        self.order.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Law: `pop_oldest` yields the key written least recently, and rewriting a key makes it
+    /// newest.
+    #[test]
+    fn test_rewrite_moves_key_to_newest() {
+        let mut map = WriteOrderedMap::default();
+        map.insert("a".to_owned(), 1);
+        map.insert("b".to_owned(), 2);
+
+        assert_eq!(map.insert("a".to_owned(), 3), Some(1));
+        assert_eq!(map.pop_oldest(), Some(("b".to_owned(), 2)));
+        assert_eq!(map.pop_oldest(), Some(("a".to_owned(), 3)));
+        assert_eq!(map.pop_oldest(), None);
+    }
+
+    /// Law: `order` and `slots` stay inverse under removal.
+    #[test]
+    fn test_remove_keeps_order_consistent() {
+        let mut map = WriteOrderedMap::default();
+        map.insert("a".to_owned(), 1);
+        map.insert("b".to_owned(), 2);
+        map.insert("c".to_owned(), 3);
+
+        assert_eq!(map.remove("a"), Some(1));
+        assert_eq!(map.remove("a"), None);
+        assert_eq!(map.len(), 2);
+        assert!(map.contains("c"));
+        assert_eq!(map.iter().map(|(key, _)| key).collect::<Vec<_>>(), [
+            "b", "c"
+        ]);
+    }
+}

--- a/crates/core/src/swarm/builder.rs
+++ b/crates/core/src/swarm/builder.rs
@@ -159,10 +159,10 @@ impl SwarmBuilder {
             ),
         );
 
-        let callback = RwLock::new(
+        let callback = Arc::new(RwLock::new(
             self.callback
                 .unwrap_or_else(|| Arc::new(DefaultCallback {})),
-        );
+        ));
 
         let transport = Arc::new(SwarmTransport::new(
             self.network_id,

--- a/crates/core/src/swarm/builder.rs
+++ b/crates/core/src/swarm/builder.rs
@@ -3,7 +3,6 @@
 //! [Swarm]
 
 use std::sync::Arc;
-use std::sync::RwLock;
 
 use rings_transport::webrtc_config::WebrtcUdpPortRange;
 
@@ -17,6 +16,7 @@ use crate::measure::MeasureImpl;
 use crate::session::SessionSk;
 use crate::swarm::callback::SharedSwarmCallback;
 use crate::swarm::callback::SwarmCallback;
+use crate::swarm::callback::SwarmCallbackSlot;
 use crate::swarm::transport::SwarmTransport;
 use crate::swarm::transport::SwarmTransportSettings;
 use crate::swarm::transport::SwarmWebrtcConfig;
@@ -159,10 +159,10 @@ impl SwarmBuilder {
             ),
         );
 
-        let callback = Arc::new(RwLock::new(
+        let callback = SwarmCallbackSlot::new(
             self.callback
                 .unwrap_or_else(|| Arc::new(DefaultCallback {})),
-        ));
+        );
 
         let transport = Arc::new(SwarmTransport::new(
             self.network_id,

--- a/crates/core/src/swarm/callback.rs
+++ b/crates/core/src/swarm/callback.rs
@@ -50,22 +50,61 @@ use inbound::ReassemblyClock;
 
 /// The application the swarm currently delivers to, replaceable through `Swarm::set_callback`;
 /// every delivery resolves it at delivery time.
-pub type SwarmCallbackSlot = Arc<RwLock<SharedSwarmCallback>>;
-
-/// Deliver a payload addressed to this node that did not arrive over a connection (a message
-/// drained from this node's relay inbox) through the same pipeline an inbound frame takes:
-/// application validation under the inbound deadline, handler dispatch, then `on_inbound`
-/// under the inbound deadline.
 ///
-/// Pre: `payload.transaction.destination == transport.dht.did` and the payload was verified by
-/// the caller (the inbox witness verifies it as of its hold instant).
-pub(crate) async fn deliver_local_payload(
-    transport: Arc<SwarmTransport>,
-    callback: SharedSwarmCallback,
-    payload: &MessagePayload,
-) -> crate::error::Result<()> {
-    let processor = InboundProcessor::new(transport, callback, ReassemblyClock::system());
-    inbound::deliver_local(&processor, payload).await
+/// Lock law: the slot is read for the duration of one clone and written for one replacement, so
+/// a poisoned slot (`Error::LockPoisoned`) is the only failure either can report.
+#[derive(Clone)]
+pub struct SwarmCallbackSlot(Arc<RwLock<SharedSwarmCallback>>);
+
+impl SwarmCallbackSlot {
+    /// A slot holding `callback`.
+    pub fn new(callback: SharedSwarmCallback) -> Self {
+        Self(Arc::new(RwLock::new(callback)))
+    }
+
+    /// The callback currently set.
+    pub fn current(&self) -> crate::error::Result<SharedSwarmCallback> {
+        Ok(self
+            .0
+            .read()
+            .map_err(|_| crate::error::Error::LockPoisoned)?
+            .clone())
+    }
+
+    /// Replace the callback for every later delivery.
+    pub fn replace(&self, callback: SharedSwarmCallback) -> crate::error::Result<()> {
+        *self
+            .0
+            .write()
+            .map_err(|_| crate::error::Error::LockPoisoned)? = callback;
+        Ok(())
+    }
+}
+
+/// Delivery of payloads addressed to this node that did not arrive over a connection (messages
+/// drained from this node's relay inbox), through the same pipeline an inbound frame takes:
+/// application validation under the inbound deadline, handler dispatch, then `on_inbound` under
+/// the inbound deadline. Built once per drain; the connection-shaped state of the processor is
+/// unused, as a drained payload is already whole.
+pub(crate) struct LocalDelivery {
+    processor: InboundProcessor,
+}
+
+impl LocalDelivery {
+    /// Deliver to `callback` through `transport`'s handlers.
+    pub(crate) fn new(transport: Arc<SwarmTransport>, callback: SharedSwarmCallback) -> Self {
+        Self {
+            processor: InboundProcessor::new(transport, callback, ReassemblyClock::system()),
+        }
+    }
+
+    /// Deliver one payload.
+    ///
+    /// Pre: `payload.transaction.destination` is this node and the payload was verified by the
+    /// caller (the inbox witness verifies it as of its hold instant).
+    pub(crate) async fn deliver(&self, payload: &MessagePayload) -> crate::error::Result<()> {
+        inbound::deliver_local(&self.processor, payload).await
+    }
 }
 
 pub use crate::error::CallbackError;

--- a/crates/core/src/swarm/callback.rs
+++ b/crates/core/src/swarm/callback.rs
@@ -54,16 +54,16 @@ use inbound::ReassemblyClock;
 /// Lock law: the slot is read for the duration of one clone and written for one replacement, so
 /// a poisoned slot (`Error::LockPoisoned`) is the only failure either can report.
 #[derive(Clone)]
-pub struct SwarmCallbackSlot(Arc<RwLock<SharedSwarmCallback>>);
+pub(crate) struct SwarmCallbackSlot(Arc<RwLock<SharedSwarmCallback>>);
 
 impl SwarmCallbackSlot {
     /// A slot holding `callback`.
-    pub fn new(callback: SharedSwarmCallback) -> Self {
+    pub(crate) fn new(callback: SharedSwarmCallback) -> Self {
         Self(Arc::new(RwLock::new(callback)))
     }
 
     /// The callback currently set.
-    pub fn current(&self) -> crate::error::Result<SharedSwarmCallback> {
+    pub(crate) fn current(&self) -> crate::error::Result<SharedSwarmCallback> {
         Ok(self
             .0
             .read()
@@ -72,7 +72,7 @@ impl SwarmCallbackSlot {
     }
 
     /// Replace the callback for every later delivery.
-    pub fn replace(&self, callback: SharedSwarmCallback) -> crate::error::Result<()> {
+    pub(crate) fn replace(&self, callback: SharedSwarmCallback) -> crate::error::Result<()> {
         *self
             .0
             .write()

--- a/crates/core/src/swarm/callback.rs
+++ b/crates/core/src/swarm/callback.rs
@@ -656,7 +656,8 @@ impl InboundProcessor {
                 return Err(e);
             }
         };
-        if !(payload.verify() && payload.transaction.verify()) {
+        let network_id = self.transport.network_id;
+        if !(payload.verify(network_id) && payload.transaction.verify(network_id)) {
             log_inbound_verification_failure(peer, &payload, msg.len());
             self.record_receive_failure(peer, authentication).await;
             return Err(crate::error::Error::InvalidMessage(
@@ -710,11 +711,12 @@ pub(super) struct PreparedInboundFrame {
 }
 
 fn prepare_transport_frame(
+    network_id: u32,
     peer: Option<Did>,
     bytes: &[u8],
 ) -> crate::error::Result<PreparedInboundFrame> {
     let payload = MessagePayload::from_wire(bytes)?;
-    if !(payload.transaction.verify() && payload.verify()) {
+    if !(payload.transaction.verify(network_id) && payload.verify(network_id)) {
         log_inbound_verification_failure(peer, &payload, bytes.len());
         return Err(crate::error::Error::InvalidMessage(
             "message verification failed or message expired".to_string(),
@@ -733,9 +735,10 @@ fn prepare_transport_frame(
 
 #[cfg(all(test, feature = "dummy", not(target_family = "wasm")))]
 pub(crate) fn prepare_transport_frame_lane_for_test(
+    network_id: u32,
     bytes: &[u8],
 ) -> crate::error::Result<InboundLane> {
-    prepare_transport_frame(None, bytes).map(|prepared| prepared.lane)
+    prepare_transport_frame(network_id, None, bytes).map(|prepared| prepared.lane)
 }
 
 impl InnerSwarmCallback {
@@ -752,7 +755,11 @@ impl InnerSwarmCallback {
         let authentication = peer.map_or(Authentication::Unauthenticated, |peer| {
             self.processor.peer_authentication(peer)
         });
-        let prepared = match prepare_transport_frame(peer, msg.as_ref()) {
+        let prepared = match prepare_transport_frame(
+            self.processor.transport.network_id,
+            peer,
+            msg.as_ref(),
+        ) {
             Ok(prepared) => prepared,
             Err(error) => {
                 self.processor

--- a/crates/core/src/swarm/callback.rs
+++ b/crates/core/src/swarm/callback.rs
@@ -82,19 +82,19 @@ impl SwarmCallbackSlot {
 }
 
 /// Delivery of payloads addressed to this node that did not arrive over a connection (messages
-/// drained from this node's relay inbox), through the same pipeline an inbound frame takes:
+/// drained from this node's relay inbox), through the logical stage of the inbound pipeline:
 /// application validation under the inbound deadline, handler dispatch, then `on_inbound` under
-/// the inbound deadline. Built once per drain; the connection-shaped state of the processor is
-/// unused, as a drained payload is already whole.
+/// the inbound deadline. A drained payload is already whole and admitted, so it needs nothing
+/// of the connection stage (reassembly, admission gates).
 pub(crate) struct LocalDelivery {
-    processor: InboundProcessor,
+    pipeline: LogicalInbound,
 }
 
 impl LocalDelivery {
     /// Deliver to `callback` through `transport`'s handlers.
     pub(crate) fn new(transport: Arc<SwarmTransport>, callback: SharedSwarmCallback) -> Self {
         Self {
-            processor: InboundProcessor::new(transport, callback, ReassemblyClock::system()),
+            pipeline: LogicalInbound::new(transport, callback),
         }
     }
 
@@ -103,7 +103,7 @@ impl LocalDelivery {
     /// Pre: `payload.transaction.destination` is this node and the payload was verified by the
     /// caller (the inbox witness verifies it as of its hold instant).
     pub(crate) async fn deliver(&self, payload: &MessagePayload) -> crate::error::Result<()> {
-        inbound::deliver_local(&self.processor, payload).await
+        inbound::deliver_local(&self.pipeline, payload).await
     }
 }
 
@@ -234,11 +234,82 @@ pub trait SwarmCallback {
     }
 }
 
+/// The logical stage of the inbound pipeline, independent of any connection: application
+/// validation, handler dispatch, and `on_inbound`. An [`InboundProcessor`] runs it once a
+/// connection's frames are reassembled and admitted; [`LocalDelivery`] runs it alone.
 #[derive(Clone)]
-pub(super) struct InboundProcessor {
+pub(super) struct LogicalInbound {
     transport: Arc<SwarmTransport>,
     message_handler: MessageHandler,
     callback: SharedSwarmCallback,
+}
+
+impl LogicalInbound {
+    fn new(transport: Arc<SwarmTransport>, callback: SharedSwarmCallback) -> Self {
+        let message_handler = MessageHandler::new(transport.clone(), callback.clone());
+        Self {
+            transport,
+            message_handler,
+            callback,
+        }
+    }
+
+    pub(super) async fn handle_payload(
+        &self,
+        payload: &MessagePayload,
+        prepared_message: Option<Message>,
+    ) -> crate::error::Result<()> {
+        let message = match prepared_message {
+            Some(message) => message,
+            None => payload.transaction.data()?,
+        };
+
+        macro_rules! dispatch_message_body {
+            (Chunk, $msg:expr) => {{
+                let _ = $msg;
+                Err(crate::error::Error::InboundActorInvariantViolation)
+            }};
+            ($variant:ident, $msg:expr) => {
+                self.message_handler.handle(payload, $msg).await
+            };
+        }
+        macro_rules! dispatch_message {
+            ($( $(#[$docs:meta])* $index:literal => $variant:ident($body:ty): $class:ident, $storage_route:ident ),+ $(,)?) => {
+                match message {
+                    $(Message::$variant(ref msg) => dispatch_message_body!($variant, msg)),+
+                }
+            };
+        }
+
+        let result = with_message_variants!(dispatch_message);
+
+        // A handler that errored must not then be reported to the application as a successful
+        // inbound message: surface the error and do not run `on_inbound` for it.
+        if let Err(e) = result {
+            tracing::error!("Failed to handle_payload: {e:?}");
+            return Err(e);
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn is_local_destination(&self, payload: &MessagePayload) -> bool {
+        payload.transaction.destination == self.transport.dht.did
+    }
+
+    pub(super) async fn on_inbound(
+        &self,
+        payload: &MessagePayload,
+    ) -> std::result::Result<(), CallbackError> {
+        self.callback.on_inbound(payload).await
+    }
+}
+
+/// The connection stage of the inbound pipeline for one connection: reassembly and admission
+/// gates in front of the logical stage.
+#[derive(Clone)]
+pub(super) struct InboundProcessor {
+    logical: LogicalInbound,
     reassembler: Arc<FuturesMutex<MessageReassembler>>,
     reassembly_clock: ReassemblyClock,
     pending_attempt: Arc<Mutex<Option<PendingConnectionAttempt>>>,
@@ -256,15 +327,12 @@ impl InboundProcessor {
         callback: SharedSwarmCallback,
         reassembly_clock: ReassemblyClock,
     ) -> Self {
-        let message_handler = MessageHandler::new(transport.clone(), callback.clone());
         let reassembler = MessageReassembler::with_limits_and_budget(
             transport.reassembly_limits(),
             transport.reassembly_budget(),
         );
         Self {
-            transport,
-            message_handler,
-            callback,
+            logical: LogicalInbound::new(transport, callback),
             reassembler: Arc::new(FuturesMutex::new(reassembler)),
             reassembly_clock,
             pending_attempt: Arc::new(Mutex::new(None)),
@@ -289,7 +357,12 @@ impl InboundProcessor {
         let Some(attempt) = self.pending_attempt() else {
             return Authentication::Unauthenticated;
         };
-        if attempt.peer() == peer && self.transport.is_admitted_connection_attempt(attempt) {
+        if attempt.peer() == peer
+            && self
+                .logical
+                .transport
+                .is_admitted_connection_attempt(attempt)
+        {
             Authentication::Authenticated
         } else {
             Authentication::Unauthenticated
@@ -302,7 +375,8 @@ impl InboundProcessor {
         authentication: Authentication,
     ) {
         if let Some(peer) = peer {
-            self.transport
+            self.logical
+                .transport
                 .record_peer_message_receive_failed(peer, authentication)
                 .await;
         }
@@ -415,6 +489,7 @@ impl InnerSwarmCallback {
                 attempt.peer()
             );
             self.processor
+                .logical
                 .transport
                 .cancel_pending_connection(attempt)
                 .await?;
@@ -422,6 +497,7 @@ impl InnerSwarmCallback {
         }
         if !self
             .processor
+            .logical
             .transport
             .begin_ready_connection_admission(attempt)?
         {
@@ -430,6 +506,7 @@ impl InnerSwarmCallback {
 
         match self
             .processor
+            .logical
             .message_handler
             .admit_dht_attempt(attempt)
             .await
@@ -439,6 +516,7 @@ impl InnerSwarmCallback {
             Err(error) => {
                 if let Err(cleanup_error) = self
                     .processor
+                    .logical
                     .transport
                     .cancel_pending_connection(attempt)
                     .await
@@ -455,11 +533,13 @@ impl InnerSwarmCallback {
         }
 
         self.processor
+            .logical
             .transport
             .record_peer_connected(attempt)
             .await;
         if !self
             .processor
+            .logical
             .transport
             .is_admitted_connection_attempt(attempt)
         {
@@ -473,11 +553,16 @@ impl InnerSwarmCallback {
         did: Did,
         attempt: PendingConnectionAttempt,
     ) -> Result<bool, CallbackError> {
-        let delivery = self.processor.transport.swarm_event_delivery_lock(did);
+        let delivery = self
+            .processor
+            .logical
+            .transport
+            .swarm_event_delivery_lock(did);
         let result = async {
             let delivery_turn = delivery.acquire().await;
             if !self
                 .processor
+                .logical
                 .transport
                 .is_admitted_connection_attempt(attempt)
             {
@@ -494,6 +579,7 @@ impl InnerSwarmCallback {
         }
         .await;
         self.processor
+            .logical
             .transport
             .prune_swarm_event_delivery_lock(did, &delivery);
         result
@@ -505,12 +591,17 @@ impl InnerSwarmCallback {
         state: WebrtcConnectionState,
         attempt: Option<PendingConnectionAttempt>,
     ) -> Result<(), CallbackError> {
-        let delivery = self.processor.transport.swarm_event_delivery_lock(did);
+        let delivery = self
+            .processor
+            .logical
+            .transport
+            .swarm_event_delivery_lock(did);
         let result = async {
             let delivery_turn = delivery.acquire().await;
             if let Some(attempt) = attempt {
                 match self
                     .processor
+                    .logical
                     .transport
                     .connection_event_disposition(attempt)?
                 {
@@ -532,6 +623,7 @@ impl InnerSwarmCallback {
         }
         .await;
         self.processor
+            .logical
             .transport
             .prune_swarm_event_delivery_lock(did, &delivery);
         result
@@ -545,7 +637,7 @@ impl InnerSwarmCallback {
     ) -> Result<(), CallbackError> {
         let event = SwarmEvent::ConnectionStateChange { peer: did, state };
         delivery_turn
-            .poll_once_then_release(self.processor.callback.on_event(&event))
+            .poll_once_then_release(self.processor.logical.callback.on_event(&event))
             .await
     }
 
@@ -556,12 +648,13 @@ impl InnerSwarmCallback {
         attempt.peer() == did
             && !self
                 .processor
+                .logical
                 .transport
                 .is_admitted_connection_attempt(attempt)
     }
 
     fn is_local_did_event(&self, did: Did, operation: &str) -> bool {
-        if did != self.processor.transport.dht.did {
+        if did != self.processor.logical.transport.dht.did {
             return false;
         }
         tracing::warn!("ignoring {operation} for local DID {did}");
@@ -585,11 +678,13 @@ impl InnerSwarmCallback {
         );
         if self
             .processor
+            .logical
             .transport
             .cancel_pending_connection(attempt)
             .await?
         {
             self.processor
+                .logical
                 .transport
                 .record_peer_disconnected(attempt)
                 .await;
@@ -607,11 +702,13 @@ impl InnerSwarmCallback {
         };
         if self
             .processor
+            .logical
             .transport
             .cancel_pending_connection(attempt)
             .await?
         {
             self.processor
+                .logical
                 .transport
                 .record_peer_disconnected(attempt)
                 .await;
@@ -619,6 +716,7 @@ impl InnerSwarmCallback {
         }
         if self
             .processor
+            .logical
             .transport
             .is_admitted_connection_attempt(attempt)
         {
@@ -651,64 +749,21 @@ impl InboundProcessor {
                 "ignoring message from {peer}; pending attempt belongs to {}",
                 attempt.peer()
             );
-            self.transport.cancel_pending_connection(attempt).await?;
+            self.logical
+                .transport
+                .cancel_pending_connection(attempt)
+                .await?;
             return Ok(false);
         }
-        if !self.transport.is_admitted_connection_attempt(attempt) {
+        if !self
+            .logical
+            .transport
+            .is_admitted_connection_attempt(attempt)
+        {
             tracing::debug!("ignoring message from {peer}; pending connection is not admitted yet");
             return Ok(false);
         }
         Ok(true)
-    }
-
-    pub(super) async fn handle_payload(
-        &self,
-        payload: &MessagePayload,
-        prepared_message: Option<Message>,
-    ) -> crate::error::Result<()> {
-        let message = match prepared_message {
-            Some(message) => message,
-            None => payload.transaction.data()?,
-        };
-
-        macro_rules! dispatch_message_body {
-            (Chunk, $msg:expr) => {{
-                let _ = $msg;
-                Err(crate::error::Error::InboundActorInvariantViolation)
-            }};
-            ($variant:ident, $msg:expr) => {
-                self.message_handler.handle(payload, $msg).await
-            };
-        }
-        macro_rules! dispatch_message {
-            ($( $(#[$docs:meta])* $index:literal => $variant:ident($body:ty): $class:ident, $storage_route:ident ),+ $(,)?) => {
-                match message {
-                    $(Message::$variant(ref msg) => dispatch_message_body!($variant, msg)),+
-                }
-            };
-        }
-
-        let result = with_message_variants!(dispatch_message);
-
-        // A handler that errored must not then be reported to the application as a successful
-        // inbound message: surface the error and do not run `on_inbound` for it.
-        if let Err(e) = result {
-            tracing::error!("Failed to handle_payload: {e:?}");
-            return Err(e);
-        }
-
-        Ok(())
-    }
-
-    pub(super) fn is_local_destination(&self, payload: &MessagePayload) -> bool {
-        payload.transaction.destination == self.transport.dht.did
-    }
-
-    pub(super) async fn on_inbound(
-        &self,
-        payload: &MessagePayload,
-    ) -> std::result::Result<(), CallbackError> {
-        self.callback.on_inbound(payload).await
     }
 
     pub(super) async fn decode_verified_payload(
@@ -724,7 +779,7 @@ impl InboundProcessor {
                 return Err(e);
             }
         };
-        let network_id = self.transport.network_id;
+        let network_id = self.logical.transport.network_id;
         if !(payload.verify(network_id) && payload.transaction.verify(network_id)) {
             log_inbound_verification_failure(peer, &payload, msg.len());
             self.record_receive_failure(peer, authentication).await;
@@ -762,7 +817,8 @@ impl InboundProcessor {
             .map_err(|_| crate::error::Error::MessageSizeOverflow)?;
         if let (Some(peer), Some(attempt)) = (peer, self.pending_attempt()) {
             if attempt.peer() == peer {
-                self.transport
+                self.logical
+                    .transport
                     .record_peer_message_received(attempt, authentication, useful_bytes)
                     .await;
             }
@@ -824,7 +880,7 @@ impl InnerSwarmCallback {
             self.processor.peer_authentication(peer)
         });
         let prepared = match prepare_transport_frame(
-            self.processor.transport.network_id,
+            self.processor.logical.transport.network_id,
             peer,
             msg.as_ref(),
         ) {
@@ -927,16 +983,19 @@ impl TransportCallback for InnerSwarmCallback {
                 };
                 if !self
                     .processor
+                    .logical
                     .transport
                     .is_admitted_connection_attempt(attempt)
                 {
                     return Ok(());
                 }
                 self.processor
+                    .logical
                     .transport
                     .record_peer_disconnected(attempt)
                     .await;
                 self.processor
+                    .logical
                     .message_handler
                     .leave_dht_attempt(attempt)
                     .await?;
@@ -960,6 +1019,7 @@ impl TransportCallback for InnerSwarmCallback {
                     return Ok(());
                 };
                 self.processor
+                    .logical
                     .transport
                     .record_peer_disconnected(attempt)
                     .await;
@@ -1001,7 +1061,7 @@ impl TransportCallback for InnerSwarmCallback {
             .admit_pending_connection(did)
             .await
             .map_err(into_transport_callback_error)?
-            && !self.processor.transport.is_admitted_connection(did)
+            && !self.processor.logical.transport.is_admitted_connection(did)
         {
             tracing::debug!("ignoring late data-channel open for {did}");
         }
@@ -1042,16 +1102,19 @@ impl TransportCallback for InnerSwarmCallback {
         };
         if !self
             .processor
+            .logical
             .transport
             .is_admitted_connection_attempt(attempt)
         {
             return Ok(());
         }
         self.processor
+            .logical
             .transport
             .record_peer_disconnected(attempt)
             .await;
         self.processor
+            .logical
             .message_handler
             .leave_dht_attempt(attempt)
             .await?;

--- a/crates/core/src/swarm/callback.rs
+++ b/crates/core/src/swarm/callback.rs
@@ -3,6 +3,7 @@ use std::cell::Cell;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::RwLock;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -46,6 +47,26 @@ pub(crate) const fn inbound_peer_capacity_for_test() -> usize {
 }
 use inbound::InboundMailbox;
 use inbound::ReassemblyClock;
+
+/// The application the swarm currently delivers to, replaceable through `Swarm::set_callback`;
+/// every delivery resolves it at delivery time.
+pub type SwarmCallbackSlot = Arc<RwLock<SharedSwarmCallback>>;
+
+/// Deliver a payload addressed to this node that did not arrive over a connection (a message
+/// drained from this node's relay inbox) through the same pipeline an inbound frame takes:
+/// application validation under the inbound deadline, handler dispatch, then `on_inbound`
+/// under the inbound deadline.
+///
+/// Pre: `payload.transaction.destination == transport.dht.did` and the payload was verified by
+/// the caller (the inbox witness verifies it as of its hold instant).
+pub(crate) async fn deliver_local_payload(
+    transport: Arc<SwarmTransport>,
+    callback: SharedSwarmCallback,
+    payload: &MessagePayload,
+) -> crate::error::Result<()> {
+    let processor = InboundProcessor::new(transport, callback, ReassemblyClock::system());
+    inbound::deliver_local(&processor, payload).await
+}
 
 pub use crate::error::CallbackError;
 type TransportCallbackError = Box<dyn std::error::Error>;
@@ -191,6 +212,26 @@ pub struct InnerSwarmCallback {
 }
 
 impl InboundProcessor {
+    fn new(
+        transport: Arc<SwarmTransport>,
+        callback: SharedSwarmCallback,
+        reassembly_clock: ReassemblyClock,
+    ) -> Self {
+        let message_handler = MessageHandler::new(transport.clone(), callback.clone());
+        let reassembler = MessageReassembler::with_limits_and_budget(
+            transport.reassembly_limits(),
+            transport.reassembly_budget(),
+        );
+        Self {
+            transport,
+            message_handler,
+            callback,
+            reassembler: Arc::new(FuturesMutex::new(reassembler)),
+            reassembly_clock,
+            pending_attempt: Arc::new(Mutex::new(None)),
+        }
+    }
+
     fn pending_attempt(&self) -> Option<PendingConnectionAttempt> {
         *self
             .pending_attempt
@@ -245,19 +286,7 @@ impl InnerSwarmCallback {
         reassembly_clock: ReassemblyClock,
     ) -> Self {
         let inbound_capacity = transport.inbound_capacity();
-        let message_handler = MessageHandler::new(transport.clone(), callback.clone());
-        let reassembler = MessageReassembler::with_limits_and_budget(
-            transport.reassembly_limits(),
-            transport.reassembly_budget(),
-        );
-        let processor = InboundProcessor {
-            transport,
-            message_handler,
-            callback,
-            reassembler: Arc::new(FuturesMutex::new(reassembler)),
-            reassembly_clock: reassembly_clock.clone(),
-            pending_attempt: Arc::new(Mutex::new(None)),
-        };
+        let processor = InboundProcessor::new(transport, callback, reassembly_clock.clone());
         let inbound = InboundMailbox::spawn(processor.clone(), inbound_capacity, reassembly_clock);
         Self { processor, inbound }
     }

--- a/crates/core/src/swarm/callback/inbound.rs
+++ b/crates/core/src/swarm/callback/inbound.rs
@@ -718,6 +718,41 @@ async fn process_event(
     }
 }
 
+/// Offer `payload` to the application's `on_validate` under the inbound deadline.
+async fn validate_payload(
+    processor: &InboundProcessor,
+    peer: Option<Did>,
+    payload: &MessagePayload,
+) -> std::result::Result<(), InboundFailure> {
+    match await_inbound_deadline(
+        processor.callback.on_validate(payload),
+        INBOUND_CALLBACK_TIMEOUT,
+    )
+    .await
+    {
+        InboundDeadline::Completed(result) => result.map_err(InboundFailure::Validation),
+        InboundDeadline::TimedOut => Err(InboundFailure::ValidationTimeout { peer }),
+        InboundDeadline::TimerUnavailable => Err(InboundFailure::TimerUnavailable {
+            peer,
+            operation: "validation",
+        }),
+    }
+}
+
+/// Deliver a locally sourced payload: validation, dispatch, and `on_inbound`, exactly as for a
+/// verified frame from a connection, but with no connection to gate on.
+pub(super) async fn deliver_local(
+    processor: &InboundProcessor,
+    payload: &MessagePayload,
+) -> Result<()> {
+    validate_payload(processor, None, payload)
+        .await
+        .map_err(inbound_failure_error)?;
+    process_logical_message(processor, None, payload, None)
+        .await
+        .map_err(inbound_failure_error)
+}
+
 async fn validate_event(
     processor: &InboundProcessor,
     event: &InboundEvent,
@@ -729,23 +764,7 @@ async fn validate_event(
     {
         return Ok(InboundValidation::AcknowledgeDrop);
     }
-    match await_inbound_deadline(
-        processor.callback.on_validate(&event.payload),
-        INBOUND_CALLBACK_TIMEOUT,
-    )
-    .await
-    {
-        InboundDeadline::Completed(result) => result.map_err(InboundFailure::Validation)?,
-        InboundDeadline::TimedOut => {
-            return Err(InboundFailure::ValidationTimeout { peer: event.peer });
-        }
-        InboundDeadline::TimerUnavailable => {
-            return Err(InboundFailure::TimerUnavailable {
-                peer: event.peer,
-                operation: "validation",
-            });
-        }
-    }
+    validate_payload(processor, event.peer, &event.payload).await?;
     let still_admitted = processor
         .pending_connection_allows_message(event.peer)
         .await

--- a/crates/core/src/swarm/callback/inbound.rs
+++ b/crates/core/src/swarm/callback/inbound.rs
@@ -26,6 +26,7 @@ use futures::StreamExt;
 use rings_transport::core::callback::InboundFrameCapacityLease;
 
 use super::InboundProcessor;
+use super::LogicalInbound;
 use super::PreparedInboundFrame;
 use crate::dht::Did;
 use crate::error::Error;
@@ -704,7 +705,7 @@ async fn process_event(
     }
 
     let result = process_logical_message(
-        &processor,
+        &processor.logical,
         event.peer,
         &event.payload,
         event.prepared_message,
@@ -720,12 +721,12 @@ async fn process_event(
 
 /// Offer `payload` to the application's `on_validate` under the inbound deadline.
 async fn validate_payload(
-    processor: &InboundProcessor,
+    pipeline: &LogicalInbound,
     peer: Option<Did>,
     payload: &MessagePayload,
 ) -> std::result::Result<(), InboundFailure> {
     match await_inbound_deadline(
-        processor.callback.on_validate(payload),
+        pipeline.callback.on_validate(payload),
         INBOUND_CALLBACK_TIMEOUT,
     )
     .await
@@ -742,13 +743,13 @@ async fn validate_payload(
 /// Deliver a locally sourced payload: validation, dispatch, and `on_inbound`, exactly as for a
 /// verified frame from a connection, but with no connection to gate on.
 pub(super) async fn deliver_local(
-    processor: &InboundProcessor,
+    pipeline: &LogicalInbound,
     payload: &MessagePayload,
 ) -> Result<()> {
-    validate_payload(processor, None, payload)
+    validate_payload(pipeline, None, payload)
         .await
         .map_err(inbound_failure_error)?;
-    process_logical_message(processor, None, payload, None)
+    process_logical_message(pipeline, None, payload, None)
         .await
         .map_err(inbound_failure_error)
 }
@@ -764,7 +765,7 @@ async fn validate_event(
     {
         return Ok(InboundValidation::AcknowledgeDrop);
     }
-    validate_payload(processor, event.peer, &event.payload).await?;
+    validate_payload(&processor.logical, event.peer, &event.payload).await?;
     let still_admitted = processor
         .pending_connection_allows_message(event.peer)
         .await
@@ -777,19 +778,19 @@ async fn validate_event(
 }
 
 async fn process_logical_message(
-    processor: &InboundProcessor,
+    pipeline: &LogicalInbound,
     peer: Option<Did>,
     payload: &MessagePayload,
     prepared_message: Option<crate::message::Message>,
 ) -> std::result::Result<(), InboundFailure> {
-    processor
+    pipeline
         .handle_payload(payload, prepared_message)
         .await
         .map_err(InboundFailure::Core)?;
-    if !processor.is_local_destination(payload) {
+    if !pipeline.is_local_destination(payload) {
         return Ok(());
     }
-    match await_inbound_deadline(processor.on_inbound(payload), INBOUND_CALLBACK_TIMEOUT).await {
+    match await_inbound_deadline(pipeline.on_inbound(payload), INBOUND_CALLBACK_TIMEOUT).await {
         InboundDeadline::Completed(result) => result.map_err(InboundFailure::Callback),
         InboundDeadline::TimedOut => Err(InboundFailure::ProcessingTimeout { peer }),
         InboundDeadline::TimerUnavailable => Err(InboundFailure::TimerUnavailable {

--- a/crates/core/src/swarm/inbox.rs
+++ b/crates/core/src/swarm/inbox.rs
@@ -17,9 +17,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::dht::entry::inbox::inbox_key;
 use crate::dht::entry::Entry;
-use crate::dht::entry::EntryKind;
 use crate::dht::entry::EntryOperation;
 use crate::dht::InboxDelivery;
 use crate::dht::StorageKey;
@@ -59,7 +57,7 @@ impl InboxDelivery for SwarmInboxDelivery {
     /// was tombstoned unread.
     async fn deliver_inbox(&self) -> Result<()> {
         let now_ms = get_epoch_ms();
-        let key = StorageKey::new(EntryKind::RelayMessage, inbox_key(self.transport.dht.did));
+        let key = StorageKey::inbox_of(self.transport.dht.did);
         let Some(inbox) = self.transport.dht.live_storage_entry(key, now_ms).await? else {
             return Ok(());
         };

--- a/crates/core/src/swarm/inbox.rs
+++ b/crates/core/src/swarm/inbox.rs
@@ -19,8 +19,10 @@ use async_trait::async_trait;
 
 use crate::dht::entry::inbox::inbox_key;
 use crate::dht::entry::Entry;
+use crate::dht::entry::EntryKind;
 use crate::dht::entry::EntryOperation;
 use crate::dht::InboxDelivery;
+use crate::dht::StorageKey;
 use crate::error::Result;
 use crate::message::handlers::storage::operate_entry;
 use crate::swarm::callback::LocalDelivery;
@@ -57,7 +59,7 @@ impl InboxDelivery for SwarmInboxDelivery {
     /// was tombstoned unread.
     async fn deliver_inbox(&self) -> Result<()> {
         let now_ms = get_epoch_ms();
-        let key = inbox_key(self.transport.dht.did);
+        let key = StorageKey::new(EntryKind::RelayMessage, inbox_key(self.transport.dht.did));
         let Some(inbox) = self.transport.dht.live_storage_entry(key, now_ms).await? else {
             return Ok(());
         };

--- a/crates/core/src/swarm/inbox.rs
+++ b/crates/core/src/swarm/inbox.rs
@@ -1,0 +1,90 @@
+//! The swarm's interpretation of the storage maintenance intent to deliver this node's inbox.
+//!
+//! The inbox carrier `d + 1` lies in `d`'s own storage interval once `d` is online, so the
+//! predecessor's storage repair pass hands the held messages to `d`. Every storage maintenance
+//! pass the DHT emits [`InboxDelivery::deliver_inbox`]; this interpreter reads the inbox from
+//! local storage, retires at once every element that fails the witness under the local overlay,
+//! and then, element by element, delivers through the inbound pipeline (application validation,
+//! handler dispatch, `on_inbound`, each under the inbound deadline) and retires the delivered
+//! element by its add dot. Retiring per element makes progress durable: a pass cut short by its
+//! step deadline resumes after the last retired element instead of redelivering the same prefix.
+//! Delivery is at least once: an element held again between the read and its tombstone is
+//! delivered by the next pass, and a message rejected by the application is retired like a
+//! delivered one, as the inbound path drops it. The application is resolved at delivery time, so
+//! `Swarm::set_callback` after `listen` is honoured.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::dht::entry::inbox::inbox_key;
+use crate::dht::entry::Entry;
+use crate::dht::entry::EntryOperation;
+use crate::dht::InboxDelivery;
+use crate::error::Result;
+use crate::message::handlers::storage::operate_entry;
+use crate::swarm::callback::LocalDelivery;
+use crate::swarm::callback::SwarmCallbackSlot;
+use crate::swarm::transport::SwarmTransport;
+use crate::utils::get_epoch_ms;
+
+/// Delivery of this node's inbox to whichever application the swarm currently serves.
+pub(crate) struct SwarmInboxDelivery {
+    transport: Arc<SwarmTransport>,
+    callback: SwarmCallbackSlot,
+}
+
+impl SwarmInboxDelivery {
+    /// Deliver through `transport` to the application in `callback` at delivery time.
+    pub(crate) fn new(transport: Arc<SwarmTransport>, callback: SwarmCallbackSlot) -> Self {
+        Self {
+            transport,
+            callback,
+        }
+    }
+
+    /// Tombstone `removal` at the carrier's owner.
+    async fn retire(&self, removal: Entry) -> Result<()> {
+        operate_entry(self.transport.clone(), EntryOperation::Tombstone(removal)).await
+    }
+}
+
+#[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
+#[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
+impl InboxDelivery for SwarmInboxDelivery {
+    /// Post: every element of the locally stored inbox that passes the witness was offered to
+    /// the application and then tombstoned at its owner; every element that fails the witness
+    /// was tombstoned unread.
+    async fn deliver_inbox(&self) -> Result<()> {
+        let now_ms = get_epoch_ms();
+        let key = inbox_key(self.transport.dht.did);
+        let Some(inbox) = self.transport.dht.live_storage_entry(key, now_ms).await? else {
+            return Ok(());
+        };
+        if inbox.data.is_empty() {
+            return Ok(());
+        }
+        let drain = inbox.partition_inbox(now_ms, self.transport.network_id);
+        if !drain.rejected.crdt.dots.is_empty() {
+            tracing::warn!(
+                local = %self.transport.dht.did,
+                rejected = drain.rejected.crdt.dots.len(),
+                "relay inbox elements failed the witness and are retired undelivered"
+            );
+            self.retire(drain.rejected).await?;
+        }
+        let delivery = LocalDelivery::new(self.transport.clone(), self.callback.current()?);
+        for element in drain.deliverable {
+            if let Err(error) = delivery.deliver(&element.payload).await {
+                tracing::warn!(
+                    local = %self.transport.dht.did,
+                    tx_id = %element.payload.transaction.tx_id,
+                    error = ?error,
+                    "relay inbox message not accepted by the application"
+                );
+            }
+            self.retire(inbox.removal_of([element.dot])).await?;
+        }
+        Ok(())
+    }
+}

--- a/crates/core/src/swarm/mod.rs
+++ b/crates/core/src/swarm/mod.rs
@@ -50,15 +50,12 @@ impl Swarm {
 
     /// Get the local account public key used for E2E public-key negotiation.
     pub fn account_pubkey(&self) -> Result<PublicKey<33>> {
-        self.transport.session_sk().session().account_pubkey()
+        self.transport.session().account_pubkey()
     }
 
     /// Get the typed account verification public key.
     pub fn account_verification_pubkey(&self) -> Result<VerificationPublicKey> {
-        self.transport
-            .session_sk()
-            .session()
-            .account_verification_pubkey()
+        self.transport.session().account_verification_pubkey()
     }
 
     /// Get this swarm's network id.
@@ -87,11 +84,7 @@ impl Swarm {
     }
 
     fn callback(&self) -> Result<SharedSwarmCallback> {
-        Ok(self
-            .callback
-            .read()
-            .map_err(|_| Error::LockPoisoned)?
-            .clone())
+        self.callback.current()
     }
 
     fn inner_callback(&self) -> Result<InnerSwarmCallback> {
@@ -103,11 +96,7 @@ impl Swarm {
 
     /// Set callback for swarm.
     pub fn set_callback(&self, callback: SharedSwarmCallback) -> Result<()> {
-        let mut inner = self.callback.write().map_err(|_| Error::LockPoisoned)?;
-
-        *inner = callback;
-
-        Ok(())
+        self.callback.replace(callback)
     }
 
     /// Create [Stabilizer] for swarm; it delivers to whichever callback is set when it delivers.

--- a/crates/core/src/swarm/mod.rs
+++ b/crates/core/src/swarm/mod.rs
@@ -90,7 +90,7 @@ impl Swarm {
         Ok(self
             .callback
             .read()
-            .map_err(|_| Error::CallbackSyncLockError)?
+            .map_err(|_| Error::LockPoisoned)?
             .clone())
     }
 
@@ -103,10 +103,7 @@ impl Swarm {
 
     /// Set callback for swarm.
     pub fn set_callback(&self, callback: SharedSwarmCallback) -> Result<()> {
-        let mut inner = self
-            .callback
-            .write()
-            .map_err(|_| Error::CallbackSyncLockError)?;
+        let mut inner = self.callback.write().map_err(|_| Error::LockPoisoned)?;
 
         *inner = callback;
 

--- a/crates/core/src/swarm/mod.rs
+++ b/crates/core/src/swarm/mod.rs
@@ -114,8 +114,8 @@ impl Swarm {
     }
 
     /// Create [Stabilizer] for swarm.
-    pub fn stabilizer(&self) -> Stabilizer {
-        Stabilizer::new(self.transport.clone())
+    pub fn stabilizer(&self) -> Result<Stabilizer> {
+        Ok(Stabilizer::new(self.transport.clone(), self.callback()?))
     }
 
     /// Disconnect a connection. There are three steps:

--- a/crates/core/src/swarm/mod.rs
+++ b/crates/core/src/swarm/mod.rs
@@ -5,6 +5,7 @@
 mod builder;
 /// Callback interface for swarm
 pub mod callback;
+mod inbox;
 pub(crate) mod transport;
 
 use std::num::NonZeroUsize;
@@ -31,6 +32,7 @@ use crate::message::MessageVerificationExt;
 use crate::message::PayloadSender;
 use crate::swarm::callback::SharedSwarmCallback;
 use crate::swarm::callback::SwarmCallbackSlot;
+use crate::swarm::inbox::SwarmInboxDelivery;
 use crate::swarm::transport::SwarmTransport;
 
 /// The transport and dht management.
@@ -99,9 +101,16 @@ impl Swarm {
         self.callback.replace(callback)
     }
 
-    /// Create [Stabilizer] for swarm; it delivers to whichever callback is set when it delivers.
+    /// Create [Stabilizer] for swarm; its inbox-delivery intent is interpreted here, toward
+    /// whichever callback is set when it delivers.
     pub fn stabilizer(&self) -> Stabilizer {
-        Stabilizer::new(self.transport.clone(), self.callback.clone())
+        Stabilizer::new(
+            self.transport.clone(),
+            Arc::new(SwarmInboxDelivery::new(
+                self.transport.clone(),
+                self.callback.clone(),
+            )),
+        )
     }
 
     /// Disconnect a connection. There are three steps:

--- a/crates/core/src/swarm/mod.rs
+++ b/crates/core/src/swarm/mod.rs
@@ -210,7 +210,7 @@ impl Swarm {
         // The invoker should fix it before sending.
         let payload = MessagePayload::new_send(
             Message::ConnectNodeSend(offer_msg),
-            self.transport.session_sk(),
+            self.transport.message_signer(),
             self.did(),
             peer,
         )?;
@@ -221,7 +221,7 @@ impl Swarm {
     /// Answer the offer of remote connection. This function will verify the answer payload and
     /// will wrap the answer inside a payload with verification.
     pub async fn answer_offer(&self, offer_payload: MessagePayload) -> Result<MessagePayload> {
-        if !offer_payload.verify() {
+        if !offer_payload.verify(self.network_id()) {
             return Err(Error::VerifySignatureFailed);
         }
 
@@ -241,7 +241,7 @@ impl Swarm {
         // The invoker should fix it before sending.
         let answer_payload = MessagePayload::new_send(
             Message::ConnectNodeReport(answer_msg),
-            self.transport.session_sk(),
+            self.transport.message_signer(),
             self.did(),
             self.did(),
         )?;
@@ -252,7 +252,7 @@ impl Swarm {
     /// Accept the answer of remote connection. This function will verify the answer payload and
     /// will return its did with the connection.
     pub async fn accept_answer(&self, answer_payload: MessagePayload) -> Result<()> {
-        if !answer_payload.verify() {
+        if !answer_payload.verify(self.network_id()) {
             return Err(Error::VerifySignatureFailed);
         }
 

--- a/crates/core/src/swarm/mod.rs
+++ b/crates/core/src/swarm/mod.rs
@@ -9,7 +9,6 @@ pub(crate) mod transport;
 
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use std::sync::RwLock;
 
 pub use builder::SwarmBuilder;
 
@@ -31,6 +30,7 @@ use crate::message::MessagePayload;
 use crate::message::MessageVerificationExt;
 use crate::message::PayloadSender;
 use crate::swarm::callback::SharedSwarmCallback;
+use crate::swarm::callback::SwarmCallbackSlot;
 use crate::swarm::transport::SwarmTransport;
 
 /// The transport and dht management.
@@ -39,7 +39,7 @@ pub struct Swarm {
     pub(crate) dht: Arc<PeerRing>,
     /// Swarm transport.
     pub(crate) transport: Arc<SwarmTransport>,
-    callback: RwLock<SharedSwarmCallback>,
+    callback: SwarmCallbackSlot,
 }
 
 impl Swarm {
@@ -113,9 +113,9 @@ impl Swarm {
         Ok(())
     }
 
-    /// Create [Stabilizer] for swarm.
-    pub fn stabilizer(&self) -> Result<Stabilizer> {
-        Ok(Stabilizer::new(self.transport.clone(), self.callback()?))
+    /// Create [Stabilizer] for swarm; it delivers to whichever callback is set when it delivers.
+    pub fn stabilizer(&self) -> Stabilizer {
+        Stabilizer::new(self.transport.clone(), self.callback.clone())
     }
 
     /// Disconnect a connection. There are three steps:

--- a/crates/core/src/swarm/transport.rs
+++ b/crates/core/src/swarm/transport.rs
@@ -363,6 +363,11 @@ impl SwarmTransport {
         Ok(cursor.as_ref().map(|cursor| format!("{cursor:?}")))
     }
 
+    /// The session key this node authenticates with.
+    pub(crate) fn session_sk(&self) -> &SessionSk {
+        &self.session_sk
+    }
+
     /// Storage virtual-node positions required by this DHT protocol mode.
     pub(crate) fn dht_virtual_nodes(&self) -> u16 {
         self.dht_virtual_nodes

--- a/crates/core/src/swarm/transport.rs
+++ b/crates/core/src/swarm/transport.rs
@@ -326,7 +326,7 @@ impl SwarmTransport {
         let cursor = self
             .storage_repair_cursor
             .lock()
-            .map_err(|_| Error::DHTSyncLockError)?;
+            .map_err(|_| Error::LockPoisoned)?;
         let start = match cursor.as_ref() {
             Some(previous) => {
                 let next = ordered.partition_point(|candidate| candidate <= previous);
@@ -349,7 +349,7 @@ impl SwarmTransport {
         let mut cursor = self
             .storage_repair_cursor
             .lock()
-            .map_err(|_| Error::DHTSyncLockError)?;
+            .map_err(|_| Error::LockPoisoned)?;
         *cursor = Some(scheduled);
         Ok(())
     }
@@ -359,7 +359,7 @@ impl SwarmTransport {
         let cursor = self
             .storage_repair_cursor
             .lock()
-            .map_err(|_| Error::DHTSyncLockError)?;
+            .map_err(|_| Error::LockPoisoned)?;
         Ok(cursor.as_ref().map(|cursor| format!("{cursor:?}")))
     }
 

--- a/crates/core/src/swarm/transport.rs
+++ b/crates/core/src/swarm/transport.rs
@@ -51,6 +51,7 @@ use crate::message::ConnectNodeSend;
 use crate::message::DhtProtocolMode;
 use crate::message::Message;
 use crate::message::PayloadSender;
+use crate::session::Session;
 use crate::session::SessionSk;
 use crate::swarm::callback::InnerSwarmCallback;
 use crate::utils::get_epoch_ms_i64;
@@ -363,9 +364,9 @@ impl SwarmTransport {
         Ok(cursor.as_ref().map(|cursor| format!("{cursor:?}")))
     }
 
-    /// The session key this node authenticates with.
-    pub(crate) fn session_sk(&self) -> &SessionSk {
-        &self.session_sk
+    /// The session this node authenticates with: its public half and account authorization.
+    pub(crate) fn session(&self) -> Session {
+        self.session_sk.session()
     }
 
     /// Storage virtual-node positions required by this DHT protocol mode.

--- a/crates/core/src/swarm/transport/delivery.rs
+++ b/crates/core/src/swarm/transport/delivery.rs
@@ -29,7 +29,7 @@ use crate::measure::MeasureImpl;
 use crate::measure::MeasurementEvent;
 use crate::message::Message;
 use crate::message::MessagePayload;
-use crate::session::SessionSk;
+use crate::message::MessageSigner;
 use crate::utils::sleep;
 
 pub(super) const DATA_CHANNEL_SEND_ACCEPT_TIMEOUT: Duration = TRANSPORT_TIMEOUT_PROFILE.send_accept;
@@ -391,8 +391,8 @@ pub(super) async fn record_measurement(
 
 /// Frame one chunk into the bytes a data-channel send carries: wrap it in a `MessagePayload`
 /// addressed to `did` and serialize it. Pure (the only failure is serialization).
-pub(super) fn frame_chunk(session_sk: &SessionSk, did: Did, chunk: Chunk) -> Result<Bytes> {
-    let payload = MessagePayload::new_send(Message::Chunk(chunk), session_sk, did, did)?;
+pub(super) fn frame_chunk(signer: MessageSigner<'_>, did: Did, chunk: Chunk) -> Result<Bytes> {
+    let payload = MessagePayload::new_send(Message::Chunk(chunk), signer, did, did)?;
     #[cfg(all(test, feature = "dummy", not(target_family = "wasm")))]
     crate::simulation::record_outbound_submission(payload.transaction.tx_id);
     payload.to_wire()

--- a/crates/core/src/swarm/transport/delivery.rs
+++ b/crates/core/src/swarm/transport/delivery.rs
@@ -30,6 +30,7 @@ use crate::measure::MeasurementEvent;
 use crate::message::Message;
 use crate::message::MessagePayload;
 use crate::message::MessageSigner;
+use crate::session::SessionSk;
 use crate::utils::sleep;
 
 pub(super) const DATA_CHANNEL_SEND_ACCEPT_TIMEOUT: Duration = TRANSPORT_TIMEOUT_PROFILE.send_accept;
@@ -391,7 +392,11 @@ pub(super) async fn record_measurement(
 
 /// Frame one chunk into the bytes a data-channel send carries: wrap it in a `MessagePayload`
 /// addressed to `did` and serialize it. Pure (the only failure is serialization).
-pub(super) fn frame_chunk(signer: MessageSigner<'_>, did: Did, chunk: Chunk) -> Result<Bytes> {
+pub(super) fn frame_chunk(
+    signer: MessageSigner<&SessionSk>,
+    did: Did,
+    chunk: Chunk,
+) -> Result<Bytes> {
     let payload = MessagePayload::new_send(Message::Chunk(chunk), signer, did, did)?;
     #[cfg(all(test, feature = "dummy", not(target_family = "wasm")))]
     crate::simulation::record_outbound_submission(payload.transaction.tx_id);

--- a/crates/core/src/swarm/transport/outbound/transfer.rs
+++ b/crates/core/src/swarm/transport/outbound/transfer.rs
@@ -34,8 +34,7 @@ pub(in crate::swarm::transport) type ChunkFrames = Box<dyn Iterator<Item = Chunk
 enum FrameSource {
     Whole(Option<Bytes>),
     Chunked {
-        session_sk: SessionSk,
-        network_id: u32,
+        signer: MessageSigner<SessionSk>,
         chunks: ChunkFrames,
     },
 }
@@ -44,11 +43,7 @@ impl FrameSource {
     fn next_frame(&mut self, did: Did) -> Result<Option<(Bytes, &'static str)>> {
         match self {
             Self::Whole(frame) => Ok(frame.take().map(|bytes| (bytes, "whole_message"))),
-            Self::Chunked {
-                session_sk,
-                network_id,
-                chunks,
-            } => {
+            Self::Chunked { signer, chunks } => {
                 let Some(chunk) = chunks.next() else {
                     return Ok(None);
                 };
@@ -58,8 +53,7 @@ impl FrameSource {
                 } else {
                     "chunked_tail"
                 };
-                frame_chunk(MessageSigner::new(session_sk, *network_id), did, chunk)
-                    .map(|bytes| Some((bytes, context)))
+                frame_chunk(signer.by_ref(), did, chunk).map(|bytes| Some((bytes, context)))
             }
         }
     }
@@ -182,7 +176,7 @@ impl OutboundTransfer {
     /// signing authority for the whole transfer.
     pub(in crate::swarm::transport) fn chunked(
         route: OutboundTransferRoute,
-        signer: MessageSigner<'_>,
+        signer: MessageSigner<&SessionSk>,
         chunks: ChunkFrames,
         useful_bytes: u64,
         completion: OutboundCompletion,
@@ -192,8 +186,7 @@ impl OutboundTransfer {
         Self::new(
             route,
             FrameSource::Chunked {
-                session_sk: signer.session_sk().clone(),
-                network_id: signer.network_id(),
+                signer: signer.to_owned(),
                 chunks,
             },
             useful_bytes,

--- a/crates/core/src/swarm/transport/outbound/transfer.rs
+++ b/crates/core/src/swarm/transport/outbound/transfer.rs
@@ -21,6 +21,7 @@ use crate::chunk::Chunk;
 use crate::dht::Did;
 use crate::error::Result;
 use crate::lifecycle::StopToken;
+use crate::message::MessageSigner;
 use crate::session::SessionSk;
 
 type TransferResultSender = oneshot::Sender<Result<SendCompletionOutcome>>;
@@ -34,6 +35,7 @@ enum FrameSource {
     Whole(Option<Bytes>),
     Chunked {
         session_sk: SessionSk,
+        network_id: u32,
         chunks: ChunkFrames,
     },
 }
@@ -42,7 +44,11 @@ impl FrameSource {
     fn next_frame(&mut self, did: Did) -> Result<Option<(Bytes, &'static str)>> {
         match self {
             Self::Whole(frame) => Ok(frame.take().map(|bytes| (bytes, "whole_message"))),
-            Self::Chunked { session_sk, chunks } => {
+            Self::Chunked {
+                session_sk,
+                network_id,
+                chunks,
+            } => {
                 let Some(chunk) = chunks.next() else {
                     return Ok(None);
                 };
@@ -52,7 +58,8 @@ impl FrameSource {
                 } else {
                     "chunked_tail"
                 };
-                frame_chunk(session_sk, did, chunk).map(|bytes| Some((bytes, context)))
+                frame_chunk(MessageSigner::new(session_sk, *network_id), did, chunk)
+                    .map(|bytes| Some((bytes, context)))
             }
         }
     }
@@ -171,9 +178,11 @@ impl OutboundTransfer {
         )
     }
 
+    /// A chunked transfer re-signs every chunk envelope, so it keeps its own copy of the
+    /// signing authority for the whole transfer.
     pub(in crate::swarm::transport) fn chunked(
         route: OutboundTransferRoute,
-        session_sk: SessionSk,
+        signer: MessageSigner<'_>,
         chunks: ChunkFrames,
         useful_bytes: u64,
         completion: OutboundCompletion,
@@ -182,7 +191,11 @@ impl OutboundTransfer {
     ) -> (Self, oneshot::Receiver<Result<SendCompletionOutcome>>) {
         Self::new(
             route,
-            FrameSource::Chunked { session_sk, chunks },
+            FrameSource::Chunked {
+                session_sk: signer.session_sk().clone(),
+                network_id: signer.network_id(),
+                chunks,
+            },
             useful_bytes,
             completion,
             stop,

--- a/crates/core/src/swarm/transport/outbound/transfer.rs
+++ b/crates/core/src/swarm/transport/outbound/transfer.rs
@@ -186,7 +186,7 @@ impl OutboundTransfer {
         Self::new(
             route,
             FrameSource::Chunked {
-                signer: signer.to_owned(),
+                signer: signer.owned(),
                 chunks,
             },
             useful_bytes,

--- a/crates/core/src/swarm/transport/payload_send.rs
+++ b/crates/core/src/swarm/transport/payload_send.rs
@@ -38,8 +38,8 @@ use crate::lifecycle::StopSource;
 use crate::lifecycle::StopToken;
 use crate::message::Message;
 use crate::message::MessagePayload;
+use crate::message::MessageSigner;
 use crate::message::PayloadSender;
-use crate::session::SessionSk;
 use crate::utils::sleep;
 
 const TRACKED_PAYLOAD_TIMEOUT: Duration = TRANSPORT_TIMEOUT_PROFILE.tracked_payload;
@@ -715,7 +715,7 @@ impl SwarmTransport {
                 let chunks: ChunkFrames = Box::new(ChunkList::stream(data, chunk_size));
                 OutboundTransfer::chunked(
                     route,
-                    self.session_sk.clone(),
+                    self.message_signer(),
                     chunks,
                     useful_bytes,
                     completion,
@@ -832,8 +832,8 @@ impl SwarmTransport {
 #[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
 impl PayloadSender for SwarmTransport {
-    fn session_sk(&self) -> &SessionSk {
-        &self.session_sk
+    fn message_signer(&self) -> MessageSigner<'_> {
+        MessageSigner::new(&self.session_sk, self.network_id)
     }
 
     fn dht(&self) -> Arc<PeerRing> {

--- a/crates/core/src/swarm/transport/payload_send.rs
+++ b/crates/core/src/swarm/transport/payload_send.rs
@@ -40,6 +40,7 @@ use crate::message::Message;
 use crate::message::MessagePayload;
 use crate::message::MessageSigner;
 use crate::message::PayloadSender;
+use crate::session::SessionSk;
 use crate::utils::sleep;
 
 const TRACKED_PAYLOAD_TIMEOUT: Duration = TRANSPORT_TIMEOUT_PROFILE.tracked_payload;
@@ -832,7 +833,7 @@ impl SwarmTransport {
 #[cfg_attr(all(feature = "wasm", target_family = "wasm"), async_trait(?Send))]
 #[cfg_attr(not(all(feature = "wasm", target_family = "wasm")), async_trait)]
 impl PayloadSender for SwarmTransport {
-    fn message_signer(&self) -> MessageSigner<'_> {
+    fn message_signer(&self) -> MessageSigner<&SessionSk> {
         MessageSigner::new(&self.session_sk, self.network_id)
     }
 

--- a/crates/core/src/swarm/transport/pending.rs
+++ b/crates/core/src/swarm/transport/pending.rs
@@ -392,6 +392,16 @@ impl SwarmTransport {
         Ok(self.peer_lifecycles()?.active_attempt(peer))
     }
 
+    /// Whether any connection attempt toward `peer` exists, admitted or still handshaking.
+    ///
+    /// Post: `false` means `peer` is unreachable from this node right now and nothing is under
+    /// way to change that; a message for it cannot be handed to a connection.
+    pub(crate) fn has_connection_attempt(&self, peer: Did) -> Result<bool> {
+        let lifecycles = self.peer_lifecycles()?;
+        Ok(lifecycles.active_attempt(peer).is_some()
+            || lifecycles.unadmitted_attempt(peer).is_some())
+    }
+
     #[cfg(all(test, feature = "dummy"))]
     pub(crate) fn is_pending_connection_attempt(
         &self,

--- a/crates/core/src/swarm/transport/storage_lookup.rs
+++ b/crates/core/src/swarm/transport/storage_lookup.rs
@@ -101,7 +101,7 @@ impl SwarmTransport {
         let mut observations = self
             .storage_lookup_observations
             .lock()
-            .map_err(|_| Error::DHTSyncLockError)?;
+            .map_err(|_| Error::LockPoisoned)?;
         let now = storage_lookup_observation_now_ms();
         evict_storage_lookup_observations(&mut observations, now);
         reserve_storage_lookup_observation_slot(&mut observations);
@@ -124,7 +124,7 @@ impl SwarmTransport {
         let mut observations = self
             .storage_lookup_observations
             .lock()
-            .map_err(|_| Error::DHTSyncLockError)?;
+            .map_err(|_| Error::LockPoisoned)?;
         let now = storage_lookup_observation_now_ms();
         evict_storage_lookup_observations(&mut observations, now);
         if observations.contains_key(&key) {
@@ -156,7 +156,7 @@ impl SwarmTransport {
         let mut observations = self
             .storage_lookup_observations
             .lock()
-            .map_err(|_| Error::DHTSyncLockError)?;
+            .map_err(|_| Error::LockPoisoned)?;
         let now = storage_lookup_observation_now_ms();
         evict_storage_lookup_observations(&mut observations, now);
         let Some(observation) = observations.get_mut(&key) else {
@@ -187,7 +187,7 @@ impl SwarmTransport {
         let mut observations = self
             .storage_lookup_observations
             .lock()
-            .map_err(|_| Error::DHTSyncLockError)?;
+            .map_err(|_| Error::LockPoisoned)?;
         let now = storage_lookup_observation_now_ms();
         evict_storage_lookup_observations(&mut observations, now);
         let Some(observation) = observations.get_mut(&key) else {
@@ -211,7 +211,7 @@ impl SwarmTransport {
         let mut observations = self
             .storage_lookup_observations
             .lock()
-            .map_err(|_| Error::DHTSyncLockError)?;
+            .map_err(|_| Error::LockPoisoned)?;
         if let Some(observation) = observations.get_mut(&key) {
             observation.observed_at_ms = storage_lookup_observation_now_ms()
                 .saturating_sub(STORAGE_LOOKUP_OBSERVATION_TTL_MS + 1);
@@ -225,7 +225,7 @@ impl SwarmTransport {
         let observations = self
             .storage_lookup_observations
             .lock()
-            .map_err(|_| Error::DHTSyncLockError)?;
+            .map_err(|_| Error::LockPoisoned)?;
         Ok(observations.len())
     }
 }

--- a/crates/core/src/swarm/transport/storage_sync.rs
+++ b/crates/core/src/swarm/transport/storage_sync.rs
@@ -4,6 +4,8 @@ use std::mem;
 use super::delivery::SendCompletionOutcome;
 use super::outbound::OutboundCompletion;
 use super::SwarmTransport;
+use crate::dht::entry::inbox::validate_inbox_relocation;
+use crate::dht::entry::EntryKind;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::SyncedEntryAck;
 use crate::dht::Did;
@@ -135,6 +137,9 @@ pub(crate) struct StorageSyncBatch<'data> {
     /// Admission time shared by validation and persistence, so a value admitted in the
     /// validate phase cannot expire between phases and fail the batch half-written.
     now_ms: u128,
+    /// The peer that sent the batch, for the relocation law of relay inboxes.
+    origin: Did,
+    purpose: StorageSyncPurpose,
     destination: StorageSyncDestination,
     data: &'data [PlacedEntry],
     validate_index: usize,
@@ -144,9 +149,11 @@ pub(crate) struct StorageSyncBatch<'data> {
 }
 
 impl<'data> StorageSyncBatch<'data> {
-    pub(crate) fn new(msg: &'data SyncEntriesWithSuccessor) -> Self {
+    pub(crate) fn new(msg: &'data SyncEntriesWithSuccessor, origin: Did) -> Self {
         Self {
             now_ms: get_epoch_ms(),
+            origin,
+            purpose: msg.purpose,
             destination: msg.destination,
             data: &msg.data,
             validate_index: 0,
@@ -241,11 +248,21 @@ impl<'data> StorageSyncBatch<'data> {
         // The admission law is re-checked by `join_storage_entry` at persist
         // time; it is evaluated here so that a failing entry rejects the batch
         // before any earlier entry has been written.
-        if should_persist_synced_entry(transport, self.destination, placed.key)? {
+        if should_persist_synced_entry(transport, self.destination, placed)? {
             placed.validate_placement(transport.storage_redundancy())?;
             placed
                 .entry
                 .validate_admissible_at(self.now_ms, transport.network_id)?;
+            if placed.entry.kind == EntryKind::RelayMessage {
+                // A relay inbox moves only with its ownership, from the predecessor.
+                if self.purpose != StorageSyncPurpose::OwnershipHandoff {
+                    return Err(Error::RelayInboxNotRelocatable);
+                }
+                let predecessor = transport
+                    .dht
+                    .with_topology_state(|state| state.predecessor)?;
+                validate_inbox_relocation(self.origin, predecessor)?;
+            }
             let entry = placed.entry.clone().try_into_storage_entry()?;
             self.accepted.push(SyncedEntryAck::new(placed.key, entry));
         }
@@ -307,13 +324,16 @@ fn test_per_entry_yield_ablation_reaches_real_storage_batch_policy() {
 fn should_persist_synced_entry(
     transport: &SwarmTransport,
     destination: StorageSyncDestination,
-    placement: Did,
+    placed: &PlacedEntry,
 ) -> Result<bool> {
-    if !storage_sync_destination_accepts_placement(destination, placement) {
+    if !storage_sync_destination_accepts_placement(destination, placed.key) {
         return Ok(false);
     }
 
-    match transport.dht.find_storage_owner(placement)? {
+    match transport
+        .dht
+        .find_storage_owner_for(placed.key, placed.entry.kind)?
+    {
         // Invariant: `Some(_)` is the local-storage branch. In non-virtual
         // Chord storage the DID carried by `Some` is the successor witness used
         // for fallback lookup, not a remote-owner denial.
@@ -345,8 +365,9 @@ impl SwarmTransport {
     pub(crate) async fn persist_storage_sync_entries(
         &self,
         msg: &SyncEntriesWithSuccessor,
+        origin: Did,
     ) -> Result<Vec<SyncedEntryAck>> {
-        StorageSyncBatch::new(msg).run(self).await
+        StorageSyncBatch::new(msg, origin).run(self).await
     }
 
     /// Record the exact ack capability created by an outbound storage-sync payload.
@@ -460,7 +481,8 @@ impl SwarmTransport {
             .next_hop_for_storage_sync(msg.destination)?
             .filter(|next_hop| *next_hop != self.dht.did)
         else {
-            self.persist_storage_sync_entries(&msg).await?;
+            self.persist_storage_sync_entries(&msg, self.dht.did)
+                .await?;
             return Ok(StorageSyncCompletion::PersistedLocally);
         };
         let payload = MessagePayload::new_send(

--- a/crates/core/src/swarm/transport/storage_sync.rs
+++ b/crates/core/src/swarm/transport/storage_sync.rs
@@ -243,7 +243,9 @@ impl<'data> StorageSyncBatch<'data> {
         // before any earlier entry has been written.
         if should_persist_synced_entry(transport, self.destination, placed.key)? {
             placed.validate_placement(transport.storage_redundancy())?;
-            placed.entry.validate_admissible_at(self.now_ms)?;
+            placed
+                .entry
+                .validate_admissible_at(self.now_ms, transport.network_id)?;
             let entry = placed.entry.clone().try_into_storage_entry()?;
             self.accepted.push(SyncedEntryAck::new(placed.key, entry));
         }

--- a/crates/core/src/swarm/transport/storage_sync.rs
+++ b/crates/core/src/swarm/transport/storage_sync.rs
@@ -132,6 +132,9 @@ pub(crate) enum StorageSyncBatchStep {
 }
 
 pub(crate) struct StorageSyncBatch<'data> {
+    /// Admission time shared by validation and persistence, so a value admitted in the
+    /// validate phase cannot expire between phases and fail the batch half-written.
+    now_ms: u128,
     destination: StorageSyncDestination,
     data: &'data [PlacedEntry],
     validate_index: usize,
@@ -143,6 +146,7 @@ pub(crate) struct StorageSyncBatch<'data> {
 impl<'data> StorageSyncBatch<'data> {
     pub(crate) fn new(msg: &'data SyncEntriesWithSuccessor) -> Self {
         Self {
+            now_ms: get_epoch_ms(),
             destination: msg.destination,
             data: &msg.data,
             validate_index: 0,
@@ -239,7 +243,7 @@ impl<'data> StorageSyncBatch<'data> {
         // before any earlier entry has been written.
         if should_persist_synced_entry(transport, self.destination, placed.key)? {
             placed.validate_placement(transport.storage_redundancy())?;
-            placed.entry.validate_admissible_at(get_epoch_ms())?;
+            placed.entry.validate_admissible_at(self.now_ms)?;
             let entry = placed.entry.clone().try_into_storage_entry()?;
             self.accepted.push(SyncedEntryAck::new(placed.key, entry));
         }
@@ -254,7 +258,10 @@ impl<'data> StorageSyncBatch<'data> {
         let key = ack.key;
         let entry = ack.entry.clone();
 
-        transport.dht.join_storage_entry(key, entry).await?;
+        transport
+            .dht
+            .join_storage_entry(self.now_ms, key, entry)
+            .await?;
         #[cfg(all(test, feature = "dummy", not(target_family = "wasm")))]
         crate::simulation::record_storage_persisted(transport.dht.did);
         self.persist_index += 1;

--- a/crates/core/src/swarm/transport/storage_sync.rs
+++ b/crates/core/src/swarm/transport/storage_sync.rs
@@ -19,6 +19,7 @@ use crate::message::MessagePayload;
 use crate::message::PayloadSender;
 use crate::message::SyncEntriesWithSuccessor;
 use crate::message::SyncEntriesWithSuccessorReport;
+use crate::utils::get_epoch_ms;
 use crate::utils::get_epoch_ms_i64;
 
 const STORAGE_SYNC_ACK_CAPACITY: usize = 1024;
@@ -233,8 +234,12 @@ impl<'data> StorageSyncBatch<'data> {
 
         // Preservation: every input is validated before the first storage
         // effect, so a later invalid input leaves the entire batch unwritten.
+        // The admission law is re-checked by `join_storage_entry` at persist
+        // time; it is evaluated here so that a failing entry rejects the batch
+        // before any earlier entry has been written.
         if should_persist_synced_entry(transport, self.destination, placed.key)? {
             placed.validate_placement(transport.storage_redundancy())?;
+            placed.entry.validate_admissible_at(get_epoch_ms())?;
             let entry = placed.entry.clone().try_into_storage_entry()?;
             self.accepted.push(SyncedEntryAck::new(placed.key, entry));
         }
@@ -451,7 +456,7 @@ impl SwarmTransport {
         };
         let payload = MessagePayload::new_send(
             Message::SyncEntriesWithSuccessor(msg.clone()),
-            self.session_sk(),
+            self.message_signer(),
             next_hop,
             destination,
         )?;

--- a/crates/core/src/swarm/transport/storage_sync.rs
+++ b/crates/core/src/swarm/transport/storage_sync.rs
@@ -5,7 +5,6 @@ use super::delivery::SendCompletionOutcome;
 use super::outbound::OutboundCompletion;
 use super::SwarmTransport;
 use crate::dht::entry::inbox::validate_inbox_relocation;
-use crate::dht::entry::EntryKind;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::SyncedEntryAck;
 use crate::dht::Did;
@@ -137,8 +136,9 @@ pub(crate) struct StorageSyncBatch<'data> {
     /// Admission time shared by validation and persistence, so a value admitted in the
     /// validate phase cannot expire between phases and fail the batch half-written.
     now_ms: u128,
-    /// The peer that sent the batch, for the relocation law of relay inboxes.
-    origin: Did,
+    /// The authenticated sender of the batch (its transaction signer), for the relocation law of
+    /// relay inboxes.
+    sender: Did,
     purpose: StorageSyncPurpose,
     destination: StorageSyncDestination,
     data: &'data [PlacedEntry],
@@ -149,10 +149,10 @@ pub(crate) struct StorageSyncBatch<'data> {
 }
 
 impl<'data> StorageSyncBatch<'data> {
-    pub(crate) fn new(msg: &'data SyncEntriesWithSuccessor, origin: Did, now_ms: u128) -> Self {
+    pub(crate) fn new(msg: &'data SyncEntriesWithSuccessor, sender: Did, now_ms: u128) -> Self {
         Self {
             now_ms,
-            origin,
+            sender,
             purpose: msg.purpose,
             destination: msg.destination,
             data: &msg.data,
@@ -273,16 +273,16 @@ impl<'data> StorageSyncBatch<'data> {
         transport: &SwarmTransport,
         placed: &PlacedEntry,
     ) -> Result<bool> {
-        if placed.entry.kind != EntryKind::RelayMessage {
+        if !placed.entry.kind.is_relay_inbox() {
             return Ok(true);
         }
-        if self.purpose != StorageSyncPurpose::OwnershipHandoff {
+        if !self.purpose.is_ownership_handoff() {
             return Ok(false);
         }
         let predecessor = transport
             .dht
             .with_topology_state(|state| state.predecessor)?;
-        Ok(validate_inbox_relocation(self.origin, predecessor).is_ok())
+        Ok(validate_inbox_relocation(self.sender, predecessor).is_ok())
     }
 
     async fn persist_one(&mut self, transport: &SwarmTransport) -> Result<StorageSyncBatchStep> {
@@ -377,12 +377,15 @@ fn evict_storage_sync_acks(pending: &mut StorageSyncAckMap) {
 
 impl SwarmTransport {
     /// Validate a complete local storage-sync batch before persisting any entry.
+    ///
+    /// Pre: `sender` is the authenticated signer of the message carrying `msg`, never a value
+    /// read from its relay path.
     pub(crate) async fn persist_storage_sync_entries(
         &self,
         msg: &SyncEntriesWithSuccessor,
-        origin: Did,
+        sender: Did,
     ) -> Result<Vec<SyncedEntryAck>> {
-        StorageSyncBatch::new(msg, origin, get_epoch_ms())
+        StorageSyncBatch::new(msg, sender, get_epoch_ms())
             .run(self)
             .await
     }

--- a/crates/core/src/swarm/transport/storage_sync.rs
+++ b/crates/core/src/swarm/transport/storage_sync.rs
@@ -248,26 +248,41 @@ impl<'data> StorageSyncBatch<'data> {
         // The admission law is re-checked by `join_storage_entry` at persist
         // time; it is evaluated here so that a failing entry rejects the batch
         // before any earlier entry has been written.
-        if should_persist_synced_entry(transport, self.destination, placed)? {
+        if should_persist_synced_entry(transport, self.destination, placed)?
+            && self.relay_relocation_permits(transport, placed)?
+        {
             placed.validate_placement(transport.storage_redundancy())?;
             placed
                 .entry
                 .validate_admissible_at(self.now_ms, transport.network_id)?;
-            if placed.entry.kind == EntryKind::RelayMessage {
-                // A relay inbox moves only with its ownership, from the predecessor.
-                if self.purpose != StorageSyncPurpose::OwnershipHandoff {
-                    return Err(Error::RelayInboxNotRelocatable);
-                }
-                let predecessor = transport
-                    .dht
-                    .with_topology_state(|state| state.predecessor)?;
-                validate_inbox_relocation(self.origin, predecessor)?;
-            }
             let entry = placed.entry.clone().try_into_storage_entry()?;
             self.accepted.push(SyncedEntryAck::new(placed.key, entry));
         }
 
         Ok(Some(StorageSyncBatchStep::Pending))
+    }
+
+    /// Whether the relocation law lets this batch carry `placed`: a data topic always, a relay
+    /// inbox only as an ownership hand-off from the receiver's predecessor.
+    ///
+    /// Post: `false` skips the entry without acknowledging it, so its owner keeps it and offers
+    /// it again on a later pass; it does not fail the batch, as the entry is not invalid, only
+    /// not this receiver's to take yet.
+    fn relay_relocation_permits(
+        &self,
+        transport: &SwarmTransport,
+        placed: &PlacedEntry,
+    ) -> Result<bool> {
+        if placed.entry.kind != EntryKind::RelayMessage {
+            return Ok(true);
+        }
+        if self.purpose != StorageSyncPurpose::OwnershipHandoff {
+            return Ok(false);
+        }
+        let predecessor = transport
+            .dht
+            .with_topology_state(|state| state.predecessor)?;
+        Ok(validate_inbox_relocation(self.origin, predecessor).is_ok())
     }
 
     async fn persist_one(&mut self, transport: &SwarmTransport) -> Result<StorageSyncBatchStep> {

--- a/crates/core/src/swarm/transport/storage_sync.rs
+++ b/crates/core/src/swarm/transport/storage_sync.rs
@@ -4,7 +4,7 @@ use std::mem;
 use super::delivery::SendCompletionOutcome;
 use super::outbound::OutboundCompletion;
 use super::SwarmTransport;
-use crate::dht::entry::inbox::validate_inbox_relocation;
+use crate::dht::entry::inbox::relocates_from_predecessor;
 use crate::dht::entry::PlacedEntry;
 use crate::dht::entry::SyncedEntryAck;
 use crate::dht::Did;
@@ -282,7 +282,7 @@ impl<'data> StorageSyncBatch<'data> {
         let predecessor = transport
             .dht
             .with_topology_state(|state| state.predecessor)?;
-        Ok(validate_inbox_relocation(self.sender, predecessor).is_ok())
+        Ok(relocates_from_predecessor(self.sender, predecessor))
     }
 
     async fn persist_one(&mut self, transport: &SwarmTransport) -> Result<StorageSyncBatchStep> {

--- a/crates/core/src/swarm/transport/storage_sync.rs
+++ b/crates/core/src/swarm/transport/storage_sync.rs
@@ -149,9 +149,9 @@ pub(crate) struct StorageSyncBatch<'data> {
 }
 
 impl<'data> StorageSyncBatch<'data> {
-    pub(crate) fn new(msg: &'data SyncEntriesWithSuccessor, origin: Did) -> Self {
+    pub(crate) fn new(msg: &'data SyncEntriesWithSuccessor, origin: Did, now_ms: u128) -> Self {
         Self {
-            now_ms: get_epoch_ms(),
+            now_ms,
             origin,
             purpose: msg.purpose,
             destination: msg.destination,
@@ -382,7 +382,9 @@ impl SwarmTransport {
         msg: &SyncEntriesWithSuccessor,
         origin: Did,
     ) -> Result<Vec<SyncedEntryAck>> {
-        StorageSyncBatch::new(msg, origin).run(self).await
+        StorageSyncBatch::new(msg, origin, get_epoch_ms())
+            .run(self)
+            .await
     }
 
     /// Record the exact ack capability created by an outbound storage-sync payload.
@@ -418,7 +420,7 @@ impl SwarmTransport {
         let mut pending = self
             .pending_storage_sync_acks
             .lock()
-            .map_err(|_| Error::DHTSyncLockError)?;
+            .map_err(|_| Error::LockPoisoned)?;
         evict_storage_sync_acks(&mut pending);
         pending.insert(tx_id, capability);
         Ok(())
@@ -457,7 +459,7 @@ impl SwarmTransport {
         let mut pending = self
             .pending_storage_sync_acks
             .lock()
-            .map_err(|_| Error::DHTSyncLockError)?;
+            .map_err(|_| Error::LockPoisoned)?;
         let Some(capability) = pending.get(&tx_id) else {
             return Err(Error::InvalidMessage(
                 "storage sync report has no pending capability".to_string(),

--- a/crates/core/src/swarm/transport/tests/mod.rs
+++ b/crates/core/src/swarm/transport/tests/mod.rs
@@ -55,7 +55,6 @@ use crate::swarm::callback::SwarmCallback;
 use crate::swarm::callback::SwarmEvent;
 use crate::swarm::SwarmBuilder;
 #[cfg(feature = "dummy")]
-#[cfg(feature = "dummy")]
 use crate::tests::TEST_NETWORK_ID;
 use crate::utils::GenerationWitness;
 #[cfg(all(feature = "dummy", not(target_family = "wasm")))]

--- a/crates/core/src/swarm/transport/tests/mod.rs
+++ b/crates/core/src/swarm/transport/tests/mod.rs
@@ -42,6 +42,8 @@ use crate::measure::PeerQuality;
 #[cfg(all(feature = "dummy", not(target_family = "wasm")))]
 use crate::message::MessageClass;
 use crate::message::MessagePayload;
+#[cfg(feature = "dummy")]
+use crate::message::MessageSigner;
 use crate::storage::MemStorage;
 #[cfg(all(feature = "dummy", not(target_family = "wasm")))]
 use crate::swarm::callback::max_on_message_recursion_depth_for_test;
@@ -52,6 +54,9 @@ use crate::swarm::callback::SwarmCallback;
 #[cfg(feature = "dummy")]
 use crate::swarm::callback::SwarmEvent;
 use crate::swarm::SwarmBuilder;
+#[cfg(feature = "dummy")]
+#[cfg(feature = "dummy")]
+use crate::tests::TEST_NETWORK_ID;
 use crate::utils::GenerationWitness;
 #[cfg(all(feature = "dummy", not(target_family = "wasm")))]
 use crate::utils::Witness;
@@ -566,7 +571,7 @@ async fn test_pending_callback_messages_do_not_dispatch_before_admission() -> Re
         .with_pending_connection_attempt(attempt);
     let payload = MessagePayload::new_send(
         Message::custom(b"message-before-admission")?,
-        &peer_session,
+        MessageSigner::new(&peer_session, TEST_NETWORK_ID),
         transport.dht.did,
         transport.dht.did,
     )?;
@@ -622,7 +627,7 @@ async fn test_nested_reassembled_chunk_is_rejected_without_recursive_callback_en
         .with_pending_connection_attempt(attempt);
     let mut current: Bytes = MessagePayload::new_send(
         Message::custom(b"mailbox-drained")?,
-        &peer_session,
+        MessageSigner::new(&peer_session, TEST_NETWORK_ID),
         transport.dht.did,
         transport.dht.did,
     )?
@@ -635,7 +640,7 @@ async fn test_nested_reassembled_chunk_is_rejected_without_recursive_callback_en
         };
         current = MessagePayload::new_send(
             Message::Chunk(chunk),
-            &peer_session,
+            MessageSigner::new(&peer_session, TEST_NETWORK_ID),
             transport.dht.did,
             transport.dht.did,
         )?
@@ -684,7 +689,7 @@ async fn test_missing_peer_error_precedes_outbound_capacity_admission() -> Resul
     }
     let payload = MessagePayload::new_send(
         Message::custom(b"missing-peer")?,
-        transport.session_sk(),
+        transport.message_signer(),
         peer,
         peer,
     )?;
@@ -718,7 +723,7 @@ async fn test_invalid_inbound_log_omits_transaction_data() -> Result<()> {
     let callback = InnerSwarmCallback::new(Arc::clone(&transport), Arc::new(NoopSwarmCallback));
     let mut payload = MessagePayload::new_send(
         Message::custom(PRIVATE_MARKER.as_bytes())?,
-        &peer_session,
+        MessageSigner::new(&peer_session, TEST_NETWORK_ID),
         transport.dht.did,
         transport.dht.did,
     )?;

--- a/crates/core/src/swarm/transport/tests/test_events.rs
+++ b/crates/core/src/swarm/transport/tests/test_events.rs
@@ -293,7 +293,7 @@ async fn test_malformed_outbound_payload_is_rejected_before_connection_admission
     let peer = SecretKey::random().address().into();
     let mut payload = MessagePayload::new_send(
         Message::custom(b"malformed outbound payload")?,
-        &transport.session_sk,
+        transport.message_signer(),
         peer,
         peer,
     )?;

--- a/crates/core/src/swarm/transport/tests/test_inbound.rs
+++ b/crates/core/src/swarm/transport/tests/test_inbound.rs
@@ -4,10 +4,12 @@ use super::*;
 use crate::chunk::ChunkList;
 use crate::message::CustomMessage;
 use crate::message::FoundEntry;
+use crate::message::MessageSigner;
 use crate::swarm::callback::inbound_application_capacity_for_test;
 use crate::swarm::callback::inbound_mailbox_capacity_for_test;
 use crate::swarm::callback::inbound_peer_capacity_for_test;
 use crate::swarm::callback::InboundLane;
+use crate::tests::TEST_NETWORK_ID;
 
 mod test_callback_failure;
 mod test_capacity_handoff;
@@ -191,7 +193,7 @@ async fn test_pending_message_rechecks_admission_after_async_validation() -> Res
 
     let message = MessagePayload::new_send(
         Message::custom(b"must-not-dispatch-after-retire")?,
-        &peer_session,
+        MessageSigner::new(&peer_session, TEST_NETWORK_ID),
         transport.dht.did,
         transport.dht.did,
     )?
@@ -237,14 +239,14 @@ async fn test_inbound_control_lane_progresses_while_application_validation_is_bl
     ));
     let application = MessagePayload::new_send(
         Message::custom(b"blocked-application")?,
-        &peer_session,
+        MessageSigner::new(&peer_session, TEST_NETWORK_ID),
         transport.dht.did,
         transport.dht.did,
     )?
     .to_wire()?;
     let control = MessagePayload::new_send(
         Message::PeerLivenessReport(crate::message::PeerLivenessReport { sent_at_ms: 1 }),
-        &peer_session,
+        MessageSigner::new(&peer_session, TEST_NETWORK_ID),
         transport.dht.did,
         transport.dht.did,
     )?
@@ -304,7 +306,7 @@ async fn test_inbound_mailbox_reserves_control_capacity_under_application_satura
         let session = SessionSk::new_with_seckey(&key)?;
         let message = MessagePayload::new_send(
             Message::custom(b"bounded-inbound-mailbox")?,
-            &session,
+            MessageSigner::new(&session, TEST_NETWORK_ID),
             transport.dht.did,
             transport.dht.did,
         )?
@@ -316,14 +318,14 @@ async fn test_inbound_mailbox_reserves_control_capacity_under_application_satura
     let control_session = SessionSk::new_with_seckey(&control_key)?;
     let overflow_message = MessagePayload::new_send(
         Message::custom(b"global-application-overflow")?,
-        &control_session,
+        MessageSigner::new(&control_session, TEST_NETWORK_ID),
         transport.dht.did,
         transport.dht.did,
     )?
     .to_wire()?;
     let control = MessagePayload::new_send(
         Message::PeerLivenessReport(crate::message::PeerLivenessReport { sent_at_ms: 2 }),
-        &control_session,
+        MessageSigner::new(&control_session, TEST_NETWORK_ID),
         transport.dht.did,
         transport.dht.did,
     )?
@@ -394,7 +396,7 @@ async fn test_closing_inbound_mailbox_cancels_pending_callback() -> Result<()> {
     ));
     let message = MessagePayload::new_send(
         Message::custom(b"pending-inbound-callback")?,
-        &peer_session,
+        MessageSigner::new(&peer_session, TEST_NETWORK_ID),
         transport.dht.did,
         transport.dht.did,
     )?
@@ -425,7 +427,13 @@ async fn test_closing_inbound_mailbox_cancels_pending_callback() -> Result<()> {
 }
 
 fn local_wire(message: Message, session: &SessionSk, local: Did) -> Result<bytes::Bytes> {
-    MessagePayload::new_send(message, session, local, local)?.to_wire()
+    MessagePayload::new_send(
+        message,
+        MessageSigner::new(session, TEST_NETWORK_ID),
+        local,
+        local,
+    )?
+    .to_wire()
 }
 
 fn failed_receive_count(measure: &RecordingMeasure, peer: Did) -> Result<usize> {
@@ -492,7 +500,7 @@ async fn test_chunk_reassembly_records_one_exact_logical_receive() -> Result<()>
         .map_err(|error| Error::InvalidMessage(error.to_string()))?;
     let logical_payload = MessagePayload::new_send(
         Message::custom(&vec![41; 512])?,
-        &peer_session,
+        MessageSigner::new(&peer_session, TEST_NETWORK_ID),
         transport.dht.did,
         transport.dht.did,
     )?;
@@ -554,7 +562,7 @@ async fn test_reassembled_undecodable_message_records_one_failure_only() -> Resu
         .map_err(|error| Error::InvalidMessage(error.to_string()))?;
     let undecodable = MessagePayload::new_send(
         vec![0xff_u8; 512],
-        &peer_session,
+        MessageSigner::new(&peer_session, TEST_NETWORK_ID),
         transport.dht.did,
         transport.dht.did,
     )?;
@@ -702,13 +710,15 @@ async fn test_transport_preparation_authenticates_every_reserved_lane() -> Resul
         .ok_or(Error::InboundActorInvariantViolation)?;
     let reassembly = local_wire(Message::Chunk(chunk), &peer_session, transport.dht.did)?;
 
-    let control_lane = crate::swarm::callback::prepare_transport_frame_lane_for_test(&control)?;
+    let control_lane =
+        crate::swarm::callback::prepare_transport_frame_lane_for_test(TEST_NETWORK_ID, &control)?;
     assert_eq!(control_lane, InboundLane::DhtControl);
     let truncated = control
         .get(..control.len().saturating_sub(1))
         .ok_or(Error::InboundActorInvariantViolation)?;
     assert!(
-        crate::swarm::callback::prepare_transport_frame_lane_for_test(truncated).is_err(),
+        crate::swarm::callback::prepare_transport_frame_lane_for_test(TEST_NETWORK_ID, truncated)
+            .is_err(),
         "a truncated control-shaped payload must not claim control capacity"
     );
     for (name, frame) in [
@@ -723,23 +733,36 @@ async fn test_transport_preparation_authenticates_every_reserved_lane() -> Resul
             .ok_or(Error::InboundActorInvariantViolation)?;
         *final_byte ^= 1;
         assert!(
-            crate::swarm::callback::prepare_transport_frame_lane_for_test(&damaged).is_err(),
+            crate::swarm::callback::prepare_transport_frame_lane_for_test(
+                TEST_NETWORK_ID,
+                &damaged
+            )
+            .is_err(),
             "unauthenticated {name} shape must not claim reserved capacity"
         );
     }
     assert_eq!(
-        crate::swarm::callback::prepare_transport_frame_lane_for_test(&application)?,
+        crate::swarm::callback::prepare_transport_frame_lane_for_test(
+            TEST_NETWORK_ID,
+            &application
+        )?,
         InboundLane::Application
     );
     assert_eq!(
-        crate::swarm::callback::prepare_transport_frame_lane_for_test(&storage)?,
+        crate::swarm::callback::prepare_transport_frame_lane_for_test(TEST_NETWORK_ID, &storage)?,
         InboundLane::Storage
     );
     assert_eq!(
-        crate::swarm::callback::prepare_transport_frame_lane_for_test(&reassembly)?,
+        crate::swarm::callback::prepare_transport_frame_lane_for_test(
+            TEST_NETWORK_ID,
+            &reassembly
+        )?,
         InboundLane::Reassembly
     );
-    assert!(crate::swarm::callback::prepare_transport_frame_lane_for_test(&[0xff]).is_err());
+    assert!(
+        crate::swarm::callback::prepare_transport_frame_lane_for_test(TEST_NETWORK_ID, &[0xff])
+            .is_err()
+    );
     Ok(())
 }
 
@@ -759,7 +782,7 @@ async fn test_reassembled_control_shape_is_verified_before_lane_transition() -> 
     let session = SessionSk::new_with_seckey(&peer_key)?;
     let mut tampered = MessagePayload::new_send(
         Message::PeerLivenessReport(crate::message::PeerLivenessReport { sent_at_ms: 4 }),
-        &session,
+        MessageSigner::new(&session, TEST_NETWORK_ID),
         transport.dht.did,
         transport.dht.did,
     )?;

--- a/crates/core/src/swarm/transport/tests/test_inbound/test_storage_interleave.rs
+++ b/crates/core/src/swarm/transport/tests/test_inbound/test_storage_interleave.rs
@@ -32,6 +32,7 @@ use crate::swarm::callback::SwarmCallback;
 use crate::swarm::transport::SwarmTransport;
 use crate::swarm::transport::SwarmTransportSettings;
 use crate::swarm::transport::SwarmWebrtcConfig;
+use crate::tests::live_entry;
 
 #[derive(Default)]
 struct InterleaveProbe {
@@ -148,7 +149,7 @@ async fn test_inbound_storage_batch_yields_to_control_between_persistence_steps(
     let entries = [31_u32, 32_u32]
         .into_iter()
         .map(|did| {
-            let entry = crate::tests::live_entry(Did::from(did), Vec::new(), EntryKind::Data);
+            let entry = live_entry(Did::from(did), Vec::new(), EntryKind::Data);
             PlacedEntry::new(entry.did, entry)
         })
         .collect();

--- a/crates/core/src/swarm/transport/tests/test_inbound/test_storage_interleave.rs
+++ b/crates/core/src/swarm/transport/tests/test_inbound/test_storage_interleave.rs
@@ -148,7 +148,7 @@ async fn test_inbound_storage_batch_yields_to_control_between_persistence_steps(
     let entries = [31_u32, 32_u32]
         .into_iter()
         .map(|did| {
-            let entry = Entry::new(Did::from(did), Vec::new(), EntryKind::Data);
+            let entry = crate::tests::live_entry(Did::from(did), Vec::new(), EntryKind::Data);
             PlacedEntry::new(entry.did, entry)
         })
         .collect();

--- a/crates/core/src/swarm/transport/tests/test_lifecycle.rs
+++ b/crates/core/src/swarm/transport/tests/test_lifecycle.rs
@@ -748,7 +748,7 @@ async fn test_stale_send_after_retirement_does_not_recreate_outbound_scheduler()
     let (transport, peer, attempt) = transport_with_routable_peer().await?;
     let payload = MessagePayload::new_send(
         Message::custom(b"stale-after-admission")?,
-        transport.session_sk(),
+        transport.message_signer(),
         peer,
         peer,
     )?;
@@ -774,7 +774,7 @@ async fn test_scheduler_shutdown_revokes_a_frame_waiting_at_transport_dispatch()
     let (transport, peer, _attempt) = transport_with_routable_peer().await?;
     let payload = MessagePayload::new_send(
         Message::custom(b"shutdown-at-dispatch")?,
-        transport.session_sk(),
+        transport.message_signer(),
         peer,
         peer,
     )?;
@@ -812,7 +812,7 @@ async fn test_scheduler_shutdown_after_backend_acceptance_preserves_detached_suc
     let (transport, peer, _attempt) = transport_with_routable_peer().await?;
     let payload = MessagePayload::new_send(
         Message::custom(b"shutdown-after-backend-acceptance")?,
-        transport.session_sk(),
+        transport.message_signer(),
         peer,
         peer,
     )?;
@@ -856,7 +856,7 @@ async fn test_scheduler_shutdown_cancels_a_send_before_queue_acceptance() -> Res
     let (transport, peer, _attempt) = transport_with_routable_peer().await?;
     let payload = MessagePayload::new_send(
         Message::custom(b"linearized-before-shutdown")?,
-        transport.session_sk(),
+        transport.message_signer(),
         peer,
         peer,
     )?;

--- a/crates/core/src/swarm/transport/tests/test_readiness.rs
+++ b/crates/core/src/swarm/transport/tests/test_readiness.rs
@@ -126,7 +126,7 @@ async fn test_tracked_send_rejects_disconnected_open_transport() -> Result<()> {
 
     let payload = MessagePayload::new_send(
         Message::custom(b"must-not-send")?,
-        transport.session_sk(),
+        transport.message_signer(),
         peer,
         peer,
     )?;

--- a/crates/core/src/tests/default/mod.rs
+++ b/crates/core/src/tests/default/mod.rs
@@ -40,6 +40,7 @@ mod test_dht_schedule;
 // End-to-end chunking uses the dummy backend's `max_message_size` test hook.
 #[cfg(feature = "dummy")]
 mod test_chunk_e2e;
+mod test_inbox;
 mod test_message_handler;
 #[cfg(all(feature = "std", not(feature = "dummy")))]
 mod test_native_transport;

--- a/crates/core/src/tests/default/mod.rs
+++ b/crates/core/src/tests/default/mod.rs
@@ -14,6 +14,7 @@ use crate::dht::entry::Entry;
 use crate::dht::successor::SuccessorReader;
 use crate::dht::Did;
 use crate::dht::PeerRing;
+use crate::dht::StorageKey;
 use crate::ecc::SecretKey;
 use crate::error::Result;
 use crate::measure::MeasureImpl;
@@ -305,7 +306,7 @@ pub async fn wait_for_predecessor(node: &Node, predecessor: Did) -> crate::error
 /// Post: returns only after `ready` held; the timeout is a failure deadline, never the event.
 pub async fn wait_for_storage_state(
     node: &Node,
-    key: Did,
+    key: StorageKey,
     label: &str,
     ready: impl Fn(Option<&Entry>) -> bool,
 ) -> crate::error::Result<Option<Entry>> {
@@ -327,13 +328,13 @@ pub async fn wait_for_storage_state(
 
 /// Wait until `node` no longer stores a value at `key`.
 #[cfg(all(feature = "dummy", not(target_family = "wasm")))]
-pub async fn wait_for_storage_absence(node: &Node, key: Did) -> crate::error::Result<()> {
+pub async fn wait_for_storage_absence(node: &Node, key: StorageKey) -> crate::error::Result<()> {
     wait_for_storage_state(node, key, "absent", |stored| stored.is_none())
         .await
         .map(drop)
 }
 
-pub async fn wait_for_storage_entry(node: &Node, key: Did) -> crate::error::Result<Entry> {
+pub async fn wait_for_storage_entry(node: &Node, key: StorageKey) -> crate::error::Result<Entry> {
     wait_for_storage_state(node, key, "present", |stored| stored.is_some())
         .await?
         .ok_or_else(|| crate::error::Error::InvalidMessage(format!("no entry at {key}")))

--- a/crates/core/src/tests/default/mod.rs
+++ b/crates/core/src/tests/default/mod.rs
@@ -298,6 +298,23 @@ pub async fn wait_for_predecessor(node: &Node, predecessor: Did) -> crate::error
     .await
 }
 
+/// Wait until `node` no longer stores a value at `entry`.
+pub async fn wait_for_storage_absence(node: &Node, entry: Did) -> crate::error::Result<()> {
+    let started = Instant::now();
+    loop {
+        if node.dht().storage.get(&entry.to_string()).await?.is_none() {
+            return Ok(());
+        }
+
+        assert!(
+            started.elapsed() <= TEST_WAIT_TIMEOUT,
+            "storage entry was not removed within {TEST_WAIT_TIMEOUT:?}: {entry}"
+        );
+        tokio::task::yield_now().await;
+        sleep(TEST_WAIT_POLL_INTERVAL).await;
+    }
+}
+
 pub async fn wait_for_storage_entry(node: &Node, entry: Did) -> crate::error::Result<Entry> {
     let started = Instant::now();
     loop {

--- a/crates/core/src/tests/default/mod.rs
+++ b/crates/core/src/tests/default/mod.rs
@@ -299,38 +299,44 @@ pub async fn wait_for_predecessor(node: &Node, predecessor: Did) -> crate::error
     .await
 }
 
-/// Wait until `node` no longer stores a value at `entry`.
-#[cfg(all(feature = "dummy", not(target_family = "wasm")))]
-pub async fn wait_for_storage_absence(node: &Node, entry: Did) -> crate::error::Result<()> {
+/// Wait until the value `node` stores at `key` (or its absence) satisfies `ready`, returning
+/// that value.
+///
+/// Post: returns only after `ready` held; the timeout is a failure deadline, never the event.
+pub async fn wait_for_storage_state(
+    node: &Node,
+    key: Did,
+    label: &str,
+    ready: impl Fn(Option<&Entry>) -> bool,
+) -> crate::error::Result<Option<Entry>> {
     let started = Instant::now();
     loop {
-        if node.dht().storage.get(&entry.to_string()).await?.is_none() {
-            return Ok(());
+        let stored = node.dht().storage.get(&key.to_string()).await?;
+        if ready(stored.as_ref()) {
+            return Ok(stored);
         }
 
         assert!(
             started.elapsed() <= TEST_WAIT_TIMEOUT,
-            "storage entry was not removed within {TEST_WAIT_TIMEOUT:?}: {entry}"
+            "storage at {key} did not reach the state within {TEST_WAIT_TIMEOUT:?}: {label}"
         );
         tokio::task::yield_now().await;
         sleep(TEST_WAIT_POLL_INTERVAL).await;
     }
 }
 
-pub async fn wait_for_storage_entry(node: &Node, entry: Did) -> crate::error::Result<Entry> {
-    let started = Instant::now();
-    loop {
-        if let Some(entry) = node.dht().storage.get(&entry.to_string()).await? {
-            return Ok(entry);
-        }
+/// Wait until `node` no longer stores a value at `key`.
+#[cfg(all(feature = "dummy", not(target_family = "wasm")))]
+pub async fn wait_for_storage_absence(node: &Node, key: Did) -> crate::error::Result<()> {
+    wait_for_storage_state(node, key, "absent", |stored| stored.is_none())
+        .await
+        .map(drop)
+}
 
-        assert!(
-            started.elapsed() <= TEST_WAIT_TIMEOUT,
-            "storage entry did not appear within {TEST_WAIT_TIMEOUT:?}: {entry}"
-        );
-        tokio::task::yield_now().await;
-        sleep(TEST_WAIT_POLL_INTERVAL).await;
-    }
+pub async fn wait_for_storage_entry(node: &Node, key: Did) -> crate::error::Result<Entry> {
+    wait_for_storage_state(node, key, "present", |stored| stored.is_some())
+        .await?
+        .ok_or_else(|| crate::error::Error::InvalidMessage(format!("no entry at {key}")))
 }
 
 pub fn gen_pure_dht(did: Did) -> PeerRing {

--- a/crates/core/src/tests/default/mod.rs
+++ b/crates/core/src/tests/default/mod.rs
@@ -40,6 +40,7 @@ mod test_dht_schedule;
 // End-to-end chunking uses the dummy backend's `max_message_size` test hook.
 #[cfg(feature = "dummy")]
 mod test_chunk_e2e;
+#[cfg(all(feature = "dummy", not(target_family = "wasm")))]
 mod test_inbox;
 mod test_message_handler;
 #[cfg(all(feature = "std", not(feature = "dummy")))]
@@ -299,6 +300,7 @@ pub async fn wait_for_predecessor(node: &Node, predecessor: Did) -> crate::error
 }
 
 /// Wait until `node` no longer stores a value at `entry`.
+#[cfg(all(feature = "dummy", not(target_family = "wasm")))]
 pub async fn wait_for_storage_absence(node: &Node, entry: Did) -> crate::error::Result<()> {
     let started = Instant::now();
     loop {

--- a/crates/core/src/tests/default/mod.rs
+++ b/crates/core/src/tests/default/mod.rs
@@ -223,7 +223,7 @@ fn prepare_node_with_optional_measure(
     let storage = Box::new(MemStorage::new());
 
     let session_sk = SessionSk::new_with_seckey(&key)?;
-    let builder = SwarmBuilder::new(0, stun, storage, session_sk)
+    let builder = SwarmBuilder::new(crate::tests::TEST_NETWORK_ID, stun, storage, session_sk)
         .dht_finger_table_size(TEST_DHT_FINGER_TABLE_SIZE)
         .dht_virtual_nodes(0);
     let builder = match measure {

--- a/crates/core/src/tests/default/test_chunk_e2e.rs
+++ b/crates/core/src/tests/default/test_chunk_e2e.rs
@@ -764,7 +764,7 @@ async fn test_tracked_cleanup_grace_terminalizes_a_nonresponsive_generation() ->
     let _pending_close = PendingCloseGuard::new();
     let payload = MessagePayload::new_send(
         Message::custom(b"tracked-cleanup-grace")?,
-        node1.swarm.transport.session_sk(),
+        node1.swarm.transport.message_signer(),
         peer,
         peer,
     )?;

--- a/crates/core/src/tests/default/test_dht_convergence.rs
+++ b/crates/core/src/tests/default/test_dht_convergence.rs
@@ -195,6 +195,14 @@ pub(super) mod spec {
         crate::dht::topology::stabilize_query(me, current, topo_predecessor)
     }
 
+    /// `Head(n)` — the nearest forward node of a successor list, the upper end of
+    /// the placement interval `(n, head]`.
+    pub fn head(me: Did, successors: &[Did]) -> Option<Did> {
+        crate::dht::topology::successors(successors, me, 1)
+            .first()
+            .copied()
+    }
+
     /// `CorrectStabilize` notify side effect: notify the new successor, if any.
     pub fn correct_stabilize_notify(me: Did, next_successors: &[Did]) -> Option<Did> {
         crate::dht::topology::stabilize_notify(me, next_successors)
@@ -344,6 +352,15 @@ fn assert_correct_stabilize_matches_spec(
         expected_actions.push(PeerRingAction::RemoteAction(
             notify,
             PeerRingRemoteAction::Notify(me),
+        ));
+    }
+    // Head law: a stabilize that moves the head requests the hand-off toward it.
+    if let Some(head) = spec::head(me, &expected_successors)
+        .filter(|head| spec::head(me, current_successors) != Some(*head))
+    {
+        expected_actions.push(PeerRingAction::RemoteAction(
+            head,
+            PeerRingRemoteAction::HandOffStorage,
         ));
     }
 

--- a/crates/core/src/tests/default/test_dht_convergence.rs
+++ b/crates/core/src/tests/default/test_dht_convergence.rs
@@ -354,14 +354,11 @@ fn assert_correct_stabilize_matches_spec(
             PeerRingRemoteAction::Notify(me),
         ));
     }
-    // Head law: a stabilize that moves the head requests the hand-off toward it.
-    if let Some(head) = spec::head(me, &expected_successors)
-        .filter(|head| spec::head(me, current_successors) != Some(*head))
+    // Head law: a stabilize that moves the head makes a storage repair round due.
+    if spec::head(me, &expected_successors)
+        .is_some_and(|head| spec::head(me, current_successors) != Some(head))
     {
-        expected_actions.push(PeerRingAction::RemoteAction(
-            head,
-            PeerRingRemoteAction::HandOffStorage,
-        ));
+        expected_actions.push(PeerRingAction::StorageRepairDue);
     }
 
     assert_eq!(

--- a/crates/core/src/tests/default/test_dht_schedule.rs
+++ b/crates/core/src/tests/default/test_dht_schedule.rs
@@ -399,7 +399,11 @@ mod tests {
         for round in 1..=MAX_ROUNDS {
             let before = actual.clone();
             for sw in &swarms {
-                let _ = sw.stabilizer().stabilize().await;
+                let _ = sw
+                    .stabilizer()
+                    .expect("swarm callback lock must be healthy")
+                    .stabilize()
+                    .await;
             }
             let stats = drain(pick, &mut delivered).await;
             actual = inspect_all(&swarms);

--- a/crates/core/src/tests/default/test_dht_schedule.rs
+++ b/crates/core/src/tests/default/test_dht_schedule.rs
@@ -399,11 +399,7 @@ mod tests {
         for round in 1..=MAX_ROUNDS {
             let before = actual.clone();
             for sw in &swarms {
-                let _ = sw
-                    .stabilizer()
-                    .expect("swarm callback lock must be healthy")
-                    .stabilize()
-                    .await;
+                let _ = sw.stabilizer().stabilize().await;
             }
             let stats = drain(pick, &mut delivered).await;
             actual = inspect_all(&swarms);

--- a/crates/core/src/tests/default/test_dht_stateright/mod.rs
+++ b/crates/core/src/tests/default/test_dht_stateright/mod.rs
@@ -10,7 +10,7 @@
 //! losslessly to/from a real `PeerRing` (proven below), making real chord ops
 //! usable from a hashable model state. The models then use the `spec` operators
 //! (proven equal to production in `test_dht_convergence`) directly, which is far
-//! cheaper for the checker to expand than a `DashMap`-backed `PeerRing` per step.
+//! cheaper for the checker to expand than a storage-backed `PeerRing` per step.
 //!
 //! Both stages are deliberately scoped (see each stage's SCOPE note); they test
 //! sub-behaviours/abstractions, not a faithful model of the full 6-node regime.
@@ -162,7 +162,7 @@ impl ChordNode {
 
     /// The predecessor update — a direct reimplementation of `PeerRing::notify`
     /// (predecessor becomes the candidate closer *behind* `me`), used instead of
-    /// a throwaway `PeerRing` (which allocates a `DashMap`) so the checker can
+    /// a throwaway `PeerRing` (which allocates its storage) so the checker can
     /// expand states cheaply. It is NOT assumed equivalent: the test
     /// `test_apply_notify_matches_peer_ring` checks it against the real
     /// `PeerRing::notify` across representative states, so it remains a faithful

--- a/crates/core/src/tests/default/test_dht_stateright/storage_model.rs
+++ b/crates/core/src/tests/default/test_dht_stateright/storage_model.rs
@@ -53,6 +53,9 @@ use crate::message::Encoded;
 // ===================================================================
 
 pub(super) const STORAGE_REPLICA_COUNT: usize = 3;
+/// Retention bound shared by every model value; the model checks the payload lattice, and a
+/// common bound keeps the retention component of every join equal.
+const MODEL_RETENTION_BOUND_MS: Option<u128> = Some(u128::MAX);
 pub(super) const STORAGE_PARTITION_MASKS: [StoragePartition; STORAGE_REPLICA_COUNT] = [
     StoragePartition(0b001),
     StoragePartition(0b010),
@@ -230,6 +233,7 @@ fn data_value_range(did: Did, label: &'static str, start_time: u128, count: usiz
             dots,
             tombstones: Vec::new(),
         },
+        expires_at_ms: MODEL_RETENTION_BOUND_MS,
     }
 }
 
@@ -243,6 +247,7 @@ fn data_overwrite_value(did: Did, label: &'static str, version: EntryVersion) ->
             dots: vec![storage_dot(version, 0)],
             tombstones: Vec::new(),
         },
+        expires_at_ms: MODEL_RETENTION_BOUND_MS,
     }
 }
 
@@ -256,6 +261,7 @@ fn relay_add_value(did: Did, label: &'static str, dot: EntryDot) -> Entry {
             dots: vec![dot],
             tombstones: Vec::new(),
         },
+        expires_at_ms: MODEL_RETENTION_BOUND_MS,
     }
 }
 
@@ -269,6 +275,7 @@ fn relay_remove_value(did: Did, dot: EntryDot) -> Entry {
             dots: Vec::new(),
             tombstones: vec![dot],
         },
+        expires_at_ms: MODEL_RETENTION_BOUND_MS,
     }
 }
 

--- a/crates/core/src/tests/default/test_inbox.rs
+++ b/crates/core/src/tests/default/test_inbox.rs
@@ -1,6 +1,10 @@
 //! End-to-end law of the relay inbox: a message to an offline peer is held in the peer's inbox
 //! carrier by whichever node owns it, handed to the peer with its storage interval when the peer
 //! returns, delivered to the peer's application on stabilization, and compacted afterwards.
+//!
+//! The hand-off is the owner's stabilization placement invariant, so it holds however the owner
+//! learns of the returning peer: through its successor's notify report, or through a direct
+//! connection from the peer.
 
 use std::time::Instant;
 
@@ -20,6 +24,7 @@ use crate::message::PayloadSender;
 use crate::tests::default::prepare_node;
 use crate::tests::default::wait_for_msgs;
 use crate::tests::default::wait_for_predecessor;
+use crate::tests::default::wait_for_storage_absence;
 use crate::tests::default::wait_for_storage_entry;
 use crate::tests::default::wait_for_successor;
 use crate::tests::default::Node;
@@ -75,6 +80,46 @@ async fn wait_for_inbox_compaction(node: &Node, key: Did) -> Result<Entry> {
     }
 }
 
+/// Phase 1: node1 and node3 form the ring and a message to the absent `offline` is held.
+///
+/// node1 routes the message to succ(offline) = node3, which is responsible for the offline
+/// position and cannot deliver, so it holds the message in the inbox carrier `offline + 1`.
+/// That key lies in node1's storage interval `(node1, node3]`, so the write lands at node1.
+async fn hold_message_for_offline_peer(node1: &Node, node3: &Node, offline: Did) -> Result<()> {
+    manually_establish_connection(&node1.swarm, &node3.swarm).await;
+    wait_for_msgs([node1, node3]).await;
+    wait_for_successor(node1, node3.did()).await?;
+
+    node1
+        .swarm
+        .transport
+        .send_message(Message::custom(HELD_MESSAGE)?, offline)
+        .await?;
+    let held = wait_for_storage_entry(node1, inbox_key(offline)).await?;
+    assert_eq!(held.kind, EntryKind::RelayMessage);
+    assert_eq!(held.data.len(), 1);
+    assert!(held
+        .deliverable_inbox_messages(node1.swarm.network_id())
+        .iter()
+        .all(is_held_message));
+    Ok(())
+}
+
+/// Phase 3: the returned peer's own stabilization round drains its inbox to the application and
+/// compacts the delivered message out of the carrier.
+async fn assert_inbox_drained(peer: &Node, sender: Did) -> Result<()> {
+    let inbox = inbox_key(peer.did());
+    peer.swarm.stabilizer()?.stabilize().await?;
+
+    let delivered = next_held_message(peer).await?;
+    assert_eq!(delivered.transaction.destination, peer.did());
+    assert_eq!(delivered.transaction.signer(), sender);
+
+    let compacted = wait_for_inbox_compaction(peer, inbox).await?;
+    assert!(compacted.crdt.register.is_some());
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_message_to_offline_peer_is_held_and_delivered_on_return() -> Result<()> {
     let [key1, key2, key3] = gen_ordered_keys::<3>();
@@ -82,29 +127,12 @@ async fn test_message_to_offline_peer_is_held_and_delivered_on_return() -> Resul
     let node3 = prepare_node(key3).await;
     let offline: Did = key2.address().into();
     let inbox = inbox_key(offline);
-    manually_establish_connection(&node1.swarm, &node3.swarm).await;
-    wait_for_msgs([&node1, &node3]).await;
-    wait_for_successor(&node1, node3.did()).await?;
-
-    // node1 routes the message to succ(offline) = node3, which is responsible for the offline
-    // position and cannot deliver, so it holds the message in the inbox carrier `offline + 1`.
-    // That key lies in node1's storage interval `(node1, node3]`, so the write lands at node1.
-    node1
-        .swarm
-        .transport
-        .send_message(Message::custom(HELD_MESSAGE)?, offline)
-        .await?;
-    let held = wait_for_storage_entry(&node1, inbox).await?;
-    assert_eq!(held.kind, EntryKind::RelayMessage);
-    assert_eq!(held.data.len(), 1);
-    assert!(held
-        .deliverable_inbox_messages(node1.swarm.network_id())
-        .iter()
-        .all(is_held_message));
+    hold_message_for_offline_peer(&node1, &node3, offline).await?;
 
     // The peer returns by joining through its successor node3. node2 notifies node3, node1's
-    // next stabilization learns from node3 that node2 now precedes it, adopts node2 as successor,
-    // and hands over the inbox carrier, whose key lies in node2's interval `(node2, node3]`.
+    // next stabilization learns from node3 that node2 now precedes it and connects to it, and the
+    // admission moves node1's head to node2. The round after that hands over the inbox carrier,
+    // whose key lies in node2's interval `(node2, node3]`.
     let node2 = prepare_node(key2).await;
     manually_establish_connection(&node2.swarm, &node3.swarm).await;
     wait_for_msgs([&node1, &node2, &node3]).await;
@@ -115,16 +143,32 @@ async fn test_message_to_offline_peer_is_held_and_delivered_on_return() -> Resul
     node1.swarm.stabilizer()?.stabilize().await?;
     wait_for_msgs([&node1, &node2, &node3]).await;
     wait_for_successor(&node1, node2.did()).await?;
+    node1.swarm.stabilizer()?.stabilize().await?;
     wait_for_storage_entry(&node2, inbox).await?;
+    wait_for_storage_absence(&node1, inbox).await?;
 
-    // Draining happens on the peer's own stabilization round.
-    node2.swarm.stabilizer()?.stabilize().await?;
+    assert_inbox_drained(&node2, node1.did()).await
+}
 
-    let delivered = next_held_message(&node2).await?;
-    assert_eq!(delivered.transaction.destination, node2.did());
-    assert_eq!(delivered.transaction.signer(), node1.did());
+#[tokio::test]
+async fn test_held_message_is_delivered_when_peer_returns_through_its_predecessor() -> Result<()> {
+    let [key1, key2, key3] = gen_ordered_keys::<3>();
+    let node1 = prepare_node(key1).await;
+    let node3 = prepare_node(key3).await;
+    let offline: Did = key2.address().into();
+    let inbox = inbox_key(offline);
+    hold_message_for_offline_peer(&node1, &node3, offline).await?;
 
-    let compacted = wait_for_inbox_compaction(&node2, inbox).await?;
-    assert!(compacted.crdt.register.is_some());
-    Ok(())
+    // The peer returns by connecting straight to node1, the inbox owner. No notify report is
+    // exchanged: the admission itself moves node1's head to node2, and node1's next round hands
+    // the inbox carrier over.
+    let node2 = prepare_node(key2).await;
+    manually_establish_connection(&node2.swarm, &node1.swarm).await;
+    wait_for_msgs([&node1, &node2, &node3]).await;
+    wait_for_successor(&node1, node2.did()).await?;
+    node1.swarm.stabilizer()?.stabilize().await?;
+    wait_for_storage_entry(&node2, inbox).await?;
+    wait_for_storage_absence(&node1, inbox).await?;
+
+    assert_inbox_drained(&node2, node1.did()).await
 }

--- a/crates/core/src/tests/default/test_inbox.rs
+++ b/crates/core/src/tests/default/test_inbox.rs
@@ -85,9 +85,12 @@ async fn hold_message_for_offline_peer(node1: &Node, node3: &Node, offline: Did)
     let held = wait_for_storage_entry(node1, inbox_key(offline)).await?;
     assert_eq!(held.kind, EntryKind::RelayMessage);
     assert_eq!(held.data.len(), 1);
-    let drain = held.drain_inbox(get_epoch_ms(), node1.swarm.network_id());
-    assert_eq!(drain.rejected, 0);
-    assert!(drain.deliverable.iter().all(is_held_message));
+    let drain = held.partition_inbox(get_epoch_ms(), node1.swarm.network_id());
+    assert!(drain.rejected.crdt.dots.is_empty());
+    assert!(drain
+        .deliverable
+        .iter()
+        .all(|element| is_held_message(&element.payload)));
     Ok(())
 }
 

--- a/crates/core/src/tests/default/test_inbox.rs
+++ b/crates/core/src/tests/default/test_inbox.rs
@@ -8,7 +8,6 @@
 
 use std::time::Instant;
 
-use crate::dht::entry::inbox::inbox_key;
 use crate::dht::entry::EntryKind;
 use crate::dht::Did;
 use crate::dht::StorageKey;
@@ -34,11 +33,6 @@ use crate::utils::get_epoch_ms;
 use crate::utils::get_epoch_ms_i64;
 
 const HELD_MESSAGE: &[u8] = b"held while offline";
-
-/// The slot of the inbox carrier kept for `destination`.
-fn inbox_slot(destination: Did) -> StorageKey {
-    StorageKey::new(EntryKind::RelayMessage, inbox_key(destination))
-}
 
 fn is_held_message(payload: &MessagePayload) -> bool {
     matches!(
@@ -88,7 +82,7 @@ async fn hold_message_for_offline_peer(node1: &Node, node3: &Node, offline: Did)
         .transport
         .send_message(Message::custom(HELD_MESSAGE)?, offline)
         .await?;
-    let held = wait_for_storage_entry(node1, inbox_slot(offline)).await?;
+    let held = wait_for_storage_entry(node1, StorageKey::inbox_of(offline)).await?;
     assert_eq!(held.kind, EntryKind::RelayMessage);
     assert_eq!(held.data.len(), 1);
     let drain = held.partition_inbox(get_epoch_ms(), node1.swarm.network_id());
@@ -112,7 +106,7 @@ async fn hand_off_inbox(owner: &Node, peer: &Node) -> Result<()> {
         get_epoch_ms_i64() - STORAGE_REPAIR_FRESH_CONNECTION_GRACE_MS - 1,
     )?;
     owner.swarm.stabilizer().stabilize().await?;
-    let inbox = inbox_slot(peer.did());
+    let inbox = StorageKey::inbox_of(peer.did());
     wait_for_storage_entry(peer, inbox).await?;
     wait_for_storage_absence(owner, inbox).await
 }
@@ -120,7 +114,7 @@ async fn hand_off_inbox(owner: &Node, peer: &Node) -> Result<()> {
 /// Phase 3: the returned peer's own stabilization round drains its inbox to the application and
 /// retires the delivered message from the carrier by its dot.
 async fn drain_and_assert_delivered(peer: &Node, sender: Did) -> Result<()> {
-    let inbox = inbox_slot(peer.did());
+    let inbox = StorageKey::inbox_of(peer.did());
     peer.swarm.stabilizer().stabilize().await?;
 
     let delivered = next_held_message(peer).await?;

--- a/crates/core/src/tests/default/test_inbox.rs
+++ b/crates/core/src/tests/default/test_inbox.rs
@@ -11,6 +11,7 @@ use std::time::Instant;
 use crate::dht::entry::inbox::inbox_key;
 use crate::dht::entry::EntryKind;
 use crate::dht::Did;
+use crate::dht::StorageKey;
 use crate::dht::STORAGE_REPAIR_FRESH_CONNECTION_GRACE_MS;
 use crate::ecc::tests::gen_ordered_keys;
 use crate::error::Error;
@@ -33,6 +34,11 @@ use crate::utils::get_epoch_ms;
 use crate::utils::get_epoch_ms_i64;
 
 const HELD_MESSAGE: &[u8] = b"held while offline";
+
+/// The slot of the inbox carrier kept for `destination`.
+fn inbox_slot(destination: Did) -> StorageKey {
+    StorageKey::new(EntryKind::RelayMessage, inbox_key(destination))
+}
 
 fn is_held_message(payload: &MessagePayload) -> bool {
     matches!(
@@ -82,7 +88,7 @@ async fn hold_message_for_offline_peer(node1: &Node, node3: &Node, offline: Did)
         .transport
         .send_message(Message::custom(HELD_MESSAGE)?, offline)
         .await?;
-    let held = wait_for_storage_entry(node1, inbox_key(offline)).await?;
+    let held = wait_for_storage_entry(node1, inbox_slot(offline)).await?;
     assert_eq!(held.kind, EntryKind::RelayMessage);
     assert_eq!(held.data.len(), 1);
     let drain = held.partition_inbox(get_epoch_ms(), node1.swarm.network_id());
@@ -106,7 +112,7 @@ async fn hand_off_inbox(owner: &Node, peer: &Node) -> Result<()> {
         get_epoch_ms_i64() - STORAGE_REPAIR_FRESH_CONNECTION_GRACE_MS - 1,
     )?;
     owner.swarm.stabilizer().stabilize().await?;
-    let inbox = inbox_key(peer.did());
+    let inbox = inbox_slot(peer.did());
     wait_for_storage_entry(peer, inbox).await?;
     wait_for_storage_absence(owner, inbox).await
 }
@@ -114,7 +120,7 @@ async fn hand_off_inbox(owner: &Node, peer: &Node) -> Result<()> {
 /// Phase 3: the returned peer's own stabilization round drains its inbox to the application and
 /// retires the delivered message from the carrier by its dot.
 async fn drain_and_assert_delivered(peer: &Node, sender: Did) -> Result<()> {
-    let inbox = inbox_key(peer.did());
+    let inbox = inbox_slot(peer.did());
     peer.swarm.stabilizer().stabilize().await?;
 
     let delivered = next_held_message(peer).await?;

--- a/crates/core/src/tests/default/test_inbox.rs
+++ b/crates/core/src/tests/default/test_inbox.rs
@@ -2,9 +2,9 @@
 //! carrier by whichever node owns it, handed to the peer with its storage interval when the peer
 //! returns, delivered to the peer's application on stabilization, and compacted afterwards.
 //!
-//! The hand-off is the owner's stabilization placement invariant, so it holds however the owner
-//! learns of the returning peer: through its successor's notify report, or through a direct
-//! connection from the peer.
+//! The hand-off is the placement invariant of the owner's storage repair pass, so it holds however
+//! the owner learns of the returning peer: through its successor's notify report, or through a
+//! direct connection from the peer.
 
 use std::time::Instant;
 
@@ -14,6 +14,7 @@ use crate::dht::entry::inbox::inbox_key;
 use crate::dht::entry::Entry;
 use crate::dht::entry::EntryKind;
 use crate::dht::Did;
+use crate::dht::STORAGE_REPAIR_FRESH_CONNECTION_GRACE_MS;
 use crate::ecc::tests::gen_ordered_keys;
 use crate::error::Error;
 use crate::error::Result;
@@ -31,6 +32,7 @@ use crate::tests::default::Node;
 use crate::tests::default::TEST_WAIT_POLL_INTERVAL;
 use crate::tests::default::TEST_WAIT_TIMEOUT;
 use crate::tests::manually_establish_connection;
+use crate::utils::get_epoch_ms_i64;
 
 const HELD_MESSAGE: &[u8] = b"held while offline";
 
@@ -105,6 +107,20 @@ async fn hold_message_for_offline_peer(node1: &Node, node3: &Node, offline: Did)
     Ok(())
 }
 
+/// Phase 2: the owner's storage repair pass hands the inbox carrier to the returned peer. The pass
+/// defers to a connection younger than the fresh-connection grace, so the connection is aged past
+/// it first; the acknowledgement then removes the owner's copy.
+async fn hand_off_inbox(owner: &Node, peer: &Node) -> Result<()> {
+    owner.swarm.transport.force_peer_connected_at(
+        peer.did(),
+        get_epoch_ms_i64() - STORAGE_REPAIR_FRESH_CONNECTION_GRACE_MS - 1,
+    )?;
+    owner.swarm.stabilizer()?.stabilize().await?;
+    let inbox = inbox_key(peer.did());
+    wait_for_storage_entry(peer, inbox).await?;
+    wait_for_storage_absence(owner, inbox).await
+}
+
 /// Phase 3: the returned peer's own stabilization round drains its inbox to the application and
 /// compacts the delivered message out of the carrier.
 async fn assert_inbox_drained(peer: &Node, sender: Did) -> Result<()> {
@@ -126,12 +142,11 @@ async fn test_message_to_offline_peer_is_held_and_delivered_on_return() -> Resul
     let node1 = prepare_node(key1).await;
     let node3 = prepare_node(key3).await;
     let offline: Did = key2.address().into();
-    let inbox = inbox_key(offline);
     hold_message_for_offline_peer(&node1, &node3, offline).await?;
 
     // The peer returns by joining through its successor node3. node2 notifies node3, node1's
     // next stabilization learns from node3 that node2 now precedes it and connects to it, and the
-    // admission moves node1's head to node2. The round after that hands over the inbox carrier,
+    // admission moves node1's head to node2. The repair pass then hands over the inbox carrier,
     // whose key lies in node2's interval `(node2, node3]`.
     let node2 = prepare_node(key2).await;
     manually_establish_connection(&node2.swarm, &node3.swarm).await;
@@ -143,9 +158,7 @@ async fn test_message_to_offline_peer_is_held_and_delivered_on_return() -> Resul
     node1.swarm.stabilizer()?.stabilize().await?;
     wait_for_msgs([&node1, &node2, &node3]).await;
     wait_for_successor(&node1, node2.did()).await?;
-    node1.swarm.stabilizer()?.stabilize().await?;
-    wait_for_storage_entry(&node2, inbox).await?;
-    wait_for_storage_absence(&node1, inbox).await?;
+    hand_off_inbox(&node1, &node2).await?;
 
     assert_inbox_drained(&node2, node1.did()).await
 }
@@ -156,19 +169,17 @@ async fn test_held_message_is_delivered_when_peer_returns_through_its_predecesso
     let node1 = prepare_node(key1).await;
     let node3 = prepare_node(key3).await;
     let offline: Did = key2.address().into();
-    let inbox = inbox_key(offline);
     hold_message_for_offline_peer(&node1, &node3, offline).await?;
 
     // The peer returns by connecting straight to node1, the inbox owner. No notify report is
-    // exchanged: the admission itself moves node1's head to node2, and node1's next round hands
-    // the inbox carrier over.
+    // exchanged: the admission itself moves node1's head to node2 and requests the repair pass
+    // that hands the inbox carrier over.
     let node2 = prepare_node(key2).await;
     manually_establish_connection(&node2.swarm, &node1.swarm).await;
     wait_for_msgs([&node1, &node2, &node3]).await;
     wait_for_successor(&node1, node2.did()).await?;
-    node1.swarm.stabilizer()?.stabilize().await?;
-    wait_for_storage_entry(&node2, inbox).await?;
-    wait_for_storage_absence(&node1, inbox).await?;
+    assert!(node1.swarm.transport.storage_repair_requested());
+    hand_off_inbox(&node1, &node2).await?;
 
     assert_inbox_drained(&node2, node1.did()).await
 }

--- a/crates/core/src/tests/default/test_inbox.rs
+++ b/crates/core/src/tests/default/test_inbox.rs
@@ -1,0 +1,130 @@
+//! End-to-end law of the relay inbox: a message to an offline peer is held in the peer's inbox
+//! carrier by whichever node owns it, handed to the peer with its storage interval when the peer
+//! returns, delivered to the peer's application on stabilization, and compacted afterwards.
+
+use std::time::Instant;
+
+use tokio::time::sleep;
+
+use crate::dht::entry::inbox::inbox_key;
+use crate::dht::entry::Entry;
+use crate::dht::entry::EntryKind;
+use crate::dht::Did;
+use crate::ecc::tests::gen_ordered_keys;
+use crate::error::Error;
+use crate::error::Result;
+use crate::message::Message;
+use crate::message::MessagePayload;
+use crate::message::MessageVerificationExt;
+use crate::message::PayloadSender;
+use crate::tests::default::prepare_node;
+use crate::tests::default::wait_for_msgs;
+use crate::tests::default::wait_for_predecessor;
+use crate::tests::default::wait_for_storage_entry;
+use crate::tests::default::wait_for_successor;
+use crate::tests::default::Node;
+use crate::tests::default::TEST_WAIT_POLL_INTERVAL;
+use crate::tests::default::TEST_WAIT_TIMEOUT;
+use crate::tests::manually_establish_connection;
+
+const HELD_MESSAGE: &[u8] = b"held while offline";
+
+fn is_held_message(payload: &MessagePayload) -> bool {
+    matches!(
+        payload.transaction.data::<Message>(),
+        Ok(Message::CustomMessage(message)) if message.0 == HELD_MESSAGE
+    )
+}
+
+async fn next_held_message(node: &Node) -> Result<MessagePayload> {
+    let deadline = Instant::now() + TEST_WAIT_TIMEOUT;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(Error::InvalidMessage(
+                "held message was not delivered from the inbox".to_string(),
+            ));
+        }
+        match tokio::time::timeout(remaining, node.listen_once()).await {
+            Ok(Some(payload)) if is_held_message(&payload) => return Ok(payload),
+            Ok(Some(_)) => continue,
+            Ok(None) => {
+                return Err(Error::InvalidMessage(
+                    "message channel closed before the held message arrived".to_string(),
+                ));
+            }
+            Err(_) => continue,
+        }
+    }
+}
+
+async fn wait_for_inbox_compaction(node: &Node, key: Did) -> Result<Entry> {
+    let started = Instant::now();
+    loop {
+        if let Some(entry) = node.dht().storage.get(&key.to_string()).await? {
+            if entry.data.is_empty() {
+                return Ok(entry);
+            }
+        }
+        assert!(
+            started.elapsed() <= TEST_WAIT_TIMEOUT,
+            "inbox at {key} was not compacted within {TEST_WAIT_TIMEOUT:?}"
+        );
+        tokio::task::yield_now().await;
+        sleep(TEST_WAIT_POLL_INTERVAL).await;
+    }
+}
+
+#[tokio::test]
+async fn test_message_to_offline_peer_is_held_and_delivered_on_return() -> Result<()> {
+    let [key1, key2, key3] = gen_ordered_keys::<3>();
+    let node1 = prepare_node(key1).await;
+    let node3 = prepare_node(key3).await;
+    let offline: Did = key2.address().into();
+    let inbox = inbox_key(offline);
+    manually_establish_connection(&node1.swarm, &node3.swarm).await;
+    wait_for_msgs([&node1, &node3]).await;
+    wait_for_successor(&node1, node3.did()).await?;
+
+    // node1 routes the message to succ(offline) = node3, which is responsible for the offline
+    // position and cannot deliver, so it holds the message in the inbox carrier `offline + 1`.
+    // That key lies in node1's storage interval `(node1, node3]`, so the write lands at node1.
+    node1
+        .swarm
+        .transport
+        .send_message(Message::custom(HELD_MESSAGE)?, offline)
+        .await?;
+    let held = wait_for_storage_entry(&node1, inbox).await?;
+    assert_eq!(held.kind, EntryKind::RelayMessage);
+    assert_eq!(held.data.len(), 1);
+    assert!(held
+        .deliverable_inbox_messages(node1.swarm.network_id())
+        .iter()
+        .all(is_held_message));
+
+    // The peer returns by joining through its successor node3. node2 notifies node3, node1's
+    // next stabilization learns from node3 that node2 now precedes it, adopts node2 as successor,
+    // and hands over the inbox carrier, whose key lies in node2's interval `(node2, node3]`.
+    let node2 = prepare_node(key2).await;
+    manually_establish_connection(&node2.swarm, &node3.swarm).await;
+    wait_for_msgs([&node1, &node2, &node3]).await;
+    wait_for_successor(&node2, node3.did()).await?;
+    node2.swarm.stabilizer()?.stabilize().await?;
+    wait_for_msgs([&node1, &node2, &node3]).await;
+    wait_for_predecessor(&node3, node2.did()).await?;
+    node1.swarm.stabilizer()?.stabilize().await?;
+    wait_for_msgs([&node1, &node2, &node3]).await;
+    wait_for_successor(&node1, node2.did()).await?;
+    wait_for_storage_entry(&node2, inbox).await?;
+
+    // Draining happens on the peer's own stabilization round.
+    node2.swarm.stabilizer()?.stabilize().await?;
+
+    let delivered = next_held_message(&node2).await?;
+    assert_eq!(delivered.transaction.destination, node2.did());
+    assert_eq!(delivered.transaction.signer(), node1.did());
+
+    let compacted = wait_for_inbox_compaction(&node2, inbox).await?;
+    assert!(compacted.crdt.register.is_some());
+    Ok(())
+}

--- a/crates/core/src/tests/default/test_inbox.rs
+++ b/crates/core/src/tests/default/test_inbox.rs
@@ -8,10 +8,7 @@
 
 use std::time::Instant;
 
-use tokio::time::sleep;
-
 use crate::dht::entry::inbox::inbox_key;
-use crate::dht::entry::Entry;
 use crate::dht::entry::EntryKind;
 use crate::dht::Did;
 use crate::dht::STORAGE_REPAIR_FRESH_CONNECTION_GRACE_MS;
@@ -27,11 +24,12 @@ use crate::tests::default::wait_for_msgs;
 use crate::tests::default::wait_for_predecessor;
 use crate::tests::default::wait_for_storage_absence;
 use crate::tests::default::wait_for_storage_entry;
+use crate::tests::default::wait_for_storage_state;
 use crate::tests::default::wait_for_successor;
 use crate::tests::default::Node;
-use crate::tests::default::TEST_WAIT_POLL_INTERVAL;
 use crate::tests::default::TEST_WAIT_TIMEOUT;
 use crate::tests::manually_establish_connection;
+use crate::utils::get_epoch_ms;
 use crate::utils::get_epoch_ms_i64;
 
 const HELD_MESSAGE: &[u8] = b"held while offline";
@@ -65,23 +63,6 @@ async fn next_held_message(node: &Node) -> Result<MessagePayload> {
     }
 }
 
-async fn wait_for_inbox_compaction(node: &Node, key: Did) -> Result<Entry> {
-    let started = Instant::now();
-    loop {
-        if let Some(entry) = node.dht().storage.get(&key.to_string()).await? {
-            if entry.data.is_empty() {
-                return Ok(entry);
-            }
-        }
-        assert!(
-            started.elapsed() <= TEST_WAIT_TIMEOUT,
-            "inbox at {key} was not compacted within {TEST_WAIT_TIMEOUT:?}"
-        );
-        tokio::task::yield_now().await;
-        sleep(TEST_WAIT_POLL_INTERVAL).await;
-    }
-}
-
 /// Phase 1: node1 and node3 form the ring and a message to the absent `offline` is held.
 ///
 /// node1 routes the message to succ(offline) = node3, which is responsible for the offline
@@ -91,6 +72,10 @@ async fn hold_message_for_offline_peer(node1: &Node, node3: &Node, offline: Did)
     manually_establish_connection(&node1.swarm, &node3.swarm).await;
     wait_for_msgs([node1, node3]).await;
     wait_for_successor(node1, node3.did()).await?;
+    // node3 is responsible for `offline` only once it knows node1 as its predecessor.
+    node1.swarm.stabilizer().stabilize().await?;
+    wait_for_msgs([node1, node3]).await;
+    wait_for_predecessor(node3, node1.did()).await?;
 
     node1
         .swarm
@@ -100,39 +85,46 @@ async fn hold_message_for_offline_peer(node1: &Node, node3: &Node, offline: Did)
     let held = wait_for_storage_entry(node1, inbox_key(offline)).await?;
     assert_eq!(held.kind, EntryKind::RelayMessage);
     assert_eq!(held.data.len(), 1);
-    assert!(held
-        .deliverable_inbox_messages(node1.swarm.network_id())
-        .iter()
-        .all(is_held_message));
+    let drain = held.drain_inbox(get_epoch_ms(), node1.swarm.network_id());
+    assert_eq!(drain.rejected, 0);
+    assert!(drain.deliverable.iter().all(is_held_message));
     Ok(())
 }
 
-/// Phase 2: the owner's storage repair pass hands the inbox carrier to the returned peer. The pass
-/// defers to a connection younger than the fresh-connection grace, so the connection is aged past
-/// it first; the acknowledgement then removes the owner's copy.
+/// Phase 2: the owner's storage repair pass hands the inbox carrier to the returned peer. The
+/// peer accepts a relay carrier only from its predecessor, so the owner's notify must have
+/// reached it first; the pass defers to a connection younger than the fresh-connection grace, so
+/// the connection is aged past it; the acknowledgement then removes the owner's copy.
 async fn hand_off_inbox(owner: &Node, peer: &Node) -> Result<()> {
+    owner.swarm.stabilizer().stabilize().await?;
+    wait_for_predecessor(peer, owner.did()).await?;
     owner.swarm.transport.force_peer_connected_at(
         peer.did(),
         get_epoch_ms_i64() - STORAGE_REPAIR_FRESH_CONNECTION_GRACE_MS - 1,
     )?;
-    owner.swarm.stabilizer()?.stabilize().await?;
+    owner.swarm.stabilizer().stabilize().await?;
     let inbox = inbox_key(peer.did());
     wait_for_storage_entry(peer, inbox).await?;
     wait_for_storage_absence(owner, inbox).await
 }
 
 /// Phase 3: the returned peer's own stabilization round drains its inbox to the application and
-/// compacts the delivered message out of the carrier.
-async fn assert_inbox_drained(peer: &Node, sender: Did) -> Result<()> {
+/// retires the delivered message from the carrier by its dot.
+async fn drain_and_assert_delivered(peer: &Node, sender: Did) -> Result<()> {
     let inbox = inbox_key(peer.did());
-    peer.swarm.stabilizer()?.stabilize().await?;
+    peer.swarm.stabilizer().stabilize().await?;
 
     let delivered = next_held_message(peer).await?;
     assert_eq!(delivered.transaction.destination, peer.did());
     assert_eq!(delivered.transaction.signer(), sender);
 
-    let compacted = wait_for_inbox_compaction(peer, inbox).await?;
-    assert!(compacted.crdt.register.is_some());
+    let retired = wait_for_storage_state(peer, inbox, "drained", |stored| {
+        stored.is_some_and(|entry| entry.data.is_empty())
+    })
+    .await?
+    .ok_or_else(|| Error::InvalidMessage("drained inbox vanished".to_string()))?;
+    assert!(retired.crdt.register.is_none());
+    assert!(!retired.crdt.tombstones.is_empty());
     Ok(())
 }
 
@@ -152,15 +144,15 @@ async fn test_message_to_offline_peer_is_held_and_delivered_on_return() -> Resul
     manually_establish_connection(&node2.swarm, &node3.swarm).await;
     wait_for_msgs([&node1, &node2, &node3]).await;
     wait_for_successor(&node2, node3.did()).await?;
-    node2.swarm.stabilizer()?.stabilize().await?;
+    node2.swarm.stabilizer().stabilize().await?;
     wait_for_msgs([&node1, &node2, &node3]).await;
     wait_for_predecessor(&node3, node2.did()).await?;
-    node1.swarm.stabilizer()?.stabilize().await?;
+    node1.swarm.stabilizer().stabilize().await?;
     wait_for_msgs([&node1, &node2, &node3]).await;
     wait_for_successor(&node1, node2.did()).await?;
     hand_off_inbox(&node1, &node2).await?;
 
-    assert_inbox_drained(&node2, node1.did()).await
+    drain_and_assert_delivered(&node2, node1.did()).await
 }
 
 #[tokio::test]
@@ -181,5 +173,5 @@ async fn test_held_message_is_delivered_when_peer_returns_through_its_predecesso
     assert!(node1.swarm.transport.storage_repair_requested());
     hand_off_inbox(&node1, &node2).await?;
 
-    assert_inbox_drained(&node2, node1.did()).await
+    drain_and_assert_delivered(&node2, node1.did()).await
 }

--- a/crates/core/src/tests/default/test_message_handler.rs
+++ b/crates/core/src/tests/default/test_message_handler.rs
@@ -11,6 +11,7 @@ use tokio::time::timeout;
 use tokio::time::Duration;
 
 use crate::dht::entry::Entry;
+use crate::dht::entry::EntryKind;
 use crate::dht::entry::EntryOperation;
 use crate::dht::entry::PlacedEntryOperation;
 use crate::dht::successor::SuccessorReader;
@@ -18,6 +19,7 @@ use crate::dht::successor::SuccessorReader;
 use crate::dht::PeerRingAction;
 #[cfg(feature = "dummy")]
 use crate::dht::PeerRingRemoteAction;
+use crate::dht::StorageKey;
 use crate::ecc::tests::gen_ordered_keys;
 use crate::ecc::SecretKey;
 use crate::error::Error;
@@ -405,7 +407,7 @@ async fn test_handle_storage() -> Result<()> {
         )
         .await
         .unwrap();
-    let data = wait_for_storage_entry(&node2, entry.did).await?;
+    let data = wait_for_storage_entry(&node2, StorageKey::new(EntryKind::Data, entry.did)).await?;
     assert!(node1.dht().storage.count().await.unwrap() == 0);
     assert!(node2.dht().storage.count().await.unwrap() > 0);
     assert_eq!(data.data[0].clone().decode::<String>().unwrap(), message);

--- a/crates/core/src/tests/default/test_outbound_scheduler/mod.rs
+++ b/crates/core/src/tests/default/test_outbound_scheduler/mod.rs
@@ -69,7 +69,7 @@ async fn connected_nodes() -> Result<(Node, Node)> {
 fn tracked_payload(node: &Node, peer: Did, body: &[u8]) -> Result<MessagePayload> {
     MessagePayload::new_send(
         Message::custom(body)?,
-        node.swarm.transport.session_sk(),
+        node.swarm.transport.message_signer(),
         peer,
         peer,
     )
@@ -134,7 +134,7 @@ async fn test_tracked_timeout_removes_target_behind_multiple_predecessors() -> R
             let body = format!("queued-predecessor-{index}");
             let payload = MessagePayload::new_send(
                 Message::custom(body.as_bytes())?,
-                swarm.transport.session_sk(),
+                swarm.transport.message_signer(),
                 peer,
                 peer,
             )?;
@@ -781,7 +781,7 @@ fn spawn_data_capacity_transfers(node: &Node, peer: Did) -> Vec<JoinHandle<Resul
             let body = format!("capacity-transfer-{index}");
             let payload = MessagePayload::new_send(
                 Message::custom(body.as_bytes())?,
-                swarm.transport.session_sk(),
+                swarm.transport.message_signer(),
                 peer,
                 peer,
             )?;
@@ -834,7 +834,7 @@ fn spawn_reserved_control_transfers(
                 Message::PeerLivenessProbe(PeerLivenessProbe {
                     sent_at_ms: index as i64,
                 }),
-                swarm.transport.session_sk(),
+                swarm.transport.message_signer(),
                 peer,
                 peer,
             )?;

--- a/crates/core/src/tests/default/test_outbound_scheduler/test_boundaries.rs
+++ b/crates/core/src/tests/default/test_outbound_scheduler/test_boundaries.rs
@@ -78,7 +78,7 @@ async fn test_oversized_payload_log_omits_the_custom_message_body() -> Result<()
     let relay_destination: Did = SecretKey::random().address().into();
     let mut payload = MessagePayload::new_send(
         Message::CustomMessage(CustomMessage(body)),
-        node1.swarm.transport.session_sk(),
+        node1.swarm.transport.message_signer(),
         next_hop,
         destination,
     )?;

--- a/crates/core/src/tests/default/test_outbound_scheduler/test_delivery.rs
+++ b/crates/core/src/tests/default/test_outbound_scheduler/test_delivery.rs
@@ -154,7 +154,7 @@ async fn test_delivery_timeout_marks_generation_terminal_before_releasing_fifo_l
     assert_eq!(dummy_controlled::sent_count(), 1);
     timeout(
         Duration::from_secs(2),
-        node1.swarm.stabilizer()?.clean_unavailable_connections(),
+        node1.swarm.stabilizer().clean_unavailable_connections(),
     )
     .await
     .map_err(|_| invalid_test_state("terminal generation cleanup stayed pending"))??;

--- a/crates/core/src/tests/default/test_outbound_scheduler/test_delivery.rs
+++ b/crates/core/src/tests/default/test_outbound_scheduler/test_delivery.rs
@@ -154,7 +154,7 @@ async fn test_delivery_timeout_marks_generation_terminal_before_releasing_fifo_l
     assert_eq!(dummy_controlled::sent_count(), 1);
     timeout(
         Duration::from_secs(2),
-        node1.swarm.stabilizer().clean_unavailable_connections(),
+        node1.swarm.stabilizer()?.clean_unavailable_connections(),
     )
     .await
     .map_err(|_| invalid_test_state("terminal generation cleanup stayed pending"))??;

--- a/crates/core/src/tests/default/test_stabilization/mod.rs
+++ b/crates/core/src/tests/default/test_stabilization/mod.rs
@@ -177,7 +177,10 @@ fn entry_for_remote_repair_placement(node: &Node, successor: Did) -> Result<(Ent
     ) {
         // `rotate_affine(n)[0] = self`, so choosing the witnessed placement as the entry key
         // deterministically makes it one of the repair placements for every non-zero redundancy.
-        return Ok((Entry::new(placement, vec![], EntryKind::Data), placement));
+        return Ok((
+            crate::tests::live_entry(placement, vec![], EntryKind::Data),
+            placement,
+        ));
     }
     Err(Error::InvalidMessage(
         "remote repair fixture DID did not route remotely".to_string(),

--- a/crates/core/src/tests/default/test_stabilization/mod.rs
+++ b/crates/core/src/tests/default/test_stabilization/mod.rs
@@ -47,6 +47,7 @@ use crate::tests::manually_establish_connection;
 use crate::tests::replace_observed_fingers;
 use crate::utils::get_epoch_ms_i64;
 
+#[cfg(all(feature = "dummy", not(target_family = "wasm")))]
 mod test_storage_handoff;
 mod test_storage_repair;
 

--- a/crates/core/src/tests/default/test_stabilization/mod.rs
+++ b/crates/core/src/tests/default/test_stabilization/mod.rs
@@ -219,7 +219,7 @@ async fn test_stabilization_once() -> Result<()> {
     wait_for_successor(&node1, node2.did()).await?;
     wait_for_successor(&node2, node1.did()).await?;
 
-    let stabilizer = node1.swarm.stabilizer();
+    let stabilizer = node1.swarm.stabilizer()?;
     stabilizer.stabilize().await?;
     wait_for_predecessor(&node2, node1.did()).await?;
     wait_for_successor(&node1, node2.did()).await?;
@@ -308,7 +308,7 @@ async fn test_liveness_probe_backpressure_does_not_degrade_peer() -> Result<()> 
     let _pending_send = PendingSendGuard::new();
     node1
         .swarm
-        .stabilizer()
+        .stabilizer()?
         .stabilize_with_step_timeout(Duration::from_secs(1))
         .await?;
 
@@ -348,7 +348,7 @@ async fn test_clean_unavailable_connections_removes_silent_connected_peer() -> R
     let _drop_messages = DropMessagesGuard::new();
     node1
         .swarm
-        .stabilizer()
+        .stabilizer()?
         .clean_unavailable_connections()
         .await?;
 
@@ -397,7 +397,7 @@ async fn test_clean_unavailable_connections_observes_disconnected_peer_without_c
 
     node1
         .swarm
-        .stabilizer()
+        .stabilizer()?
         .clean_unavailable_connections()
         .await?;
 
@@ -418,7 +418,7 @@ async fn test_clean_unavailable_connections_observes_disconnected_peer_without_c
 
     node1
         .swarm
-        .stabilizer()
+        .stabilizer()?
         .clean_unavailable_connections()
         .await?;
 
@@ -458,7 +458,7 @@ async fn test_clean_unavailable_connections_fails_over_to_live_successor_tail() 
 
     node1
         .swarm
-        .stabilizer()
+        .stabilizer()?
         .clean_unavailable_connections()
         .await?;
 
@@ -523,7 +523,7 @@ async fn test_clean_unavailable_connections_prunes_disconnected_non_head_slots()
 
     node1
         .swarm
-        .stabilizer()
+        .stabilizer()?
         .clean_unavailable_connections()
         .await?;
 
@@ -592,7 +592,7 @@ async fn test_clean_unavailable_connections_does_not_fail_over_to_disconnected_f
 
     node1
         .swarm
-        .stabilizer()
+        .stabilizer()?
         .clean_unavailable_connections()
         .await?;
 
@@ -646,7 +646,7 @@ async fn test_clean_unavailable_connections_prunes_disconnected_finger() -> Resu
 
     node1
         .swarm
-        .stabilizer()
+        .stabilizer()?
         .clean_unavailable_connections()
         .await?;
 
@@ -676,7 +676,7 @@ async fn test_clean_unavailable_connections_prunes_disconnected_finger() -> Resu
 
     node1
         .swarm
-        .stabilizer()
+        .stabilizer()?
         .clean_unavailable_connections()
         .await?;
 
@@ -706,7 +706,7 @@ async fn test_clean_unavailable_connections_removes_stale_topology_peer() -> Res
     assert!(!node.swarm.transport.is_admitted_connection(stale));
 
     node.swarm
-        .stabilizer()
+        .stabilizer()?
         .clean_unavailable_connections()
         .await?;
 
@@ -755,7 +755,7 @@ async fn test_clean_unavailable_connections_keeps_degraded_admitted_peer() -> Re
 
     node1
         .swarm
-        .stabilizer()
+        .stabilizer()?
         .clean_unavailable_connections()
         .await?;
 
@@ -782,8 +782,8 @@ async fn test_stabilization() -> Result<()> {
     wait_for_successor(&node1, node2.did()).await?;
     wait_for_successor(&node2, node1.did()).await?;
 
-    let stabilizer1 = node1.swarm.stabilizer();
-    let stabilizer2 = node2.swarm.stabilizer();
+    let stabilizer1 = node1.swarm.stabilizer()?;
+    let stabilizer2 = node2.swarm.stabilizer()?;
     tokio::try_join!(stabilizer1.stabilize(), stabilizer2.stabilize())?;
 
     wait_for_predecessor(&node2, node1.did()).await?;

--- a/crates/core/src/tests/default/test_stabilization/mod.rs
+++ b/crates/core/src/tests/default/test_stabilization/mod.rs
@@ -47,6 +47,7 @@ use crate::tests::manually_establish_connection;
 use crate::tests::replace_observed_fingers;
 use crate::utils::get_epoch_ms_i64;
 
+mod test_storage_handoff;
 mod test_storage_repair;
 
 #[derive(Default)]

--- a/crates/core/src/tests/default/test_stabilization/mod.rs
+++ b/crates/core/src/tests/default/test_stabilization/mod.rs
@@ -43,6 +43,7 @@ use crate::tests::default::wait_for_msgs;
 use crate::tests::default::wait_for_predecessor;
 use crate::tests::default::wait_for_successor;
 use crate::tests::default::Node;
+use crate::tests::live_entry;
 use crate::tests::manually_establish_connection;
 use crate::tests::replace_observed_fingers;
 use crate::utils::get_epoch_ms_i64;
@@ -179,10 +180,7 @@ fn entry_for_remote_repair_placement(node: &Node, successor: Did) -> Result<(Ent
     ) {
         // `rotate_affine(n)[0] = self`, so choosing the witnessed placement as the entry key
         // deterministically makes it one of the repair placements for every non-zero redundancy.
-        return Ok((
-            crate::tests::live_entry(placement, vec![], EntryKind::Data),
-            placement,
-        ));
+        return Ok((live_entry(placement, vec![], EntryKind::Data), placement));
     }
     Err(Error::InvalidMessage(
         "remote repair fixture DID did not route remotely".to_string(),

--- a/crates/core/src/tests/default/test_stabilization/mod.rs
+++ b/crates/core/src/tests/default/test_stabilization/mod.rs
@@ -221,7 +221,7 @@ async fn test_stabilization_once() -> Result<()> {
     wait_for_successor(&node1, node2.did()).await?;
     wait_for_successor(&node2, node1.did()).await?;
 
-    let stabilizer = node1.swarm.stabilizer()?;
+    let stabilizer = node1.swarm.stabilizer();
     stabilizer.stabilize().await?;
     wait_for_predecessor(&node2, node1.did()).await?;
     wait_for_successor(&node1, node2.did()).await?;
@@ -310,7 +310,7 @@ async fn test_liveness_probe_backpressure_does_not_degrade_peer() -> Result<()> 
     let _pending_send = PendingSendGuard::new();
     node1
         .swarm
-        .stabilizer()?
+        .stabilizer()
         .stabilize_with_step_timeout(Duration::from_secs(1))
         .await?;
 
@@ -350,7 +350,7 @@ async fn test_clean_unavailable_connections_removes_silent_connected_peer() -> R
     let _drop_messages = DropMessagesGuard::new();
     node1
         .swarm
-        .stabilizer()?
+        .stabilizer()
         .clean_unavailable_connections()
         .await?;
 
@@ -399,7 +399,7 @@ async fn test_clean_unavailable_connections_observes_disconnected_peer_without_c
 
     node1
         .swarm
-        .stabilizer()?
+        .stabilizer()
         .clean_unavailable_connections()
         .await?;
 
@@ -420,7 +420,7 @@ async fn test_clean_unavailable_connections_observes_disconnected_peer_without_c
 
     node1
         .swarm
-        .stabilizer()?
+        .stabilizer()
         .clean_unavailable_connections()
         .await?;
 
@@ -460,7 +460,7 @@ async fn test_clean_unavailable_connections_fails_over_to_live_successor_tail() 
 
     node1
         .swarm
-        .stabilizer()?
+        .stabilizer()
         .clean_unavailable_connections()
         .await?;
 
@@ -525,7 +525,7 @@ async fn test_clean_unavailable_connections_prunes_disconnected_non_head_slots()
 
     node1
         .swarm
-        .stabilizer()?
+        .stabilizer()
         .clean_unavailable_connections()
         .await?;
 
@@ -594,7 +594,7 @@ async fn test_clean_unavailable_connections_does_not_fail_over_to_disconnected_f
 
     node1
         .swarm
-        .stabilizer()?
+        .stabilizer()
         .clean_unavailable_connections()
         .await?;
 
@@ -648,7 +648,7 @@ async fn test_clean_unavailable_connections_prunes_disconnected_finger() -> Resu
 
     node1
         .swarm
-        .stabilizer()?
+        .stabilizer()
         .clean_unavailable_connections()
         .await?;
 
@@ -678,7 +678,7 @@ async fn test_clean_unavailable_connections_prunes_disconnected_finger() -> Resu
 
     node1
         .swarm
-        .stabilizer()?
+        .stabilizer()
         .clean_unavailable_connections()
         .await?;
 
@@ -708,7 +708,7 @@ async fn test_clean_unavailable_connections_removes_stale_topology_peer() -> Res
     assert!(!node.swarm.transport.is_admitted_connection(stale));
 
     node.swarm
-        .stabilizer()?
+        .stabilizer()
         .clean_unavailable_connections()
         .await?;
 
@@ -757,7 +757,7 @@ async fn test_clean_unavailable_connections_keeps_degraded_admitted_peer() -> Re
 
     node1
         .swarm
-        .stabilizer()?
+        .stabilizer()
         .clean_unavailable_connections()
         .await?;
 
@@ -784,8 +784,8 @@ async fn test_stabilization() -> Result<()> {
     wait_for_successor(&node1, node2.did()).await?;
     wait_for_successor(&node2, node1.did()).await?;
 
-    let stabilizer1 = node1.swarm.stabilizer()?;
-    let stabilizer2 = node2.swarm.stabilizer()?;
+    let stabilizer1 = node1.swarm.stabilizer();
+    let stabilizer2 = node2.swarm.stabilizer();
     tokio::try_join!(stabilizer1.stabilize(), stabilizer2.stabilize())?;
 
     wait_for_predecessor(&node2, node1.did()).await?;

--- a/crates/core/src/tests/default/test_stabilization/test_storage_handoff.rs
+++ b/crates/core/src/tests/default/test_stabilization/test_storage_handoff.rs
@@ -4,6 +4,8 @@
 //! reports, and admitting it only requests the pass.
 
 use super::*;
+use crate::dht::entry::EntryKind;
+use crate::dht::StorageKey;
 use crate::dht::STORAGE_REPAIR_FRESH_CONNECTION_GRACE_MS;
 use crate::ecc::tests::gen_ordered_keys;
 use crate::message::Encoder;
@@ -65,10 +67,8 @@ async fn test_repair_pass_hands_off_entries_beyond_a_directly_connected_head() -
         Some(StorageRepairOutcome::Complete)
     );
 
-    assert_eq!(
-        wait_for_storage_entry(&node2, entry.did).await?,
-        stored_entry
-    );
-    wait_for_storage_absence(&node1, entry.did).await?;
+    let slot = StorageKey::new(EntryKind::Data, entry.did);
+    assert_eq!(wait_for_storage_entry(&node2, slot).await?, stored_entry);
+    wait_for_storage_absence(&node1, slot).await?;
     Ok(())
 }

--- a/crates/core/src/tests/default/test_stabilization/test_storage_handoff.rs
+++ b/crates/core/src/tests/default/test_stabilization/test_storage_handoff.rs
@@ -39,7 +39,7 @@ async fn test_repair_pass_hands_off_entries_beyond_a_directly_connected_head() -
     let stored_entry = entry.clone().try_into_storage_entry()?;
     assert!(matches!(
         node1.dht().find_storage_owner(entry.did)?,
-        PeerRingAction::Some(_)
+        PeerRingAction::Some(witness) if witness == node3.did()
     ));
 
     // node2 connects straight to node1. Admission moves node1's head to node2, so the key now
@@ -58,8 +58,8 @@ async fn test_repair_pass_hands_off_entries_beyond_a_directly_connected_head() -
     assert_eq!(
         node1
             .swarm
-            .stabilizer()?
-            .run_requested_storage_repair()
+            .stabilizer()
+            .run_requested_storage_maintenance()
             .await,
         Some(StorageRepairOutcome::Complete)
     );

--- a/crates/core/src/tests/default/test_stabilization/test_storage_handoff.rs
+++ b/crates/core/src/tests/default/test_stabilization/test_storage_handoff.rs
@@ -1,0 +1,55 @@
+//! Placement invariant of the stabilizer: every live local entry lies in `(self, head]`, or the
+//! round offers it to the head as an ownership hand-off. The invariant is over the ring state, so
+//! it holds whichever input moved the head; a direct connection is the case no message reports.
+
+use super::*;
+use crate::ecc::tests::gen_ordered_keys;
+use crate::message::Encoder;
+use crate::tests::default::wait_for_msgs;
+use crate::tests::default::wait_for_storage_absence;
+use crate::tests::default::wait_for_storage_entry;
+
+/// Placement invariant at the stabilizer boundary: after a direct connection moves the successor
+/// head, the owner's next round hands the entries placed beyond the new head over to it. No notify
+/// report is involved, and the local copy is removed only by the receiver's acknowledgement.
+#[tokio::test]
+async fn test_owner_round_hands_off_entries_beyond_a_directly_connected_head() -> Result<()> {
+    let [key1, key2, key3] = gen_ordered_keys::<3>();
+    let node1 = prepare_node(key1).await;
+    let node2 = prepare_node(key2).await;
+    let node3 = prepare_node(key3).await;
+    manually_establish_connection(&node1.swarm, &node3.swarm).await;
+    wait_for_msgs([&node1, &node3]).await;
+    wait_for_successor(&node1, node3.did()).await?;
+
+    // `node3 ∈ (node1, node3]`, so node1 owns the key while node3 is its head.
+    let entry = crate::tests::live_entry(
+        node3.did(),
+        vec![String::from("sync me").encode()?],
+        EntryKind::Data,
+    );
+    node1
+        .dht()
+        .storage
+        .put(&entry.did.to_string(), &entry)
+        .await?;
+    let stored_entry = entry.clone().try_into_storage_entry()?;
+    assert!(matches!(
+        node1.dht().find_storage_owner(entry.did)?,
+        PeerRingAction::Some(_)
+    ));
+
+    // node2 connects straight to node1. Admission moves node1's head to node2, so the key now
+    // lies beyond `(node1, node2]` and node1's next round hands it over.
+    manually_establish_connection(&node2.swarm, &node1.swarm).await;
+    wait_for_msgs([&node1, &node2, &node3]).await;
+    wait_for_successor(&node1, node2.did()).await?;
+    node1.swarm.stabilizer()?.stabilize().await?;
+
+    assert_eq!(
+        wait_for_storage_entry(&node2, entry.did).await?,
+        stored_entry
+    );
+    wait_for_storage_absence(&node1, entry.did).await?;
+    Ok(())
+}

--- a/crates/core/src/tests/default/test_stabilization/test_storage_handoff.rs
+++ b/crates/core/src/tests/default/test_stabilization/test_storage_handoff.rs
@@ -1,19 +1,22 @@
-//! Placement invariant of the stabilizer: every live local entry lies in `(self, head]`, or the
-//! round offers it to the head as an ownership hand-off. The invariant is over the ring state, so
-//! it holds whichever input moved the head; a direct connection is the case no message reports.
+//! Placement invariant of the storage repair pass: every live local entry lies in `(self, head]`,
+//! or the pass offers it to the head as an ownership hand-off. The invariant is over the ring
+//! state, so it holds whichever input moved the head; a direct connection is the case no message
+//! reports, and admitting it only requests the pass.
 
 use super::*;
+use crate::dht::STORAGE_REPAIR_FRESH_CONNECTION_GRACE_MS;
 use crate::ecc::tests::gen_ordered_keys;
 use crate::message::Encoder;
 use crate::tests::default::wait_for_msgs;
 use crate::tests::default::wait_for_storage_absence;
 use crate::tests::default::wait_for_storage_entry;
 
-/// Placement invariant at the stabilizer boundary: after a direct connection moves the successor
-/// head, the owner's next round hands the entries placed beyond the new head over to it. No notify
-/// report is involved, and the local copy is removed only by the receiver's acknowledgement.
+/// After a direct connection moves the successor head, admission requests a repair pass, and the
+/// owner's pass hands the entries placed beyond the new head over to it once the connection has
+/// outlived the fresh-connection grace. No notify report is involved, and the local copy is
+/// removed only by the receiver's acknowledgement.
 #[tokio::test]
-async fn test_owner_round_hands_off_entries_beyond_a_directly_connected_head() -> Result<()> {
+async fn test_repair_pass_hands_off_entries_beyond_a_directly_connected_head() -> Result<()> {
     let [key1, key2, key3] = gen_ordered_keys::<3>();
     let node1 = prepare_node(key1).await;
     let node2 = prepare_node(key2).await;
@@ -40,11 +43,26 @@ async fn test_owner_round_hands_off_entries_beyond_a_directly_connected_head() -
     ));
 
     // node2 connects straight to node1. Admission moves node1's head to node2, so the key now
-    // lies beyond `(node1, node2]` and node1's next round hands it over.
+    // lies beyond `(node1, node2]`; the head change requests a repair pass rather than sending.
     manually_establish_connection(&node2.swarm, &node1.swarm).await;
     wait_for_msgs([&node1, &node2, &node3]).await;
     wait_for_successor(&node1, node2.did()).await?;
-    node1.swarm.stabilizer()?.stabilize().await?;
+    assert!(node1.swarm.transport.storage_repair_requested());
+
+    // The pass defers to a connection younger than the grace, which is what outlives the peer's
+    // own admission of this node; age the connection past it, then run the requested pass.
+    node1.swarm.transport.force_peer_connected_at(
+        node2.did(),
+        get_epoch_ms_i64() - STORAGE_REPAIR_FRESH_CONNECTION_GRACE_MS - 1,
+    )?;
+    assert_eq!(
+        node1
+            .swarm
+            .stabilizer()?
+            .run_requested_storage_repair()
+            .await,
+        Some(StorageRepairOutcome::Complete)
+    );
 
     assert_eq!(
         wait_for_storage_entry(&node2, entry.did).await?,

--- a/crates/core/src/tests/default/test_stabilization/test_storage_handoff.rs
+++ b/crates/core/src/tests/default/test_stabilization/test_storage_handoff.rs
@@ -10,6 +10,7 @@ use crate::message::Encoder;
 use crate::tests::default::wait_for_msgs;
 use crate::tests::default::wait_for_storage_absence;
 use crate::tests::default::wait_for_storage_entry;
+use crate::tests::live_entry;
 
 /// After a direct connection moves the successor head, admission requests a repair pass, and the
 /// owner's pass hands the entries placed beyond the new head over to it once the connection has
@@ -26,7 +27,7 @@ async fn test_repair_pass_hands_off_entries_beyond_a_directly_connected_head() -
     wait_for_successor(&node1, node3.did()).await?;
 
     // `node3 ∈ (node1, node3]`, so node1 owns the key while node3 is its head.
-    let entry = crate::tests::live_entry(
+    let entry = live_entry(
         node3.did(),
         vec![String::from("sync me").encode()?],
         EntryKind::Data,

--- a/crates/core/src/tests/default/test_stabilization/test_storage_repair.rs
+++ b/crates/core/src/tests/default/test_stabilization/test_storage_repair.rs
@@ -5,6 +5,7 @@ use crate::dht::topology;
 use crate::dht::StorageSyncDestination;
 #[cfg(not(target_family = "wasm"))]
 use crate::lifecycle::StopSource;
+use crate::tests::live_entry;
 #[cfg(all(feature = "dummy", not(target_family = "wasm")))]
 use crate::tests::midpoint_storage_key;
 #[cfg(all(feature = "dummy", not(target_family = "wasm")))]
@@ -41,7 +42,7 @@ async fn test_stabilize_republishes_local_entries_to_missing_affine_owners() -> 
         .build(),
     );
     let node = Node::new(swarm);
-    let entry = crate::tests::live_entry(key.address().into(), vec![], EntryKind::Data);
+    let entry = live_entry(key.address().into(), vec![], EntryKind::Data);
     let placement_keys = entry.did.rotate_affine(2)?;
     node.dht()
         .storage
@@ -91,8 +92,8 @@ async fn test_continuous_storage_repair_reaches_remote_owners_across_three_nodes
     ensure_storage_repair_route(&node1, head_key, head.did())?;
     ensure_storage_repair_route(&node1, tail_key, tail.did())?;
 
-    let head_entry = crate::tests::live_entry(head_key, vec![], EntryKind::Data);
-    let tail_entry = crate::tests::live_entry(tail_key, vec![], EntryKind::Data);
+    let head_entry = live_entry(head_key, vec![], EntryKind::Data);
+    let tail_entry = live_entry(tail_key, vec![], EntryKind::Data);
     let expected_head_entry = head_entry.clone().try_into_storage_entry()?;
     let expected_tail_entry = tail_entry.clone().try_into_storage_entry()?;
     node1

--- a/crates/core/src/tests/default/test_stabilization/test_storage_repair.rs
+++ b/crates/core/src/tests/default/test_stabilization/test_storage_repair.rs
@@ -41,7 +41,7 @@ async fn test_stabilize_republishes_local_entries_to_missing_affine_owners() -> 
         .build(),
     );
     let node = Node::new(swarm);
-    let entry = Entry::new(key.address().into(), vec![], EntryKind::Data);
+    let entry = crate::tests::live_entry(key.address().into(), vec![], EntryKind::Data);
     let placement_keys = entry.did.rotate_affine(2)?;
     node.dht()
         .storage
@@ -91,8 +91,8 @@ async fn test_continuous_storage_repair_reaches_remote_owners_across_three_nodes
     ensure_storage_repair_route(&node1, head_key, head.did())?;
     ensure_storage_repair_route(&node1, tail_key, tail.did())?;
 
-    let head_entry = Entry::new(head_key, vec![], EntryKind::Data);
-    let tail_entry = Entry::new(tail_key, vec![], EntryKind::Data);
+    let head_entry = crate::tests::live_entry(head_key, vec![], EntryKind::Data);
+    let tail_entry = crate::tests::live_entry(tail_key, vec![], EntryKind::Data);
     let expected_head_entry = head_entry.clone().try_into_storage_entry()?;
     let expected_tail_entry = tail_entry.clone().try_into_storage_entry()?;
     node1

--- a/crates/core/src/tests/default/test_stabilization/test_storage_repair.rs
+++ b/crates/core/src/tests/default/test_stabilization/test_storage_repair.rs
@@ -48,7 +48,7 @@ async fn test_stabilize_republishes_local_entries_to_missing_affine_owners() -> 
         .put(&placement_keys[0].to_string(), &entry)
         .await?;
 
-    node.swarm.stabilizer()?.stabilize().await?;
+    node.swarm.stabilizer().stabilize().await?;
 
     assert_eq!(
         node.dht()
@@ -112,9 +112,9 @@ async fn test_continuous_storage_repair_reaches_remote_owners_across_three_nodes
     let stop = StopSource::new();
     let maintenance_interval = Duration::from_millis(500);
     let maintenance = [
-        node1.swarm.stabilizer()?,
-        node2.swarm.stabilizer()?,
-        node3.swarm.stabilizer()?,
+        node1.swarm.stabilizer(),
+        node2.swarm.stabilizer(),
+        node3.swarm.stabilizer(),
     ]
     .map(|stabilizer| {
         let token = stop.token();
@@ -221,7 +221,7 @@ async fn test_native_wait_with_repairs_storage_before_connection_retirement() ->
     let maintenance = {
         let token = stop.token();
         tokio::spawn(
-            Arc::new(node1.swarm.stabilizer()?).wait_with(Duration::from_millis(500), token),
+            Arc::new(node1.swarm.stabilizer()).wait_with(Duration::from_millis(500), token),
         )
     };
     let repair_pressure = {
@@ -321,7 +321,7 @@ async fn test_repair_storage_defers_sync_to_fresh_next_hop() -> Result<()> {
         .await?;
 
     assert_eq!(
-        node1.swarm.stabilizer()?.repair_storage().await?,
+        node1.swarm.stabilizer().repair_storage().await?,
         StorageRepairOutcome::Deferred
     );
 
@@ -372,7 +372,7 @@ async fn test_repair_storage_defers_disconnected_open_transport_without_sending(
     let _pending_wait = PendingDataChannelWaitGuard::new();
     let outcome = timeout(
         Duration::from_millis(200),
-        node1.swarm.stabilizer()?.repair_storage(),
+        node1.swarm.stabilizer().repair_storage(),
     )
     .await
     .map_err(|_| Error::PromiseStateTimeout)??;
@@ -427,7 +427,7 @@ async fn test_repair_storage_backpressure_defers_without_degrading_or_removing_p
 
     let _pending_send = PendingSendGuard::new();
     assert_eq!(
-        node1.swarm.stabilizer()?.repair_storage().await?,
+        node1.swarm.stabilizer().repair_storage().await?,
         StorageRepairOutcome::Deferred
     );
 
@@ -450,8 +450,8 @@ async fn test_repair_storage_backpressure_defers_without_degrading_or_removing_p
     assert_eq!(
         node1
             .swarm
-            .stabilizer()?
-            .run_requested_storage_repair()
+            .stabilizer()
+            .run_requested_storage_maintenance()
             .await,
         Some(StorageRepairOutcome::Deferred)
     );
@@ -462,7 +462,7 @@ async fn test_repair_storage_backpressure_defers_without_degrading_or_removing_p
 
     node1
         .swarm
-        .stabilizer()?
+        .stabilizer()
         .clean_unavailable_connections()
         .await?;
 

--- a/crates/core/src/tests/default/test_stabilization/test_storage_repair.rs
+++ b/crates/core/src/tests/default/test_stabilization/test_storage_repair.rs
@@ -48,7 +48,7 @@ async fn test_stabilize_republishes_local_entries_to_missing_affine_owners() -> 
         .put(&placement_keys[0].to_string(), &entry)
         .await?;
 
-    node.swarm.stabilizer().stabilize().await?;
+    node.swarm.stabilizer()?.stabilize().await?;
 
     assert_eq!(
         node.dht()
@@ -112,9 +112,9 @@ async fn test_continuous_storage_repair_reaches_remote_owners_across_three_nodes
     let stop = StopSource::new();
     let maintenance_interval = Duration::from_millis(500);
     let maintenance = [
-        node1.swarm.stabilizer(),
-        node2.swarm.stabilizer(),
-        node3.swarm.stabilizer(),
+        node1.swarm.stabilizer()?,
+        node2.swarm.stabilizer()?,
+        node3.swarm.stabilizer()?,
     ]
     .map(|stabilizer| {
         let token = stop.token();
@@ -221,7 +221,7 @@ async fn test_native_wait_with_repairs_storage_before_connection_retirement() ->
     let maintenance = {
         let token = stop.token();
         tokio::spawn(
-            Arc::new(node1.swarm.stabilizer()).wait_with(Duration::from_millis(500), token),
+            Arc::new(node1.swarm.stabilizer()?).wait_with(Duration::from_millis(500), token),
         )
     };
     let repair_pressure = {
@@ -321,7 +321,7 @@ async fn test_repair_storage_defers_sync_to_fresh_next_hop() -> Result<()> {
         .await?;
 
     assert_eq!(
-        node1.swarm.stabilizer().repair_storage().await?,
+        node1.swarm.stabilizer()?.repair_storage().await?,
         StorageRepairOutcome::Deferred
     );
 
@@ -372,7 +372,7 @@ async fn test_repair_storage_defers_disconnected_open_transport_without_sending(
     let _pending_wait = PendingDataChannelWaitGuard::new();
     let outcome = timeout(
         Duration::from_millis(200),
-        node1.swarm.stabilizer().repair_storage(),
+        node1.swarm.stabilizer()?.repair_storage(),
     )
     .await
     .map_err(|_| Error::PromiseStateTimeout)??;
@@ -427,7 +427,7 @@ async fn test_repair_storage_backpressure_defers_without_degrading_or_removing_p
 
     let _pending_send = PendingSendGuard::new();
     assert_eq!(
-        node1.swarm.stabilizer().repair_storage().await?,
+        node1.swarm.stabilizer()?.repair_storage().await?,
         StorageRepairOutcome::Deferred
     );
 
@@ -450,7 +450,7 @@ async fn test_repair_storage_backpressure_defers_without_degrading_or_removing_p
     assert_eq!(
         node1
             .swarm
-            .stabilizer()
+            .stabilizer()?
             .run_requested_storage_repair()
             .await,
         Some(StorageRepairOutcome::Deferred)
@@ -462,7 +462,7 @@ async fn test_repair_storage_backpressure_defers_without_degrading_or_removing_p
 
     node1
         .swarm
-        .stabilizer()
+        .stabilizer()?
         .clean_unavailable_connections()
         .await?;
 

--- a/crates/core/src/tests/default/test_stabilization_failover.rs
+++ b/crates/core/src/tests/default/test_stabilization_failover.rs
@@ -38,7 +38,7 @@ async fn assert_unavailable_successor_fails_over(
 
     node1
         .swarm
-        .stabilizer()
+        .stabilizer()?
         .clean_unavailable_connections()
         .await?;
 

--- a/crates/core/src/tests/default/test_stabilization_failover.rs
+++ b/crates/core/src/tests/default/test_stabilization_failover.rs
@@ -38,7 +38,7 @@ async fn assert_unavailable_successor_fails_over(
 
     node1
         .swarm
-        .stabilizer()?
+        .stabilizer()
         .clean_unavailable_connections()
         .await?;
 

--- a/crates/core/src/tests/default/test_sync_storm/legacy.rs
+++ b/crates/core/src/tests/default/test_sync_storm/legacy.rs
@@ -457,7 +457,10 @@ fn entry_routed_remotely_by(node: &Node, label: &str) -> PlacedEntry {
             let data = vec![0x6d; ENTRY_PAYLOAD_BYTES]
                 .encode()
                 .expect("repair fixture payload must encode");
-            return PlacedEntry::new(key, Entry::new(key, vec![data], EntryKind::Data));
+            return PlacedEntry::new(
+                key,
+                crate::tests::live_entry(key, vec![data], EntryKind::Data),
+            );
         }
     }
     panic!("failed to derive a remote repair entry from {}", node.did());

--- a/crates/core/src/tests/default/test_sync_storm/legacy.rs
+++ b/crates/core/src/tests/default/test_sync_storm/legacy.rs
@@ -3,6 +3,7 @@ use super::pressure::exercise_per_entry_yield;
 use super::pressure::start_controlled_deliveries;
 use super::pressure::wait_for_control_barrier_verdict;
 use super::*;
+use crate::tests::live_entry;
 
 pub(super) async fn legacy_feedback_loop_state() -> SimState {
     let runtime =
@@ -457,10 +458,7 @@ fn entry_routed_remotely_by(node: &Node, label: &str) -> PlacedEntry {
             let data = vec![0x6d; ENTRY_PAYLOAD_BYTES]
                 .encode()
                 .expect("repair fixture payload must encode");
-            return PlacedEntry::new(
-                key,
-                crate::tests::live_entry(key, vec![data], EntryKind::Data),
-            );
+            return PlacedEntry::new(key, live_entry(key, vec![data], EntryKind::Data));
         }
     }
     panic!("failed to derive a remote repair entry from {}", node.did());

--- a/crates/core/src/tests/default/test_sync_storm/legacy.rs
+++ b/crates/core/src/tests/default/test_sync_storm/legacy.rs
@@ -141,6 +141,7 @@ async fn expire_healthy_peer(
     nodes[observer]
         .swarm
         .stabilizer()
+        .expect("swarm callback lock must be healthy")
         .probe_peer_liveness_for_simulation()
         .await
         .expect("production stabilizer must send its real liveness probe");
@@ -315,6 +316,7 @@ async fn observe_false_disconnect(
     nodes[observer]
         .swarm
         .stabilizer()
+        .expect("swarm callback lock must be healthy")
         .clean_unavailable_connections()
         .await
         .expect("expired liveness evidence must be processed");
@@ -393,7 +395,10 @@ async fn observe_repair_feedback(
         .into_iter()
         .map(|delivery| delivery.sequence)
         .collect::<BTreeSet<_>>();
-    let stabilizer = nodes[observer].swarm.stabilizer();
+    let stabilizer = nodes[observer]
+        .swarm
+        .stabilizer()
+        .expect("swarm callback lock must be healthy");
     let outcome = stabilizer
         .run_requested_storage_repair()
         .await

--- a/crates/core/src/tests/default/test_sync_storm/legacy.rs
+++ b/crates/core/src/tests/default/test_sync_storm/legacy.rs
@@ -141,7 +141,6 @@ async fn expire_healthy_peer(
     nodes[observer]
         .swarm
         .stabilizer()
-        .expect("swarm callback lock must be healthy")
         .probe_peer_liveness_for_simulation()
         .await
         .expect("production stabilizer must send its real liveness probe");
@@ -316,7 +315,6 @@ async fn observe_false_disconnect(
     nodes[observer]
         .swarm
         .stabilizer()
-        .expect("swarm callback lock must be healthy")
         .clean_unavailable_connections()
         .await
         .expect("expired liveness evidence must be processed");
@@ -395,12 +393,9 @@ async fn observe_repair_feedback(
         .into_iter()
         .map(|delivery| delivery.sequence)
         .collect::<BTreeSet<_>>();
-    let stabilizer = nodes[observer]
-        .swarm
-        .stabilizer()
-        .expect("swarm callback lock must be healthy");
+    let stabilizer = nodes[observer].swarm.stabilizer();
     let outcome = stabilizer
-        .run_requested_storage_repair()
+        .run_requested_storage_maintenance()
         .await
         .expect("claimed repair request must execute a bounded pass");
     assert!(

--- a/crates/core/src/tests/default/test_sync_storm/mod.rs
+++ b/crates/core/src/tests/default/test_sync_storm/mod.rs
@@ -56,6 +56,7 @@ use crate::swarm::transport::PEER_LIVENESS_TIMEOUT_MS;
 use crate::swarm::SwarmBuilder;
 use crate::tests::default::prepare_node;
 use crate::tests::default::Node;
+use crate::tests::live_entry;
 use crate::tests::manually_establish_connection;
 
 const TEST_EPOCH_MS: u128 = 1_700_000_000_000;
@@ -457,10 +458,7 @@ fn entry_owned_by(owner: &Node, label: &str) -> PlacedEntry {
             let data = vec![u8::try_from(nonce % 251).expect("byte must fit"); ENTRY_PAYLOAD_BYTES]
                 .encode()
                 .expect("test payload must encode");
-            return PlacedEntry::new(
-                key,
-                crate::tests::live_entry(key, vec![data], EntryKind::Data),
-            );
+            return PlacedEntry::new(key, live_entry(key, vec![data], EntryKind::Data));
         }
     }
     panic!("failed to derive an entry owned by {}", owner.did());

--- a/crates/core/src/tests/default/test_sync_storm/mod.rs
+++ b/crates/core/src/tests/default/test_sync_storm/mod.rs
@@ -687,7 +687,6 @@ async fn run_empty_repair_maintenance(nodes: &[Node], driver: &mut TraceDriver) 
     for node in nodes {
         node.swarm
             .stabilizer()
-            .expect("swarm callback lock must be healthy")
             .clean_unavailable_connections()
             .await
             .expect("pre-storm topology maintenance must succeed");
@@ -697,8 +696,7 @@ async fn run_empty_repair_maintenance(nodes: &[Node], driver: &mut TraceDriver) 
         let outcome = node
             .swarm
             .stabilizer()
-            .expect("swarm callback lock must be healthy")
-            .run_requested_storage_repair()
+            .run_requested_storage_maintenance()
             .await
             .expect("claimed empty repair request must run");
         let model_outcome = match outcome {
@@ -722,7 +720,6 @@ async fn begin_liveness_under_storm(
     for node in nodes {
         node.swarm
             .stabilizer()
-            .expect("swarm callback lock must be healthy")
             .probe_peer_liveness_for_simulation()
             .await
             .expect("real liveness probe pass must succeed");
@@ -771,7 +768,6 @@ async fn conclude_healthy_liveness(
     for node in nodes {
         node.swarm
             .stabilizer()
-            .expect("swarm callback lock must be healthy")
             .clean_unavailable_connections()
             .await
             .expect("real healthy liveness verdict must succeed");

--- a/crates/core/src/tests/default/test_sync_storm/mod.rs
+++ b/crates/core/src/tests/default/test_sync_storm/mod.rs
@@ -687,6 +687,7 @@ async fn run_empty_repair_maintenance(nodes: &[Node], driver: &mut TraceDriver) 
     for node in nodes {
         node.swarm
             .stabilizer()
+            .expect("swarm callback lock must be healthy")
             .clean_unavailable_connections()
             .await
             .expect("pre-storm topology maintenance must succeed");
@@ -696,6 +697,7 @@ async fn run_empty_repair_maintenance(nodes: &[Node], driver: &mut TraceDriver) 
         let outcome = node
             .swarm
             .stabilizer()
+            .expect("swarm callback lock must be healthy")
             .run_requested_storage_repair()
             .await
             .expect("claimed empty repair request must run");
@@ -720,6 +722,7 @@ async fn begin_liveness_under_storm(
     for node in nodes {
         node.swarm
             .stabilizer()
+            .expect("swarm callback lock must be healthy")
             .probe_peer_liveness_for_simulation()
             .await
             .expect("real liveness probe pass must succeed");
@@ -768,6 +771,7 @@ async fn conclude_healthy_liveness(
     for node in nodes {
         node.swarm
             .stabilizer()
+            .expect("swarm callback lock must be healthy")
             .clean_unavailable_connections()
             .await
             .expect("real healthy liveness verdict must succeed");

--- a/crates/core/src/tests/default/test_sync_storm/mod.rs
+++ b/crates/core/src/tests/default/test_sync_storm/mod.rs
@@ -457,7 +457,10 @@ fn entry_owned_by(owner: &Node, label: &str) -> PlacedEntry {
             let data = vec![u8::try_from(nonce % 251).expect("byte must fit"); ENTRY_PAYLOAD_BYTES]
                 .encode()
                 .expect("test payload must encode");
-            return PlacedEntry::new(key, Entry::new(key, vec![data], EntryKind::Data));
+            return PlacedEntry::new(
+                key,
+                crate::tests::live_entry(key, vec![data], EntryKind::Data),
+            );
         }
     }
     panic!("failed to derive an entry owned by {}", owner.did());

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -4,6 +4,8 @@
 ))]
 use num_bigint::BigUint;
 
+#[cfg(not(all(feature = "wasm", target_family = "wasm")))]
+use crate::dht::entry::inbox::HeldMessage;
 use crate::dht::entry::Entry;
 use crate::dht::entry::EntryKind;
 use crate::dht::entry::PlacedEntry;
@@ -18,10 +20,20 @@ use crate::dht::successor::SuccessorReader;
 ))]
 use crate::dht::topology;
 use crate::dht::Did;
+#[cfg(not(all(feature = "wasm", target_family = "wasm")))]
+use crate::ecc::SecretKey;
 use crate::error::Result;
 use crate::message::Encoded;
 use crate::message::Encoder;
+#[cfg(not(all(feature = "wasm", target_family = "wasm")))]
+use crate::message::Message;
 use crate::message::MessageClass;
+#[cfg(not(all(feature = "wasm", target_family = "wasm")))]
+use crate::message::MessagePayload;
+#[cfg(not(all(feature = "wasm", target_family = "wasm")))]
+use crate::message::MessageSigner;
+#[cfg(not(all(feature = "wasm", target_family = "wasm")))]
+use crate::session::SessionSk;
 #[cfg(all(feature = "dummy", not(target_family = "wasm")))]
 use crate::swarm::transport::SwarmTransport;
 use crate::swarm::Swarm;
@@ -54,6 +66,25 @@ pub(crate) fn with_retention(mut entry: Entry, expires_at_ms: u128) -> Entry {
 #[cfg(not(all(feature = "wasm", target_family = "wasm")))]
 pub(crate) fn expired(entry: Entry) -> Entry {
     with_retention(entry, 1)
+}
+
+/// A live inbox delta for `destination`: one custom message from a fresh sender, held now by
+/// `holder` inside [`TEST_NETWORK_ID`].
+#[cfg(not(all(feature = "wasm", target_family = "wasm")))]
+pub(crate) fn held_inbox_for(destination: Did, holder: &SessionSk) -> Result<Entry> {
+    let sender = SessionSk::new_with_seckey(&SecretKey::random())?;
+    let payload = MessagePayload::new_send(
+        Message::custom(b"held")?,
+        MessageSigner::new(&sender, TEST_NETWORK_ID),
+        destination,
+        destination,
+    )?;
+    let held = HeldMessage::hold(
+        payload,
+        MessageSigner::new(holder, TEST_NETWORK_ID),
+        get_epoch_ms(),
+    )?;
+    Ok(live(Entry::inbox_delta(&held)?))
 }
 
 #[cfg(all(feature = "wasm", target_family = "wasm"))]

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -19,11 +19,31 @@ use crate::dht::successor::SuccessorReader;
 use crate::dht::topology;
 use crate::dht::Did;
 use crate::error::Result;
+use crate::message::Encoded;
 use crate::message::Encoder;
 use crate::message::MessageClass;
 #[cfg(all(feature = "dummy", not(target_family = "wasm")))]
 use crate::swarm::transport::SwarmTransport;
 use crate::swarm::Swarm;
+use crate::utils::get_epoch_ms;
+
+/// Overlay every test fixture signs for and verifies against.
+pub(crate) const TEST_NETWORK_ID: u32 = 0;
+
+/// Retention bound far enough ahead that a fixture stays live for a whole test.
+const FIXTURE_RETENTION_MS: u128 = 60 * 60 * 1_000;
+
+/// An entry stamped as the operation boundary would stamp it, so a fixture that is written
+/// to storage or carried in a sync message passes storage admission.
+pub(crate) fn live_entry(did: Did, data: Vec<Encoded>, kind: EntryKind) -> Entry {
+    live(Entry::new(did, data, kind))
+}
+
+/// Stamp an existing fixture with a live retention bound.
+pub(crate) fn live(mut entry: Entry) -> Entry {
+    entry.expires_at_ms = Some(get_epoch_ms() + FIXTURE_RETENTION_MS);
+    entry
+}
 
 #[cfg(all(feature = "wasm", target_family = "wasm"))]
 pub mod wasm;
@@ -99,7 +119,7 @@ pub fn multi_frame_storage_sync_entries() -> Result<Vec<PlacedEntry>> {
     let topic = "shared multi-frame storage contention";
     let entry_did = Entry::gen_did(topic)?;
     let payload = vec![0xcd; 1024 * 1024].encode()?;
-    let entry = Entry::new(entry_did, vec![payload], EntryKind::Data);
+    let entry = live_entry(entry_did, vec![payload], EntryKind::Data);
     Ok(vec![PlacedEntry::new(entry_did, entry)])
 }
 

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -40,9 +40,20 @@ pub(crate) fn live_entry(did: Did, data: Vec<Encoded>, kind: EntryKind) -> Entry
 }
 
 /// Stamp an existing fixture with a live retention bound.
-pub(crate) fn live(mut entry: Entry) -> Entry {
-    entry.expires_at_ms = Some(get_epoch_ms() + FIXTURE_RETENTION_MS);
+pub(crate) fn live(entry: Entry) -> Entry {
+    with_retention(entry, get_epoch_ms() + FIXTURE_RETENTION_MS)
+}
+
+/// Stamp an existing fixture with the retention bound `expires_at_ms`.
+pub(crate) fn with_retention(mut entry: Entry, expires_at_ms: u128) -> Entry {
+    entry.expires_at_ms = Some(expires_at_ms);
     entry
+}
+
+/// Stamp an existing fixture with a retention bound that has already elapsed.
+#[cfg(not(all(feature = "wasm", target_family = "wasm")))]
+pub(crate) fn expired(entry: Entry) -> Entry {
+    with_retention(entry, 1)
 }
 
 #[cfg(all(feature = "wasm", target_family = "wasm"))]

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -33,8 +33,8 @@ pub(crate) const TEST_NETWORK_ID: u32 = 0;
 /// Retention bound far enough ahead that a fixture stays live for a whole test.
 const FIXTURE_RETENTION_MS: u128 = 60 * 60 * 1_000;
 
-/// An entry stamped as the operation boundary would stamp it, so a fixture that is written
-/// to storage or carried in a sync message passes storage admission.
+/// An entry with a retention bound one hour ahead, inside the admission maximum, so a fixture
+/// that is written to storage or carried in a sync message passes storage admission.
 pub(crate) fn live_entry(did: Did, data: Vec<Encoded>, kind: EntryKind) -> Entry {
     live(Entry::new(did, data, kind))
 }

--- a/crates/core/src/tests/wasm/test_wasm_transport.rs
+++ b/crates/core/src/tests/wasm/test_wasm_transport.rs
@@ -33,6 +33,7 @@ use crate::swarm::transport::Transport;
 use crate::swarm::Swarm;
 use crate::tests::assert_control_interleaves_transfer;
 use crate::tests::control_interleaves_transfer;
+use crate::tests::live_entry;
 use crate::tests::manually_establish_connection;
 use crate::tests::midpoint_storage_key;
 use crate::tests::multi_frame_storage_sync_entries;
@@ -155,12 +156,14 @@ async fn seed_remote_repair_entries(node1: &Swarm, node2: &Swarm, node3: &Swarm)
     replace_observed_fingers(node1, &[(0, head.did()), (3, tail.did())]).unwrap();
     let head_key = midpoint_storage_key(node1.did(), head.did(), tail.did());
     let tail_key = tail_storage_key(node1.did(), tail.did());
-    let head_entry = Entry::new(
+    // Stamped live: a value written to storage without a retention bound is retired on its
+    // next read and would never be republished.
+    let head_entry = live_entry(
         head_key,
         vec!["repair-head".encode().unwrap()],
         EntryKind::Data,
     );
-    let tail_entry = Entry::new(
+    let tail_entry = live_entry(
         tail_key,
         vec!["repair-tail".encode().unwrap()],
         EntryKind::Data,

--- a/crates/core/src/tests/wasm/test_wasm_transport.rs
+++ b/crates/core/src/tests/wasm/test_wasm_transport.rs
@@ -76,15 +76,9 @@ async fn wait_for_ring_convergence(nodes: &[&crate::swarm::Swarm]) {
 
 async fn run_stabilization_round(nodes: &[&crate::swarm::Swarm; 3]) {
     let [first_node, second_node, third_node] = *nodes;
-    let first = first_node
-        .stabilizer()
-        .expect("swarm callback lock must be healthy");
-    let second = second_node
-        .stabilizer()
-        .expect("swarm callback lock must be healthy");
-    let third = third_node
-        .stabilizer()
-        .expect("swarm callback lock must be healthy");
+    let first = first_node.stabilizer();
+    let second = second_node.stabilizer();
+    let third = third_node.stabilizer();
     let (first, second, third) =
         futures::join!(first.stabilize(), second.stabilize(), third.stabilize(),);
     first.unwrap();
@@ -293,10 +287,7 @@ fn start_browser_maintenance(
 ) -> Vec<futures::channel::oneshot::Receiver<()>> {
     let mut completions = Vec::new();
     for node in nodes {
-        let stabilizer = Arc::new(
-            node.stabilizer()
-                .expect("swarm callback lock must be healthy"),
-        );
+        let stabilizer = Arc::new(node.stabilizer());
         let token = stop.token();
         let (completed, completion) = futures::channel::oneshot::channel();
         wasm_bindgen_futures::spawn_local(async move {

--- a/crates/core/src/tests/wasm/test_wasm_transport.rs
+++ b/crates/core/src/tests/wasm/test_wasm_transport.rs
@@ -76,9 +76,15 @@ async fn wait_for_ring_convergence(nodes: &[&crate::swarm::Swarm]) {
 
 async fn run_stabilization_round(nodes: &[&crate::swarm::Swarm; 3]) {
     let [first_node, second_node, third_node] = *nodes;
-    let first = first_node.stabilizer();
-    let second = second_node.stabilizer();
-    let third = third_node.stabilizer();
+    let first = first_node
+        .stabilizer()
+        .expect("swarm callback lock must be healthy");
+    let second = second_node
+        .stabilizer()
+        .expect("swarm callback lock must be healthy");
+    let third = third_node
+        .stabilizer()
+        .expect("swarm callback lock must be healthy");
     let (first, second, third) =
         futures::join!(first.stabilize(), second.stabilize(), third.stabilize(),);
     first.unwrap();
@@ -287,7 +293,10 @@ fn start_browser_maintenance(
 ) -> Vec<futures::channel::oneshot::Receiver<()>> {
     let mut completions = Vec::new();
     for node in nodes {
-        let stabilizer = Arc::new(node.stabilizer());
+        let stabilizer = Arc::new(
+            node.stabilizer()
+                .expect("swarm callback lock must be healthy"),
+        );
         let token = stop.token();
         let (completed, completion) = futures::channel::oneshot::channel();
         wasm_bindgen_futures::spawn_local(async move {

--- a/crates/node/bin/rings.rs
+++ b/crates/node/bin/rings.rs
@@ -38,7 +38,7 @@ use rings_node::onion::OnionServiceName;
 use rings_node::prelude::rings_core::chunk::ReassemblyLimits;
 use rings_node::prelude::rings_core::dht::Did;
 use rings_node::prelude::rings_core::ecc::SecretKey;
-use rings_node::prelude::rings_core::storage::sled::SledStorage;
+use rings_node::prelude::rings_core::storage::file::FileStorage;
 use rings_node::prelude::SessionSkBuilder;
 use rings_node::prelude::StopSource;
 use rings_node::processor::ProcessorBuilder;
@@ -836,10 +836,10 @@ async fn foreground_run(args: RunCommand) -> anyhow::Result<()> {
     };
 
     let per_data_storage = Box::new(
-        SledStorage::new_with_cap_and_path(data_storage.capacity, data_storage.path).await?,
+        FileStorage::new_with_cap_and_path(data_storage.capacity, data_storage.path).await?,
     );
     let per_measure_storage = Box::new(
-        SledStorage::new_with_cap_and_path(measure_storage.capacity, measure_storage.path).await?,
+        FileStorage::new_with_cap_and_path(measure_storage.capacity, measure_storage.path).await?,
     );
 
     let measure = PeriodicMeasure::new(per_measure_storage).await?;

--- a/crates/node/bin/rings.rs
+++ b/crates/node/bin/rings.rs
@@ -864,6 +864,7 @@ async fn foreground_run(args: RunCommand) -> anyhow::Result<()> {
     let onion = NativeOnionCircuitHandle::install(
         &provider.extensions(),
         onion_session_sk,
+        pc.network_id(),
         advertise_onion_relay,
         onion_exit_config,
     )?;

--- a/crates/node/src/descriptor.rs
+++ b/crates/node/src/descriptor.rs
@@ -69,14 +69,20 @@ pub(crate) trait SignedDescriptor: Sized {
 
     fn descriptor_did(&self) -> Did;
     fn descriptor_public_key(&self) -> &VerificationPublicKey;
+    /// The overlay the body states.
+    fn descriptor_network_id(&self) -> u32;
     fn descriptor_signature(&self) -> &MessageVerification;
     fn descriptor_heartbeat_at_ms(&self) -> u128;
     fn descriptor_expires_at_ms(&self) -> u128;
     fn descriptor_signing_data(&self) -> Result<Vec<u8>>;
 
-    /// Verify the signature under the receiver's overlay `network_id` and the DID/public-key
-    /// binding of the signer.
+    /// Verify the signature under the receiver's overlay `network_id`, the DID/public-key
+    /// binding of the signer, and that the body states that same overlay, so a verified
+    /// descriptor's stated overlay is the overlay it was signed for.
     fn descriptor_verify_signature(&self, network_id: u32) -> bool {
+        if self.descriptor_network_id() != network_id {
+            return false;
+        }
         let did = self.descriptor_did();
         let public_key = self.descriptor_public_key();
         let signature = self.descriptor_signature();

--- a/crates/node/src/descriptor.rs
+++ b/crates/node/src/descriptor.rs
@@ -1,4 +1,10 @@
 //! Shared helpers for signed DHT descriptors.
+//!
+//! A descriptor is signed by the node's [`MessageSigner`], so its signature is bound to the
+//! signer's overlay exactly like every other message, and verified under the *receiver's*
+//! overlay. The body also carries `network_id` as a signed field; signing refuses a body whose
+//! stated overlay differs from the signer's, so a verified descriptor's stated overlay is the
+//! overlay it was signed for, and a descriptor issued in one overlay does not verify in another.
 
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
@@ -10,17 +16,14 @@ use rings_core::error::Result;
 use rings_core::message::DomainTag;
 use rings_core::message::Encoded;
 use rings_core::message::Encoder;
+use rings_core::message::MessageSigner;
 use rings_core::message::MessageVerification;
 use rings_core::message::SigningDomain;
 use rings_core::session::SessionSk;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-/// A descriptor body signs under its own message family inside the overlay it names.
-///
-/// Both descriptor kinds carry `network_id` as a signed body field, so the overlay component of
-/// the [`SigningDomain`] is read from the body on signing and from the descriptor on
-/// verification: a descriptor whose stated overlay differs from the signer's fails to verify.
+/// The signed fields of one descriptor kind.
 pub(crate) trait SignedDescriptorBody: Sized {
     type Descriptor;
 
@@ -34,37 +37,46 @@ pub(crate) trait SignedDescriptorBody: Sized {
     fn into_signed_descriptor(self, signature: MessageVerification) -> Self::Descriptor;
 }
 
+/// Sign `body` with the node's authority.
+///
+/// Pre: the body names the signer's account and public key, and states the signer's overlay.
 pub(crate) fn sign_descriptor_body<B>(
     body: B,
-    session_sk: &SessionSk,
+    signer: MessageSigner<&SessionSk>,
     mismatch_message: &'static str,
 ) -> Result<B::Descriptor>
 where
     B: SignedDescriptorBody,
 {
     let did = body.body_did();
-    if body.body_public_key().did() != did || session_sk.account_did() != did {
+    if body.body_public_key().did() != did || signer.account_did() != did {
         return Err(Error::InvalidMessage(mismatch_message.to_string()));
     }
+    if body.body_network_id() != signer.network_id() {
+        return Err(Error::InvalidMessage(
+            "descriptor states an overlay other than the signer's".to_string(),
+        ));
+    }
 
-    let domain = SigningDomain::new(B::DOMAIN_TAG, body.body_network_id());
-    let signature = MessageVerification::new(domain, &body.body_signing_data()?, session_sk)?;
+    let signature = signer.sign(B::DOMAIN_TAG, &body.body_signing_data()?)?;
     Ok(body.into_signed_descriptor(signature))
 }
 
+/// A published descriptor: its body plus the signature over it.
 pub(crate) trait SignedDescriptor: Sized {
-    /// Message family of this descriptor kind; equal to its body's tag.
-    const DOMAIN_TAG: DomainTag;
+    /// The body this descriptor was signed from; fixes the message family.
+    type Body: SignedDescriptorBody<Descriptor = Self>;
 
     fn descriptor_did(&self) -> Did;
     fn descriptor_public_key(&self) -> &VerificationPublicKey;
-    fn descriptor_network_id(&self) -> u32;
     fn descriptor_signature(&self) -> &MessageVerification;
     fn descriptor_heartbeat_at_ms(&self) -> u128;
     fn descriptor_expires_at_ms(&self) -> u128;
     fn descriptor_signing_data(&self) -> Result<Vec<u8>>;
 
-    fn descriptor_verify_signature(&self) -> bool {
+    /// Verify the signature under the receiver's overlay `network_id` and the DID/public-key
+    /// binding of the signer.
+    fn descriptor_verify_signature(&self, network_id: u32) -> bool {
         let did = self.descriptor_did();
         let public_key = self.descriptor_public_key();
         let signature = self.descriptor_signature();
@@ -82,7 +94,8 @@ pub(crate) trait SignedDescriptor: Sized {
         let Ok(data) = self.descriptor_signing_data() else {
             return false;
         };
-        let domain = SigningDomain::new(Self::DOMAIN_TAG, self.descriptor_network_id());
+        let domain =
+            SigningDomain::new(<Self::Body as SignedDescriptorBody>::DOMAIN_TAG, network_id);
         signature.verify(domain, &data)
     }
 
@@ -90,14 +103,16 @@ pub(crate) trait SignedDescriptor: Sized {
         self.descriptor_expires_at_ms() < now_ms
     }
 
-    fn descriptor_is_live_at(&self, now_ms: u128) -> bool {
-        self.descriptor_verify_signature() && !self.descriptor_is_expired_at(now_ms)
+    fn descriptor_is_live_at(&self, now_ms: u128, network_id: u32) -> bool {
+        self.descriptor_verify_signature(network_id) && !self.descriptor_is_expired_at(now_ms)
     }
 }
 
+/// Select the newest descriptor per DID that verifies under the receiver's overlay.
 pub(crate) fn latest_valid_by_did<D>(
     descriptors: impl IntoIterator<Item = D>,
     now_ms: u128,
+    network_id: u32,
     include_expired: bool,
 ) -> Vec<D>
 where
@@ -106,10 +121,10 @@ where
     let mut latest = BTreeMap::<Did, D>::new();
     for descriptor in descriptors {
         if include_expired {
-            if !descriptor.descriptor_verify_signature() {
+            if !descriptor.descriptor_verify_signature(network_id) {
                 continue;
             }
-        } else if !descriptor.descriptor_is_live_at(now_ms) {
+        } else if !descriptor.descriptor_is_live_at(now_ms, network_id) {
             continue;
         }
         match latest.entry(descriptor.descriptor_did()) {

--- a/crates/node/src/descriptor.rs
+++ b/crates/node/src/descriptor.rs
@@ -7,18 +7,29 @@ use rings_core::dht::Did;
 use rings_core::ecc::VerificationPublicKey;
 use rings_core::error::Error;
 use rings_core::error::Result;
+use rings_core::message::DomainTag;
 use rings_core::message::Encoded;
 use rings_core::message::Encoder;
 use rings_core::message::MessageVerification;
+use rings_core::message::SigningDomain;
 use rings_core::session::SessionSk;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
+/// A descriptor body signs under its own message family inside the overlay it names.
+///
+/// Both descriptor kinds carry `network_id` as a signed body field, so the overlay component of
+/// the [`SigningDomain`] is read from the body on signing and from the descriptor on
+/// verification: a descriptor whose stated overlay differs from the signer's fails to verify.
 pub(crate) trait SignedDescriptorBody: Sized {
     type Descriptor;
 
+    /// Message family of this descriptor kind.
+    const DOMAIN_TAG: DomainTag;
+
     fn body_did(&self) -> Did;
     fn body_public_key(&self) -> &VerificationPublicKey;
+    fn body_network_id(&self) -> u32;
     fn body_signing_data(&self) -> Result<Vec<u8>>;
     fn into_signed_descriptor(self, signature: MessageVerification) -> Self::Descriptor;
 }
@@ -36,13 +47,18 @@ where
         return Err(Error::InvalidMessage(mismatch_message.to_string()));
     }
 
-    let signature = MessageVerification::new(&body.body_signing_data()?, session_sk)?;
+    let domain = SigningDomain::new(B::DOMAIN_TAG, body.body_network_id());
+    let signature = MessageVerification::new(domain, &body.body_signing_data()?, session_sk)?;
     Ok(body.into_signed_descriptor(signature))
 }
 
 pub(crate) trait SignedDescriptor: Sized {
+    /// Message family of this descriptor kind; equal to its body's tag.
+    const DOMAIN_TAG: DomainTag;
+
     fn descriptor_did(&self) -> Did;
     fn descriptor_public_key(&self) -> &VerificationPublicKey;
+    fn descriptor_network_id(&self) -> u32;
     fn descriptor_signature(&self) -> &MessageVerification;
     fn descriptor_heartbeat_at_ms(&self) -> u128;
     fn descriptor_expires_at_ms(&self) -> u128;
@@ -66,7 +82,8 @@ pub(crate) trait SignedDescriptor: Sized {
         let Ok(data) = self.descriptor_signing_data() else {
             return false;
         };
-        signature.verify(&data)
+        let domain = SigningDomain::new(Self::DOMAIN_TAG, self.descriptor_network_id());
+        signature.verify(domain, &data)
     }
 
     fn descriptor_is_expired_at(&self, now_ms: u128) -> bool {

--- a/crates/node/src/measure/tests.rs
+++ b/crates/node/src/measure/tests.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::Ordering;
 
 use rings_core::error::Error as CoreError;
 use rings_core::measure::BehaviourJudgement;
-use rings_core::storage::sled::SledStorage;
+use rings_core::storage::file::FileStorage;
 use rings_core::storage::KvStorageInterface;
 use rings_core::storage::MemStorage;
 use tokio::sync::Notify;
@@ -302,7 +302,7 @@ async fn useful_bytes_produce_amule_credit_and_one_reliability_event() {
 async fn persistence_restores_complete_credit_and_epoch_state() {
     let path = "tmp/measure_snapshot_test_db";
     let storage: MeasureStorage = Box::new(
-        SledStorage::new_with_cap_and_path(4096, path)
+        FileStorage::new_with_cap_and_path(4096, path)
             .await
             .unwrap_or_else(|error| panic!("test storage must open: {error}")),
     );
@@ -330,7 +330,7 @@ async fn persistence_restores_complete_credit_and_epoch_state() {
 
     let restored = PeriodicMeasure::new_with_clock(
         Box::new(
-            SledStorage::new_with_cap_and_path(4096, path)
+            FileStorage::new_with_cap_and_path(4096, path)
                 .await
                 .unwrap_or_else(|error| panic!("test storage must reopen: {error}")),
         ),

--- a/crates/node/src/onion/circuit/crypto.rs
+++ b/crates/node/src/onion/circuit/crypto.rs
@@ -426,7 +426,7 @@ impl OnionAuthenticatedPayload {
                     return_id,
                     nonce,
                     sequence,
-                    signer.session_sk().session_public_key(),
+                    signer.session_public_key(),
                     &payload,
                 )?,
             )

--- a/crates/node/src/onion/circuit/crypto.rs
+++ b/crates/node/src/onion/circuit/crypto.rs
@@ -446,12 +446,13 @@ impl OnionAuthenticatedPayload {
     /// signer account DID equals descriptor DID, signer account public key equals descriptor public
     /// key, and signer session DID equals the descriptor session encryption key DID. The signed
     /// transcript also binds the client/exit return id, per-frame nonce, exit session public key,
-    /// and payload, and its signing domain binds the overlay the exit descriptor was published
-    /// for.
+    /// and payload, and its signing domain binds the receiver's overlay `network_id`, never a
+    /// value carried by the exit.
     pub fn into_verified_payload(
         self,
         return_id: OnionReturnId,
         expected_exit: &OnionExitDescriptor,
+        network_id: u32,
     ) -> Result<OnionVerifiedPayload> {
         if self.return_id != return_id {
             return Err(Error::OnionRouteError(
@@ -484,8 +485,7 @@ impl OnionAuthenticatedPayload {
             expected_exit.session_public_key,
             &self.payload,
         )?;
-        let domain =
-            SigningDomain::new(ONION_BACKWARD_PAYLOAD_DOMAIN_TAG, expected_exit.network_id);
+        let domain = SigningDomain::new(ONION_BACKWARD_PAYLOAD_DOMAIN_TAG, network_id);
         if !self.authentication.verify_unexpired(domain, &data) {
             return Err(Error::OnionRouteError(
                 OnionRouteError::InvalidBackwardSignature,

--- a/crates/node/src/onion/circuit/crypto.rs
+++ b/crates/node/src/onion/circuit/crypto.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::Ordering;
 
 use bytes::Bytes;
 use rings_core::dht::Did;
+use rings_core::domain_tag;
 use rings_core::ecc::elgamal::impls::secp256k1::encrypt_aead_with_rng;
 use rings_core::ecc::elgamal::impls::secp256k1::AeadCiphertext;
 use rings_core::ecc::PublicKey;
@@ -48,7 +49,7 @@ use crate::onion::OnionServiceName;
 
 /// Message family of the exit's backward-payload signature.
 const ONION_BACKWARD_PAYLOAD_DOMAIN_TAG: DomainTag =
-    DomainTag::new("rings-node:onion-backward-payload:v1");
+    domain_tag!("rings-node:onion-backward-payload:v1");
 
 /// Encode the first forward frame for `route`.
 ///
@@ -170,7 +171,7 @@ pub(crate) fn route_first_link(route: &OnionRoute) -> Result<OnionLink> {
 pub async fn send_backward(
     link_sender: &OnionLinkSender,
     scope: &Scope,
-    signer: MessageSigner<'_>,
+    signer: MessageSigner<&SessionSk>,
     path: OnionBackwardPath,
     sequence: OnionBackwardSequence,
     payload: OnionCircuitPayload,
@@ -360,7 +361,7 @@ pub(super) fn encrypt_client_payload(
     return_id: OnionReturnId,
     payload: OnionCircuitPayload,
     recipient: PublicKey<33>,
-    signer: MessageSigner<'_>,
+    signer: MessageSigner<&SessionSk>,
 ) -> Result<AeadCiphertext> {
     encrypt_client_payload_at_sequence(
         return_id,
@@ -376,7 +377,7 @@ pub(super) fn encrypt_client_payload_at_sequence(
     sequence: OnionBackwardSequence,
     payload: OnionCircuitPayload,
     recipient: PublicKey<33>,
-    signer: MessageSigner<'_>,
+    signer: MessageSigner<&SessionSk>,
 ) -> Result<AeadCiphertext> {
     let authenticated =
         OnionAuthenticatedPayload::new_signed_at_sequence(return_id, sequence, payload, signer)?;
@@ -405,7 +406,7 @@ impl OnionAuthenticatedPayload {
     pub fn new_signed(
         return_id: OnionReturnId,
         payload: OnionCircuitPayload,
-        signer: MessageSigner<'_>,
+        signer: MessageSigner<&SessionSk>,
     ) -> Result<Self> {
         Self::new_signed_at_sequence(return_id, OnionBackwardSequence::FIRST, payload, signer)
     }
@@ -415,7 +416,7 @@ impl OnionAuthenticatedPayload {
         return_id: OnionReturnId,
         sequence: OnionBackwardSequence,
         payload: OnionCircuitPayload,
-        signer: MessageSigner<'_>,
+        signer: MessageSigner<&SessionSk>,
     ) -> Result<Self> {
         let nonce = OnionBackwardNonce::random();
         let authentication = signer

--- a/crates/node/src/onion/circuit/crypto.rs
+++ b/crates/node/src/onion/circuit/crypto.rs
@@ -486,7 +486,7 @@ impl OnionAuthenticatedPayload {
             &self.payload,
         )?;
         let domain = SigningDomain::new(ONION_BACKWARD_PAYLOAD_DOMAIN_TAG, network_id);
-        if !self.authentication.verify_unexpired(domain, &data) {
+        if !self.authentication.verify_live(domain, &data) {
             return Err(Error::OnionRouteError(
                 OnionRouteError::InvalidBackwardSignature,
             ));

--- a/crates/node/src/onion/circuit/crypto.rs
+++ b/crates/node/src/onion/circuit/crypto.rs
@@ -8,7 +8,9 @@ use rings_core::dht::Did;
 use rings_core::ecc::elgamal::impls::secp256k1::encrypt_aead_with_rng;
 use rings_core::ecc::elgamal::impls::secp256k1::AeadCiphertext;
 use rings_core::ecc::PublicKey;
-use rings_core::message::MessageVerification;
+use rings_core::message::DomainTag;
+use rings_core::message::MessageSigner;
+use rings_core::message::SigningDomain;
 use rings_core::session::SessionSk;
 use rings_core::utils::get_epoch_ms;
 use serde::Serialize;
@@ -43,6 +45,10 @@ use crate::onion::OnionRouteError;
 use crate::onion::OnionRouteHop;
 #[cfg(rings_native)]
 use crate::onion::OnionServiceName;
+
+/// Message family of the exit's backward-payload signature.
+const ONION_BACKWARD_PAYLOAD_DOMAIN_TAG: DomainTag =
+    DomainTag::new("rings-node:onion-backward-payload:v1");
 
 /// Encode the first forward frame for `route`.
 ///
@@ -164,7 +170,7 @@ pub(crate) fn route_first_link(route: &OnionRoute) -> Result<OnionLink> {
 pub async fn send_backward(
     link_sender: &OnionLinkSender,
     scope: &Scope,
-    signer: &SessionSk,
+    signer: MessageSigner<'_>,
     path: OnionBackwardPath,
     sequence: OnionBackwardSequence,
     payload: OnionCircuitPayload,
@@ -354,7 +360,7 @@ pub(super) fn encrypt_client_payload(
     return_id: OnionReturnId,
     payload: OnionCircuitPayload,
     recipient: PublicKey<33>,
-    signer: &SessionSk,
+    signer: MessageSigner<'_>,
 ) -> Result<AeadCiphertext> {
     encrypt_client_payload_at_sequence(
         return_id,
@@ -370,7 +376,7 @@ pub(super) fn encrypt_client_payload_at_sequence(
     sequence: OnionBackwardSequence,
     payload: OnionCircuitPayload,
     recipient: PublicKey<33>,
-    signer: &SessionSk,
+    signer: MessageSigner<'_>,
 ) -> Result<AeadCiphertext> {
     let authenticated =
         OnionAuthenticatedPayload::new_signed_at_sequence(return_id, sequence, payload, signer)?;
@@ -399,7 +405,7 @@ impl OnionAuthenticatedPayload {
     pub fn new_signed(
         return_id: OnionReturnId,
         payload: OnionCircuitPayload,
-        signer: &SessionSk,
+        signer: MessageSigner<'_>,
     ) -> Result<Self> {
         Self::new_signed_at_sequence(return_id, OnionBackwardSequence::FIRST, payload, signer)
     }
@@ -409,20 +415,21 @@ impl OnionAuthenticatedPayload {
         return_id: OnionReturnId,
         sequence: OnionBackwardSequence,
         payload: OnionCircuitPayload,
-        signer: &SessionSk,
+        signer: MessageSigner<'_>,
     ) -> Result<Self> {
         let nonce = OnionBackwardNonce::random();
-        let authentication = MessageVerification::new(
-            &backward_payload_authentication_data(
-                return_id,
-                nonce,
-                sequence,
-                signer.session_public_key(),
-                &payload,
-            )?,
-            signer,
-        )
-        .map_err(Error::CoreError)?;
+        let authentication = signer
+            .sign(
+                ONION_BACKWARD_PAYLOAD_DOMAIN_TAG,
+                &backward_payload_authentication_data(
+                    return_id,
+                    nonce,
+                    sequence,
+                    signer.session_sk().session_public_key(),
+                    &payload,
+                )?,
+            )
+            .map_err(Error::CoreError)?;
         Ok(Self {
             return_id,
             nonce,
@@ -438,7 +445,8 @@ impl OnionAuthenticatedPayload {
     /// signer account DID equals descriptor DID, signer account public key equals descriptor public
     /// key, and signer session DID equals the descriptor session encryption key DID. The signed
     /// transcript also binds the client/exit return id, per-frame nonce, exit session public key,
-    /// and payload.
+    /// and payload, and its signing domain binds the overlay the exit descriptor was published
+    /// for.
     pub fn into_verified_payload(
         self,
         return_id: OnionReturnId,
@@ -475,7 +483,9 @@ impl OnionAuthenticatedPayload {
             expected_exit.session_public_key,
             &self.payload,
         )?;
-        if !self.authentication.verify_unexpired(&data) {
+        let domain =
+            SigningDomain::new(ONION_BACKWARD_PAYLOAD_DOMAIN_TAG, expected_exit.network_id);
+        if !self.authentication.verify_unexpired(domain, &data) {
             return Err(Error::OnionRouteError(
                 OnionRouteError::InvalidBackwardSignature,
             ));

--- a/crates/node/src/onion/circuit/tests/test_circuit_protocol.rs
+++ b/crates/node/src/onion/circuit/tests/test_circuit_protocol.rs
@@ -1083,7 +1083,7 @@ async fn test_client_backward_payload_decryption_runs_in_shell_handler() {
     assert_eq!(
         authenticated
             .clone()
-            .into_verified_payload(return_id, &expected_exit)
+            .into_verified_payload(return_id, &expected_exit, TEST_NETWORK_ID)
             .expect("valid exit proof")
             .payload,
         expected

--- a/crates/node/src/onion/circuit/tests/test_circuit_protocol.rs
+++ b/crates/node/src/onion/circuit/tests/test_circuit_protocol.rs
@@ -9,6 +9,8 @@ use std::sync::Mutex;
 
 use rings_core::dht::Did;
 use rings_core::ecc::SecretKey;
+#[cfg(rings_native)]
+use rings_core::message::MessageSigner;
 use rings_core::session::SessionSk;
 
 #[cfg(rings_native)]
@@ -56,6 +58,10 @@ use crate::processor::ProcessorBuilder;
 use crate::processor::ProcessorConfig;
 #[cfg(rings_native)]
 use crate::sync_lock::lock;
+
+/// Overlay every fixture exit descriptor is published for.
+#[cfg(rings_native)]
+const TEST_NETWORK_ID: u32 = 1;
 
 pub(super) fn session() -> SessionSk {
     SessionSk::new_with_seckey(&SecretKey::random()).expect("session key")
@@ -634,7 +640,7 @@ async fn test_send_effect_releases_transition_turn_and_preserves_peer_order() {
                 OnionReturnId::new([tag; 16]),
                 test_payload("ordered"),
                 local.session_public_key(),
-                &local,
+                MessageSigner::new(&local, TEST_NETWORK_ID),
             )
             .expect("encrypt ordered fixture"),
         })
@@ -691,7 +697,7 @@ async fn test_endpoint_send_awaits_the_same_paced_link_lane_and_emits_cover() {
                 OnionReturnId::new([42; 16]),
                 test_payload("endpoint-shaped"),
                 local.session_public_key(),
-                &local,
+                MessageSigner::new(&local, TEST_NETWORK_ID),
             )
             .expect("encrypt endpoint fixture"),
         }),
@@ -1016,7 +1022,7 @@ async fn test_client_backward_payload_decryption_runs_in_shell_handler() {
             return_id,
             expected.clone(),
             client.session_public_key(),
-            &exit,
+            MessageSigner::new(&exit, TEST_NETWORK_ID),
         )
         .expect("encrypt backward"),
     };

--- a/crates/node/src/onion/circuit/tests/test_circuit_protocol.rs
+++ b/crates/node/src/onion/circuit/tests/test_circuit_protocol.rs
@@ -9,7 +9,6 @@ use std::sync::Mutex;
 
 use rings_core::dht::Did;
 use rings_core::ecc::SecretKey;
-#[cfg(rings_native)]
 use rings_core::message::MessageSigner;
 use rings_core::session::SessionSk;
 
@@ -58,10 +57,7 @@ use crate::processor::ProcessorBuilder;
 use crate::processor::ProcessorConfig;
 #[cfg(rings_native)]
 use crate::sync_lock::lock;
-
-/// Overlay every fixture exit descriptor is published for.
-#[cfg(rings_native)]
-const TEST_NETWORK_ID: u32 = 1;
+use crate::tests::TEST_NETWORK_ID;
 
 pub(super) fn session() -> SessionSk {
     SessionSk::new_with_seckey(&SecretKey::random()).expect("session key")
@@ -118,7 +114,7 @@ fn route_for_service(service: &str, relays: &[SessionSk], exit_session: &Session
             public_key,
             session_public_key: exit_session.session_public_key(),
             node_type: OnlineNodeType::Native,
-            network_id: 1,
+            network_id: TEST_NETWORK_ID,
             service: OnionExitService::new("https", OnionExitTransport::Tcp)
                 .expect("valid test service"),
             policy: Default::default(),
@@ -127,7 +123,7 @@ fn route_for_service(service: &str, relays: &[SessionSk], exit_session: &Session
             expires_at_ms: 1,
             version: "test".to_string(),
         },
-        exit_session,
+        MessageSigner::new(exit_session, TEST_NETWORK_ID),
     )
     .expect("signed exit");
     OnionRoute::new(

--- a/crates/node/src/onion/circuit/tests/test_circuit_security.rs
+++ b/crates/node/src/onion/circuit/tests/test_circuit_security.rs
@@ -295,10 +295,10 @@ fn test_aead_context_binds_direction_and_circuit_id() {
     let authenticated = decrypt_client_payload(&client, &backward).expect("decrypt backward");
     assert!(authenticated
         .clone()
-        .into_verified_payload(return_id, route.exit())
+        .into_verified_payload(return_id, route.exit(), TEST_NETWORK_ID)
         .is_ok());
     assert!(authenticated
-        .into_verified_payload(wrong_return_id, route.exit())
+        .into_verified_payload(wrong_return_id, route.exit(), TEST_NETWORK_ID)
         .is_err());
     assert!(decrypt_forward_layer(&client, wrong_circuit_id, &backward).is_err());
 }
@@ -321,7 +321,7 @@ fn test_backward_payload_authentication_rejects_wrong_exit_signer() {
     let authenticated = decrypt_client_payload(&client, &sealed).expect("decrypt forged payload");
 
     assert!(matches!(
-        authenticated.into_verified_payload(return_id, route.exit()),
+        authenticated.into_verified_payload(return_id, route.exit(), TEST_NETWORK_ID),
         Err(crate::error::Error::OnionRouteError(_))
     ));
 }

--- a/crates/node/src/onion/circuit/tests/test_circuit_security.rs
+++ b/crates/node/src/onion/circuit/tests/test_circuit_security.rs
@@ -17,9 +17,7 @@ use super::test_circuit_protocol::return_edge;
 use super::test_circuit_protocol::route;
 use super::test_circuit_protocol::session;
 use super::test_circuit_protocol::test_payload;
-
-/// Overlay every fixture exit descriptor is published for.
-const TEST_NETWORK_ID: u32 = 1;
+use crate::tests::TEST_NETWORK_ID;
 
 #[test]
 fn test_relay_return_table_evicts_expired_entries() {

--- a/crates/node/src/onion/circuit/tests/test_circuit_security.rs
+++ b/crates/node/src/onion/circuit/tests/test_circuit_security.rs
@@ -1,3 +1,5 @@
+use rings_core::message::MessageSigner;
+
 use super::super::codec::OnionCircuitInput;
 use super::super::codec::OnionWireMessage;
 use super::super::crypto::decrypt_client_payload;
@@ -15,6 +17,9 @@ use super::test_circuit_protocol::return_edge;
 use super::test_circuit_protocol::route;
 use super::test_circuit_protocol::session;
 use super::test_circuit_protocol::test_payload;
+
+/// Overlay every fixture exit descriptor is published for.
+const TEST_NETWORK_ID: u32 = 1;
 
 #[test]
 fn test_relay_return_table_evicts_expired_entries() {
@@ -87,7 +92,7 @@ fn test_backward_cell_after_return_expiry_is_never_forwarded() {
             OnionReturnId::new([43; 16]),
             test_payload("expired-return"),
             client.session_public_key(),
-            &next,
+            MessageSigner::new(&next, TEST_NETWORK_ID),
         )
         .expect("encrypt backward fixture"),
     });
@@ -286,7 +291,7 @@ fn test_aead_context_binds_direction_and_circuit_id() {
         return_id,
         test_payload("tcp-close"),
         client.session_public_key(),
-        &exit,
+        MessageSigner::new(&exit, TEST_NETWORK_ID),
     )
     .expect("encrypt backward");
     let authenticated = decrypt_client_payload(&client, &backward).expect("decrypt backward");
@@ -311,7 +316,7 @@ fn test_backward_payload_authentication_rejects_wrong_exit_signer() {
         return_id,
         test_payload("forged"),
         client.session_public_key(),
-        &attacker,
+        MessageSigner::new(&attacker, TEST_NETWORK_ID),
     )
     .expect("encrypt forged payload");
 

--- a/crates/node/src/onion/directory.rs
+++ b/crates/node/src/onion/directory.rs
@@ -74,11 +74,11 @@ pub(crate) async fn build_onion_proxy_route_with_first_hop(
     let directory_exits = OnionExitDescriptor::latest_valid_by_service_did(
         reader.live_onion_exits("").await?,
         now_ms,
+        reader.dht_protocol_mode().network_id,
         false,
     );
     let service_exits = directory_exits
         .into_iter()
-        .filter(|exit| exit.matches_network(reader.dht_protocol_mode().network_id))
         .filter(|exit| exit.advertises_service_name(service_name.as_str()))
         .collect::<Vec<_>>();
     if service_exits.is_empty() {

--- a/crates/node/src/onion/https/mod.rs
+++ b/crates/node/src/onion/https/mod.rs
@@ -281,8 +281,10 @@ impl OnionHttpsRuntime {
         from: Did,
         id: OnionCircuitId,
         payload: OnionAuthenticatedPayload,
+        network_id: u32,
     ) {
-        let Some((pending, payload)) = self.take_pending_payload(from, id, payload) else {
+        let Some((pending, payload)) = self.take_pending_payload(from, id, payload, network_id)
+        else {
             return;
         };
         match decode_https_payload(payload) {
@@ -318,6 +320,7 @@ impl OnionHttpsRuntime {
         from: Did,
         id: OnionCircuitId,
         payload: OnionAuthenticatedPayload,
+        network_id: u32,
     ) -> Option<(PendingRequest, OnionCircuitPayload)> {
         let mut pending = self.pending.lock().ok()?;
         let request = pending.remove(&id)?;
@@ -325,7 +328,7 @@ impl OnionHttpsRuntime {
             pending.insert(id, request);
             return None;
         }
-        match payload.into_verified_payload(request.return_id, &request.expected_exit) {
+        match payload.into_verified_payload(request.return_id, &request.expected_exit, network_id) {
             Ok(verified) => Some((request, verified.payload)),
             Err(error) => {
                 let _ = request.sender.send(Err(error));
@@ -553,7 +556,8 @@ impl OnionCircuitHandler for BrowserOnionCircuitHandler {
         circuit_id: OnionCircuitId,
         payload: OnionAuthenticatedPayload,
     ) -> Result<()> {
-        self.https.complete_payload(from, circuit_id, payload);
+        self.https
+            .complete_payload(from, circuit_id, payload, self.signer.network_id());
         Ok(())
     }
 }

--- a/crates/node/src/onion/https/mod.rs
+++ b/crates/node/src/onion/https/mod.rs
@@ -17,6 +17,8 @@ use bytes::Bytes;
 #[cfg(any(test, rings_browser))]
 use futures::channel::oneshot;
 use rings_core::dht::Did;
+use rings_core::message::MessageSigner;
+#[cfg(rings_browser)]
 use rings_core::session::SessionSk;
 use serde::Deserialize;
 use serde::Serialize;
@@ -524,13 +526,23 @@ fn url_path(suffix: &str) -> String {
 pub(crate) struct BrowserOnionCircuitHandler {
     https: Arc<OnionHttpsRuntime>,
     session_sk: SessionSk,
+    network_id: u32,
 }
 
 #[cfg(rings_browser)]
 impl BrowserOnionCircuitHandler {
-    /// Create a browser circuit handler backed by the HTTPS runtime.
-    pub(crate) fn new(https: Arc<OnionHttpsRuntime>, session_sk: SessionSk) -> Self {
-        Self { https, session_sk }
+    /// Create a browser circuit handler backed by the HTTPS runtime, signing backward payloads
+    /// for the overlay `network_id`.
+    pub(crate) fn new(
+        https: Arc<OnionHttpsRuntime>,
+        session_sk: SessionSk,
+        network_id: u32,
+    ) -> Self {
+        Self {
+            https,
+            session_sk,
+            network_id,
+        }
     }
 }
 
@@ -538,7 +550,13 @@ impl BrowserOnionCircuitHandler {
 #[async_trait::async_trait(?Send)]
 impl OnionCircuitHandler for BrowserOnionCircuitHandler {
     async fn handle_exit(&self, scope: &Scope, frame: OnionCircuitExitFrame) -> Result<()> {
-        let _ = try_handle_https_exit_payload(&self.https, &self.session_sk, scope, frame).await?;
+        let _ = try_handle_https_exit_payload(
+            &self.https,
+            MessageSigner::new(&self.session_sk, self.network_id),
+            scope,
+            frame,
+        )
+        .await?;
         Ok(())
     }
 
@@ -556,7 +574,7 @@ impl OnionCircuitHandler for BrowserOnionCircuitHandler {
 
 pub(crate) async fn try_handle_https_exit_payload(
     runtime: &Arc<OnionHttpsRuntime>,
-    session_sk: &SessionSk,
+    signer: MessageSigner<'_>,
     scope: &Scope,
     frame: OnionCircuitExitFrame,
 ) -> Result<bool> {
@@ -591,7 +609,7 @@ pub(crate) async fn try_handle_https_exit_payload(
     send_backward(
         &runtime.link_sender,
         scope,
-        session_sk,
+        signer,
         OnionBackwardPath::new(
             frame.circuit_id,
             frame.return_peer,

--- a/crates/node/src/onion/https/mod.rs
+++ b/crates/node/src/onion/https/mod.rs
@@ -18,7 +18,6 @@ use bytes::Bytes;
 use futures::channel::oneshot;
 use rings_core::dht::Did;
 use rings_core::message::MessageSigner;
-#[cfg(rings_browser)]
 use rings_core::session::SessionSk;
 use serde::Deserialize;
 use serde::Serialize;
@@ -525,24 +524,16 @@ fn url_path(suffix: &str) -> String {
 #[cfg(rings_browser)]
 pub(crate) struct BrowserOnionCircuitHandler {
     https: Arc<OnionHttpsRuntime>,
-    session_sk: SessionSk,
-    network_id: u32,
+    /// The exit's signing authority for backward payloads.
+    signer: MessageSigner<SessionSk>,
 }
 
 #[cfg(rings_browser)]
 impl BrowserOnionCircuitHandler {
     /// Create a browser circuit handler backed by the HTTPS runtime, signing backward payloads
     /// for the overlay `network_id`.
-    pub(crate) fn new(
-        https: Arc<OnionHttpsRuntime>,
-        session_sk: SessionSk,
-        network_id: u32,
-    ) -> Self {
-        Self {
-            https,
-            session_sk,
-            network_id,
-        }
+    pub(crate) fn new(https: Arc<OnionHttpsRuntime>, signer: MessageSigner<SessionSk>) -> Self {
+        Self { https, signer }
     }
 }
 
@@ -550,13 +541,8 @@ impl BrowserOnionCircuitHandler {
 #[async_trait::async_trait(?Send)]
 impl OnionCircuitHandler for BrowserOnionCircuitHandler {
     async fn handle_exit(&self, scope: &Scope, frame: OnionCircuitExitFrame) -> Result<()> {
-        let _ = try_handle_https_exit_payload(
-            &self.https,
-            MessageSigner::new(&self.session_sk, self.network_id),
-            scope,
-            frame,
-        )
-        .await?;
+        let _ =
+            try_handle_https_exit_payload(&self.https, self.signer.by_ref(), scope, frame).await?;
         Ok(())
     }
 
@@ -574,7 +560,7 @@ impl OnionCircuitHandler for BrowserOnionCircuitHandler {
 
 pub(crate) async fn try_handle_https_exit_payload(
     runtime: &Arc<OnionHttpsRuntime>,
-    signer: MessageSigner<'_>,
+    signer: MessageSigner<&SessionSk>,
     scope: &Scope,
     frame: OnionCircuitExitFrame,
 ) -> Result<bool> {

--- a/crates/node/src/onion/https/tests/test_https_proxy.rs
+++ b/crates/node/src/onion/https/tests/test_https_proxy.rs
@@ -6,6 +6,8 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use rings_core::ecc::SecretKey;
+#[cfg(rings_native)]
+use rings_core::message::MessageSigner;
 use rings_core::session::SessionSk;
 #[cfg(rings_native)]
 use tokio::io::AsyncReadExt;
@@ -18,6 +20,9 @@ use super::super::*;
 use crate::onion::OnionExitDescriptorBody;
 use crate::onion::OnionExitService;
 use crate::online::OnlineNodeType;
+
+/// Overlay every fixture exit descriptor is published for.
+const TEST_NETWORK_ID: u32 = 1;
 
 fn did() -> Did {
     SecretKey::random().address().into()
@@ -60,7 +65,7 @@ fn dummy_authenticated_payload(
             "wrong peer".to_string(),
         )))
         .expect("encode payload"),
-        session,
+        MessageSigner::new(session, TEST_NETWORK_ID),
     )
     .expect("signed payload")
 }
@@ -233,7 +238,7 @@ fn test_pending_request_reports_authenticated_request_as_unexpected_backward_pay
     let payload = OnionAuthenticatedPayload::new_signed(
         return_id,
         encode_https_payload(request_payload).unwrap(),
-        &exit,
+        MessageSigner::new(&exit, TEST_NETWORK_ID),
     )
     .unwrap();
 

--- a/crates/node/src/onion/https/tests/test_https_proxy.rs
+++ b/crates/node/src/onion/https/tests/test_https_proxy.rs
@@ -191,7 +191,12 @@ fn test_pending_request_completes_only_from_expected_return_peer() {
         .begin_request(expected, exit_descriptor(&exit), return_id)
         .unwrap();
 
-    runtime.complete_payload(other, id, dummy_authenticated_payload(return_id, &exit));
+    runtime.complete_payload(
+        other,
+        id,
+        dummy_authenticated_payload(return_id, &exit),
+        TEST_NETWORK_ID,
+    );
     assert_eq!(runtime.pending_len(), 1);
     drop(pending_request);
 }
@@ -211,6 +216,7 @@ fn test_pending_request_rejects_payload_from_wrong_exit_session() {
         expected,
         id,
         dummy_authenticated_payload(return_id, &wrong_exit),
+        TEST_NETWORK_ID,
     );
 
     assert_eq!(runtime.pending_len(), 0);
@@ -240,7 +246,7 @@ fn test_pending_request_reports_authenticated_request_as_unexpected_backward_pay
     )
     .unwrap();
 
-    runtime.complete_payload(expected, id, payload);
+    runtime.complete_payload(expected, id, payload, TEST_NETWORK_ID);
 
     assert_eq!(runtime.pending_len(), 0);
     assert!(matches!(

--- a/crates/node/src/onion/https/tests/test_https_proxy.rs
+++ b/crates/node/src/onion/https/tests/test_https_proxy.rs
@@ -20,9 +20,7 @@ use super::super::*;
 use crate::onion::OnionExitDescriptorBody;
 use crate::onion::OnionExitService;
 use crate::online::OnlineNodeType;
-
-/// Overlay every fixture exit descriptor is published for.
-const TEST_NETWORK_ID: u32 = 1;
+use crate::tests::TEST_NETWORK_ID;
 
 fn did() -> Did {
     SecretKey::random().address().into()
@@ -42,7 +40,7 @@ fn exit_descriptor(session: &SessionSk) -> OnionExitDescriptor {
                 .expect("verification key"),
             session_public_key: session.session_public_key(),
             node_type: OnlineNodeType::Browser,
-            network_id: 1,
+            network_id: TEST_NETWORK_ID,
             service: OnionExitService::https(),
             policy: OnionExitPolicy::default(),
             started_at_ms: 0,
@@ -50,7 +48,7 @@ fn exit_descriptor(session: &SessionSk) -> OnionExitDescriptor {
             expires_at_ms: 1,
             version: "test".to_string(),
         },
-        session,
+        MessageSigner::new(session, TEST_NETWORK_ID),
     )
     .expect("signed exit")
 }

--- a/crates/node/src/onion/mod.rs
+++ b/crates/node/src/onion/mod.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use rings_core::dht::Did;
+use rings_core::domain_tag;
 use rings_core::ecc::PublicKey;
 use rings_core::ecc::VerificationPublicKey;
 use rings_core::error::Error as CoreError;
@@ -21,6 +22,7 @@ use rings_core::message::Decoder;
 use rings_core::message::DomainTag;
 use rings_core::message::Encoded;
 use rings_core::message::Encoder;
+use rings_core::message::MessageSigner;
 use rings_core::message::MessageVerification;
 use rings_core::session::SessionSk;
 use rings_core::utils::get_epoch_ms;
@@ -81,7 +83,7 @@ const DEFAULT_ONION_EXIT_HEARTBEAT_INTERVAL_SECS: u64 = 30;
 const DEFAULT_ONION_EXIT_TTL_SECS: u64 = 90;
 /// Message family of the onion-exit descriptor signature.
 const ONION_EXIT_DESCRIPTOR_DOMAIN_TAG: DomainTag =
-    DomainTag::new("rings-node:onion-exit-descriptor:v1");
+    domain_tag!("rings-node:onion-exit-descriptor:v1");
 
 /// Default onion-exit registry heartbeat interval in seconds.
 pub(crate) const fn default_onion_exit_heartbeat_interval_secs() -> u64 {
@@ -564,10 +566,13 @@ pub struct OnionExitDescriptor {
 
 impl OnionExitDescriptor {
     /// Create and sign an onion-exit descriptor.
-    pub fn new_signed(body: OnionExitDescriptorBody, session_sk: &SessionSk) -> CoreResult<Self> {
+    pub fn new_signed(
+        body: OnionExitDescriptorBody,
+        signer: MessageSigner<&SessionSk>,
+    ) -> CoreResult<Self> {
         sign_descriptor_body(
             body,
-            session_sk,
+            signer,
             "onion exit descriptor DID/public key/session mismatch",
         )
     }
@@ -614,11 +619,6 @@ impl OnionExitDescriptor {
         self.schema_version == ONION_EXIT_DESCRIPTOR_SCHEMA_VERSION
     }
 
-    /// Return whether this descriptor belongs to `network_id`.
-    pub const fn matches_network(&self, network_id: u32) -> bool {
-        self.network_id == network_id
-    }
-
     /// Return whether this descriptor advertises the requested service name.
     pub fn advertises_service_name(&self, service: &str) -> bool {
         self.service.has_name(service)
@@ -637,8 +637,8 @@ impl OnionExitDescriptor {
     }
 
     /// Verify the descriptor signature and DID/public-key binding.
-    pub fn verify_signature(&self) -> bool {
-        self.has_supported_schema() && self.descriptor_verify_signature()
+    pub fn verify_signature(&self, network_id: u32) -> bool {
+        self.has_supported_schema() && self.descriptor_verify_signature(network_id)
     }
 
     /// Returns whether this descriptor is expired at `now_ms`.
@@ -647,8 +647,8 @@ impl OnionExitDescriptor {
     }
 
     /// Returns whether this descriptor has a valid signature and is not expired.
-    pub fn is_live_at(&self, now_ms: u128) -> bool {
-        self.verify_signature() && !self.is_expired_at(now_ms)
+    pub fn is_live_at(&self, now_ms: u128, network_id: u32) -> bool {
+        self.verify_signature(network_id) && !self.is_expired_at(now_ms)
     }
 
     /// Select the newest valid onion-exit descriptor per `(DID, service)`.
@@ -659,15 +659,16 @@ impl OnionExitDescriptor {
     pub fn latest_valid_by_service_did(
         descriptors: impl IntoIterator<Item = Self>,
         now_ms: u128,
+        network_id: u32,
         include_expired: bool,
     ) -> Vec<Self> {
         let mut latest = BTreeMap::<(Did, OnionExitService), Self>::new();
         for descriptor in descriptors {
             if include_expired {
-                if !descriptor.verify_signature() {
+                if !descriptor.verify_signature(network_id) {
                     continue;
                 }
-            } else if !descriptor.is_live_at(now_ms) {
+            } else if !descriptor.is_live_at(now_ms, network_id) {
                 continue;
             }
             let key = (descriptor.did, descriptor.service.clone());
@@ -687,7 +688,7 @@ impl OnionExitDescriptor {
 }
 
 impl SignedDescriptor for OnionExitDescriptor {
-    const DOMAIN_TAG: DomainTag = ONION_EXIT_DESCRIPTOR_DOMAIN_TAG;
+    type Body = OnionExitDescriptorBody;
 
     fn descriptor_did(&self) -> Did {
         self.did
@@ -695,10 +696,6 @@ impl SignedDescriptor for OnionExitDescriptor {
 
     fn descriptor_public_key(&self) -> &VerificationPublicKey {
         &self.public_key
-    }
-
-    fn descriptor_network_id(&self) -> u32 {
-        self.network_id
     }
 
     fn descriptor_signature(&self) -> &MessageVerification {
@@ -827,7 +824,7 @@ impl OnionExitRegistration {
                 expires_at_ms: now_ms + self.ttl.as_millis(),
                 version: crate::util::build_version(),
             },
-            context.session_sk(),
+            context.message_signer(),
         )
         .map_err(Error::CoreError)
     }
@@ -849,7 +846,8 @@ impl OnionExitRegistration {
                     .decode::<OnionExitDescriptor>()
                     .is_ok_and(|descriptor| {
                         descriptor.did == context.did()
-                            || (descriptor.verify_signature() && descriptor.is_expired_at(now_ms))
+                            || (descriptor.verify_signature(context.network_id())
+                                && descriptor.is_expired_at(now_ms))
                     })
             })
             .await?;

--- a/crates/node/src/onion/mod.rs
+++ b/crates/node/src/onion/mod.rs
@@ -698,6 +698,10 @@ impl SignedDescriptor for OnionExitDescriptor {
         &self.public_key
     }
 
+    fn descriptor_network_id(&self) -> u32 {
+        self.network_id
+    }
+
     fn descriptor_signature(&self) -> &MessageVerification {
         &self.signature
     }

--- a/crates/node/src/onion/mod.rs
+++ b/crates/node/src/onion/mod.rs
@@ -18,6 +18,7 @@ use rings_core::ecc::VerificationPublicKey;
 use rings_core::error::Error as CoreError;
 use rings_core::error::Result as CoreResult;
 use rings_core::message::Decoder;
+use rings_core::message::DomainTag;
 use rings_core::message::Encoded;
 use rings_core::message::Encoder;
 use rings_core::message::MessageVerification;
@@ -78,6 +79,9 @@ pub const ONION_RELAY_CAPABILITY: &str = "onion-relay";
 
 const DEFAULT_ONION_EXIT_HEARTBEAT_INTERVAL_SECS: u64 = 30;
 const DEFAULT_ONION_EXIT_TTL_SECS: u64 = 90;
+/// Message family of the onion-exit descriptor signature.
+const ONION_EXIT_DESCRIPTOR_DOMAIN_TAG: DomainTag =
+    DomainTag::new("rings-node:onion-exit-descriptor:v1");
 
 /// Default onion-exit registry heartbeat interval in seconds.
 pub(crate) const fn default_onion_exit_heartbeat_interval_secs() -> u64 {
@@ -468,12 +472,18 @@ impl OnionExitDescriptorBody {
 impl SignedDescriptorBody for OnionExitDescriptorBody {
     type Descriptor = OnionExitDescriptor;
 
+    const DOMAIN_TAG: DomainTag = ONION_EXIT_DESCRIPTOR_DOMAIN_TAG;
+
     fn body_did(&self) -> Did {
         self.did
     }
 
     fn body_public_key(&self) -> &VerificationPublicKey {
         &self.public_key
+    }
+
+    fn body_network_id(&self) -> u32 {
+        self.network_id
     }
 
     fn body_signing_data(&self) -> CoreResult<Vec<u8>> {
@@ -677,12 +687,18 @@ impl OnionExitDescriptor {
 }
 
 impl SignedDescriptor for OnionExitDescriptor {
+    const DOMAIN_TAG: DomainTag = ONION_EXIT_DESCRIPTOR_DOMAIN_TAG;
+
     fn descriptor_did(&self) -> Did {
         self.did
     }
 
     fn descriptor_public_key(&self) -> &VerificationPublicKey {
         &self.public_key
+    }
+
+    fn descriptor_network_id(&self) -> u32 {
+        self.network_id
     }
 
     fn descriptor_signature(&self) -> &MessageVerification {

--- a/crates/node/src/onion/route/mod.rs
+++ b/crates/node/src/onion/route/mod.rs
@@ -465,9 +465,8 @@ fn eligible_exits(
     service: &OnionServiceName,
     exits: impl IntoIterator<Item = OnionExitDescriptor>,
 ) -> Vec<OnionExitDescriptor> {
-    OnionExitDescriptor::latest_valid_by_service_did(exits, now_ms, false)
+    OnionExitDescriptor::latest_valid_by_service_did(exits, now_ms, network_id, false)
         .into_iter()
-        .filter(|descriptor| descriptor.matches_network(network_id))
         .filter(|descriptor| descriptor.offers_service(service.as_str()))
         .collect()
 }
@@ -478,7 +477,7 @@ fn eligible_relay_dids(
     local: Did,
     online_nodes: impl IntoIterator<Item = OnlineNodeDescriptor>,
 ) -> Vec<OnionRouteHop> {
-    OnlineNodeDescriptor::latest_valid_by_did(online_nodes, now_ms, false)
+    OnlineNodeDescriptor::latest_valid_by_did(online_nodes, now_ms, dht_protocol.network_id, false)
         .into_iter()
         .filter(|descriptor| descriptor.matches_dht_protocol(dht_protocol))
         .filter(has_onion_relay_capability)

--- a/crates/node/src/onion/route/tests/test_route_selection.rs
+++ b/crates/node/src/onion/route/tests/test_route_selection.rs
@@ -4,6 +4,7 @@ use rings_core::ecc::SecretKey;
 use rings_core::error::Result as CoreResult;
 use rings_core::measure::PeerQuality;
 use rings_core::message::DhtProtocolMode;
+use rings_core::message::MessageSigner;
 use rings_core::session::SessionSk;
 
 use super::super::*;
@@ -70,7 +71,7 @@ fn signed_exit_for_session_network_at(
             expires_at_ms,
             version: "test".to_string(),
         },
-        session_sk,
+        MessageSigner::new(session_sk, network_id),
     )
     .map_err(Error::CoreError)
 }
@@ -123,7 +124,7 @@ fn online_node_at_with_network_and_capabilities(
             expires_at_ms,
             version: "test".to_string(),
         },
-        session_sk,
+        MessageSigner::new(session_sk, network_id),
     )
 }
 

--- a/crates/node/src/onion/tcp/client.rs
+++ b/crates/node/src/onion/tcp/client.rs
@@ -1,5 +1,6 @@
 use rings_core::ecc::PublicKey;
 use rings_core::message::MessageSigner;
+use rings_core::session::SessionSk;
 
 use super::*;
 use crate::onion::circuit::OnionBackwardPath;
@@ -69,7 +70,7 @@ async fn send_client_payload(
 pub(super) struct TcpBackwardRoute<'route> {
     pub(super) link_sender: &'route OnionLinkSender,
     pub(super) scope: &'route Scope,
-    pub(super) signer: MessageSigner<'route>,
+    pub(super) signer: MessageSigner<&'route SessionSk>,
     pub(super) service: &'route OnionServiceName,
     pub(super) circuit_id: OnionCircuitId,
     pub(super) return_peer: Did,

--- a/crates/node/src/onion/tcp/client.rs
+++ b/crates/node/src/onion/tcp/client.rs
@@ -1,4 +1,5 @@
 use rings_core::ecc::PublicKey;
+use rings_core::message::MessageSigner;
 
 use super::*;
 use crate::onion::circuit::OnionBackwardPath;
@@ -68,7 +69,7 @@ async fn send_client_payload(
 pub(super) struct TcpBackwardRoute<'route> {
     pub(super) link_sender: &'route OnionLinkSender,
     pub(super) scope: &'route Scope,
-    pub(super) signer: &'route SessionSk,
+    pub(super) signer: MessageSigner<'route>,
     pub(super) service: &'route OnionServiceName,
     pub(super) circuit_id: OnionCircuitId,
     pub(super) return_peer: Did,

--- a/crates/node/src/onion/tcp/exit.rs
+++ b/crates/node/src/onion/tcp/exit.rs
@@ -111,7 +111,7 @@ impl ExitReturnPath {
         TcpBackwardRoute {
             link_sender: &self.runtime.link_sender,
             scope: &self.scope,
-            signer: &self.runtime.session_sk,
+            signer: self.runtime.message_signer(),
             service: &self.service,
             circuit_id: self.circuit_id,
             return_peer: self.return_peer,

--- a/crates/node/src/onion/tcp/mod.rs
+++ b/crates/node/src/onion/tcp/mod.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use rings_core::dht::Did;
 use rings_core::ecc::PublicKey;
+use rings_core::message::MessageSigner;
 use rings_core::session::SessionSk;
 use serde::Deserialize;
 use serde::Serialize;
@@ -123,11 +124,12 @@ impl NativeOnionCircuitHandle {
     pub fn install(
         extensions: &Extensions,
         session_sk: SessionSk,
+        network_id: u32,
         allow_relay: bool,
         exit_config: Option<NativeOnionTcpExitConfig>,
     ) -> Result<Self> {
         let allow_exit = exit_config.is_some();
-        let (runtime, https) = native_onion_runtimes(session_sk.clone(), exit_config);
+        let (runtime, https) = native_onion_runtimes(session_sk.clone(), network_id, exit_config);
         if let Some(config) = runtime.exit_config.as_ref() {
             if config.allows_service(&OnionServiceName::https()) {
                 https.set_exit_policy(Some(config.policy().clone()));
@@ -144,6 +146,7 @@ impl NativeOnionCircuitHandle {
                     runtime: runtime.clone(),
                     https,
                     session_sk: handler_session_sk,
+                    network_id,
                 },
                 runtime.link_sender.clone(),
             ),
@@ -180,12 +183,14 @@ impl NativeOnionCircuitHandle {
 
 fn native_onion_runtimes(
     session_sk: SessionSk,
+    network_id: u32,
     exit_config: Option<NativeOnionTcpExitConfig>,
 ) -> (Arc<OnionTcpRuntime>, Arc<OnionHttpsRuntime>) {
     let accounting = OnionExitAccounting::default();
     let link_sender = OnionLinkSender::default();
     let runtime = Arc::new(OnionTcpRuntime::with_resources(
         session_sk,
+        network_id,
         exit_config,
         accounting.clone(),
         link_sender.clone(),
@@ -225,6 +230,7 @@ struct NativeOnionCircuitHandler {
     runtime: Arc<OnionTcpRuntime>,
     https: Arc<OnionHttpsRuntime>,
     session_sk: SessionSk,
+    network_id: u32,
 }
 
 #[async_trait::async_trait]
@@ -233,8 +239,13 @@ impl OnionCircuitHandler for NativeOnionCircuitHandler {
         if frame
             .payload
             .matches_service(crate::onion::proxy::ONION_PROXY_HTTPS_SERVICE)
-            && try_handle_https_exit_payload(&self.https, &self.session_sk, scope, frame.clone())
-                .await?
+            && try_handle_https_exit_payload(
+                &self.https,
+                MessageSigner::new(&self.session_sk, self.network_id),
+                scope,
+                frame.clone(),
+            )
+            .await?
         {
             return Ok(());
         }
@@ -256,6 +267,7 @@ impl OnionCircuitHandler for NativeOnionCircuitHandler {
 
 struct OnionTcpRuntime {
     session_sk: SessionSk,
+    network_id: u32,
     client_streams: Mutex<HashMap<TcpStreamKey, ClientStream>>,
     exit_streams: Mutex<HashMap<TcpStreamKey, ExitStream>>,
     forward_replays: Mutex<OnionForwardReplayPartitions>,
@@ -266,9 +278,14 @@ struct OnionTcpRuntime {
 
 impl OnionTcpRuntime {
     #[cfg(test)]
-    fn new(session_sk: SessionSk, exit_config: Option<NativeOnionTcpExitConfig>) -> Self {
+    fn new(
+        session_sk: SessionSk,
+        network_id: u32,
+        exit_config: Option<NativeOnionTcpExitConfig>,
+    ) -> Self {
         Self::with_resources(
             session_sk,
+            network_id,
             exit_config,
             OnionExitAccounting::default(),
             OnionLinkSender::default(),
@@ -277,12 +294,14 @@ impl OnionTcpRuntime {
 
     fn with_resources(
         session_sk: SessionSk,
+        network_id: u32,
         exit_config: Option<NativeOnionTcpExitConfig>,
         accounting: OnionExitAccounting,
         link_sender: OnionLinkSender,
     ) -> Self {
         Self {
             session_sk,
+            network_id,
             client_streams: Mutex::new(HashMap::new()),
             exit_streams: Mutex::new(HashMap::new()),
             forward_replays: Mutex::new(OnionForwardReplayPartitions::default()),
@@ -290,6 +309,11 @@ impl OnionTcpRuntime {
             accounting,
             link_sender,
         }
+    }
+
+    /// The authority that signs this exit's backward payloads.
+    fn message_signer(&self) -> MessageSigner<'_> {
+        MessageSigner::new(&self.session_sk, self.network_id)
     }
 
     async fn open_client_connection(
@@ -606,7 +630,7 @@ impl OnionTcpRuntime {
         TcpBackwardRoute {
             link_sender: &self.link_sender,
             scope: &request.scope,
-            signer: &self.session_sk,
+            signer: self.message_signer(),
             service: &request.service,
             circuit_id: request.circuit_id,
             return_peer: request.return_peer,

--- a/crates/node/src/onion/tcp/mod.rs
+++ b/crates/node/src/onion/tcp/mod.rs
@@ -788,7 +788,8 @@ impl OnionTcpRuntime {
                 stream.return_id,
             )
         };
-        let verified = payload.into_verified_payload(return_id, &expected_exit)?;
+        let verified =
+            payload.into_verified_payload(return_id, &expected_exit, self.signer.network_id())?;
         if !verified.payload.is_service(&service) {
             return Err(Error::OnionRouteError(
                 OnionRouteError::PayloadServiceMismatch {

--- a/crates/node/src/onion/tcp/mod.rs
+++ b/crates/node/src/onion/tcp/mod.rs
@@ -314,10 +314,6 @@ impl OnionTcpRuntime {
         self.signer.by_ref()
     }
 
-    fn session_sk(&self) -> &SessionSk {
-        self.signer.session_sk()
-    }
-
     async fn open_client_connection(
         self: &Arc<Self>,
         scope: Scope,
@@ -327,7 +323,7 @@ impl OnionTcpRuntime {
         let expected_return_peer = route_first_hop(&route)?;
         let expected_exit = route.exit().clone();
         let service = route.service_name().clone();
-        let client_return = OnionClientReturn::new(self.session_sk().session_public_key());
+        let client_return = OnionClientReturn::new(self.signer.session_public_key());
         let (tx, rx) = mpsc::channel(32);
         let (open_tx, open_rx) = oneshot::channel();
         let key = self.insert_client_stream(

--- a/crates/node/src/onion/tcp/mod.rs
+++ b/crates/node/src/onion/tcp/mod.rs
@@ -145,8 +145,7 @@ impl NativeOnionCircuitHandle {
                 NativeOnionCircuitHandler {
                     runtime: runtime.clone(),
                     https,
-                    session_sk: handler_session_sk,
-                    network_id,
+                    signer: MessageSigner::new(handler_session_sk, network_id),
                 },
                 runtime.link_sender.clone(),
             ),
@@ -229,8 +228,8 @@ impl NativeOnionOpenStream {
 struct NativeOnionCircuitHandler {
     runtime: Arc<OnionTcpRuntime>,
     https: Arc<OnionHttpsRuntime>,
-    session_sk: SessionSk,
-    network_id: u32,
+    /// The exit's signing authority for backward payloads.
+    signer: MessageSigner<SessionSk>,
 }
 
 #[async_trait::async_trait]
@@ -241,7 +240,7 @@ impl OnionCircuitHandler for NativeOnionCircuitHandler {
             .matches_service(crate::onion::proxy::ONION_PROXY_HTTPS_SERVICE)
             && try_handle_https_exit_payload(
                 &self.https,
-                MessageSigner::new(&self.session_sk, self.network_id),
+                self.signer.by_ref(),
                 scope,
                 frame.clone(),
             )
@@ -266,8 +265,8 @@ impl OnionCircuitHandler for NativeOnionCircuitHandler {
 }
 
 struct OnionTcpRuntime {
-    session_sk: SessionSk,
-    network_id: u32,
+    /// The session key decrypts inbound cells; paired with the overlay it signs backward payloads.
+    signer: MessageSigner<SessionSk>,
     client_streams: Mutex<HashMap<TcpStreamKey, ClientStream>>,
     exit_streams: Mutex<HashMap<TcpStreamKey, ExitStream>>,
     forward_replays: Mutex<OnionForwardReplayPartitions>,
@@ -300,8 +299,7 @@ impl OnionTcpRuntime {
         link_sender: OnionLinkSender,
     ) -> Self {
         Self {
-            session_sk,
-            network_id,
+            signer: MessageSigner::new(session_sk, network_id),
             client_streams: Mutex::new(HashMap::new()),
             exit_streams: Mutex::new(HashMap::new()),
             forward_replays: Mutex::new(OnionForwardReplayPartitions::default()),
@@ -312,8 +310,12 @@ impl OnionTcpRuntime {
     }
 
     /// The authority that signs this exit's backward payloads.
-    fn message_signer(&self) -> MessageSigner<'_> {
-        MessageSigner::new(&self.session_sk, self.network_id)
+    fn message_signer(&self) -> MessageSigner<&SessionSk> {
+        self.signer.by_ref()
+    }
+
+    fn session_sk(&self) -> &SessionSk {
+        self.signer.session_sk()
     }
 
     async fn open_client_connection(
@@ -325,7 +327,7 @@ impl OnionTcpRuntime {
         let expected_return_peer = route_first_hop(&route)?;
         let expected_exit = route.exit().clone();
         let service = route.service_name().clone();
-        let client_return = OnionClientReturn::new(self.session_sk.session_public_key());
+        let client_return = OnionClientReturn::new(self.session_sk().session_public_key());
         let (tx, rx) = mpsc::channel(32);
         let (open_tx, open_rx) = oneshot::channel();
         let key = self.insert_client_stream(

--- a/crates/node/src/onion/tcp/tests/test_tcp_proxy.rs
+++ b/crates/node/src/onion/tcp/tests/test_tcp_proxy.rs
@@ -1,4 +1,5 @@
 use rings_core::ecc::SecretKey;
+use rings_core::message::MessageSigner;
 
 use super::super::*;
 use crate::onion::OnionExitDescriptorBody;
@@ -7,6 +8,9 @@ use crate::onion::OnionExitTransport;
 use crate::onion::OnionServiceName;
 use crate::online::OnlineNodeType;
 use crate::sync_lock::lock;
+
+/// Overlay every fixture exit descriptor is published for.
+const TEST_NETWORK_ID: u32 = 1;
 
 fn did() -> Did {
     SecretKey::random().address().into()
@@ -40,7 +44,7 @@ fn exit_descriptor(session: &SessionSk) -> OnionExitDescriptor {
 }
 
 fn runtime() -> OnionTcpRuntime {
-    OnionTcpRuntime::new(session(), None)
+    OnionTcpRuntime::new(session(), TEST_NETWORK_ID, None)
 }
 
 #[test]
@@ -51,7 +55,7 @@ fn test_native_tcp_and_https_share_one_node_wide_exit_budget() {
         max_streams_per_circuit: 1,
         ..OnionExitPolicy::default()
     };
-    let (tcp, https) = native_onion_runtimes(session, None);
+    let (tcp, https) = native_onion_runtimes(session, TEST_NETWORK_ID, None);
     let peer = Did::from(71_u32);
     let _tcp_lease = tcp
         .accounting
@@ -93,7 +97,7 @@ fn dummy_authenticated_payload_for_service(
     OnionAuthenticatedPayload::new_signed(
         return_id,
         encode_tcp_payload(&service, OnionTcpPayload::Close).expect("encode payload"),
-        session,
+        MessageSigner::new(session, TEST_NETWORK_ID),
     )
     .expect("signed payload")
 }
@@ -425,7 +429,7 @@ fn test_exit_runtime_accepts_only_installed_tcp_services() -> Result<()> {
         vec![OnionExitService::new("web", OnionExitTransport::Tcp)?],
         OnionExitPolicy::default(),
     )?;
-    let runtime = OnionTcpRuntime::new(session(), Some(config));
+    let runtime = OnionTcpRuntime::new(session(), TEST_NETWORK_ID, Some(config));
     let custom_payload = encode_tcp_payload(&service, OnionTcpPayload::Close)?;
     let tcp_payload = encode_tcp_payload(&OnionServiceName::tcp(), OnionTcpPayload::Close)?;
 
@@ -536,11 +540,18 @@ fn test_exit_limiter_counts_distinct_circuit_ids() {
 async fn test_install_rejects_duplicate_namespace_instead_of_splitting_runtime() -> Result<()> {
     let processor = Arc::new(crate::tests::native::prepare_processor().await);
     let session_sk = processor.session_sk().clone();
+    let network_id = processor.swarm.network_id();
     let extensions = Extensions::new(processor);
-    let _handle = NativeOnionCircuitHandle::install(&extensions, session_sk.clone(), false, None)?;
+    let _handle = NativeOnionCircuitHandle::install(
+        &extensions,
+        session_sk.clone(),
+        network_id,
+        false,
+        None,
+    )?;
 
     assert!(matches!(
-        NativeOnionCircuitHandle::install(&extensions, session_sk, false, None),
+        NativeOnionCircuitHandle::install(&extensions, session_sk, network_id, false, None),
         Err(Error::ExtensionError(_))
     ));
     Ok(())

--- a/crates/node/src/onion/tcp/tests/test_tcp_proxy.rs
+++ b/crates/node/src/onion/tcp/tests/test_tcp_proxy.rs
@@ -8,9 +8,7 @@ use crate::onion::OnionExitTransport;
 use crate::onion::OnionServiceName;
 use crate::online::OnlineNodeType;
 use crate::sync_lock::lock;
-
-/// Overlay every fixture exit descriptor is published for.
-const TEST_NETWORK_ID: u32 = 1;
+use crate::tests::TEST_NETWORK_ID;
 
 fn did() -> Did {
     SecretKey::random().address().into()
@@ -30,7 +28,7 @@ fn exit_descriptor(session: &SessionSk) -> OnionExitDescriptor {
                 .expect("verification key"),
             session_public_key: session.session_public_key(),
             node_type: OnlineNodeType::Native,
-            network_id: 1,
+            network_id: TEST_NETWORK_ID,
             service: OnionExitService::tcp(),
             policy: OnionExitPolicy::default(),
             started_at_ms: 0,
@@ -38,7 +36,7 @@ fn exit_descriptor(session: &SessionSk) -> OnionExitDescriptor {
             expires_at_ms: 1,
             version: "test".to_string(),
         },
-        session,
+        MessageSigner::new(session, TEST_NETWORK_ID),
     )
     .expect("signed exit")
 }

--- a/crates/node/src/onion/tests/test_exit_registry.rs
+++ b/crates/node/src/onion/tests/test_exit_registry.rs
@@ -1,9 +1,11 @@
 use rings_core::dht::entry;
 use rings_core::ecc::SecretKey;
 use rings_core::message::Encoder;
+use rings_core::message::MessageSigner;
 use rings_core::session::SessionSk;
 
 use super::super::*;
+use crate::tests::TEST_NETWORK_ID;
 
 fn service(name: &str) -> OnionExitService {
     OnionExitService::new(name, OnionExitTransport::Tcp).expect("valid test service")
@@ -52,7 +54,7 @@ fn signed_exit_for_session_at(
             expires_at_ms,
             version: version.to_string(),
         },
-        session_sk,
+        MessageSigner::new(session_sk, TEST_NETWORK_ID),
     )
     .map_err(Error::CoreError)
 }
@@ -176,11 +178,11 @@ fn test_exit_policy_rejects_invalid_target_entries() {
 #[test]
 fn test_exit_descriptor_signature_covers_policy() -> Result<()> {
     let mut descriptor = signed_exit_at(20, 100)?;
-    assert!(descriptor.verify_signature());
+    assert!(descriptor.verify_signature(TEST_NETWORK_ID));
 
     descriptor.policy.max_circuits = 32;
 
-    assert!(!descriptor.verify_signature());
+    assert!(!descriptor.verify_signature(TEST_NETWORK_ID));
     Ok(())
 }
 
@@ -191,11 +193,11 @@ fn test_exit_descriptor_signature_covers_schema_version() -> Result<()> {
         descriptor.schema_version,
         ONION_EXIT_DESCRIPTOR_SCHEMA_VERSION
     );
-    assert!(descriptor.verify_signature());
+    assert!(descriptor.verify_signature(TEST_NETWORK_ID));
 
     descriptor.schema_version = descriptor.schema_version.saturating_add(1);
 
-    assert!(!descriptor.verify_signature());
+    assert!(!descriptor.verify_signature(TEST_NETWORK_ID));
     Ok(())
 }
 
@@ -245,7 +247,7 @@ fn test_latest_valid_by_service_did_filters_expired_and_keeps_newest() -> Result
             expires_at_ms: 100,
             version: "old".to_string(),
         },
-        &session_sk,
+        MessageSigner::new(&session_sk, TEST_NETWORK_ID),
     )
     .map_err(Error::CoreError)?;
     let newer = OnionExitDescriptor::new_signed(
@@ -262,7 +264,7 @@ fn test_latest_valid_by_service_did_filters_expired_and_keeps_newest() -> Result
             expires_at_ms: 100,
             version: "new".to_string(),
         },
-        &session_sk,
+        MessageSigner::new(&session_sk, TEST_NETWORK_ID),
     )
     .map_err(Error::CoreError)?;
     let other_live = signed_exit_at(25, 100)?;
@@ -276,6 +278,7 @@ fn test_latest_valid_by_service_did_filters_expired_and_keeps_newest() -> Result
             expired.clone(),
         ],
         50,
+        TEST_NETWORK_ID,
         false,
     );
 
@@ -288,6 +291,7 @@ fn test_latest_valid_by_service_did_filters_expired_and_keeps_newest() -> Result
     let with_expired = OnionExitDescriptor::latest_valid_by_service_did(
         vec![older, newer, other_live, expired],
         50,
+        TEST_NETWORK_ID,
         true,
     );
     assert_eq!(with_expired.len(), 3);
@@ -315,6 +319,7 @@ fn test_latest_valid_by_service_did_preserves_same_did_distinct_services() -> Re
     let descriptors = OnionExitDescriptor::latest_valid_by_service_did(
         vec![old_tcp, new_tcp.clone(), https.clone(), custom.clone()],
         50,
+        TEST_NETWORK_ID,
         false,
     );
 

--- a/crates/node/src/online.rs
+++ b/crates/node/src/online.rs
@@ -305,6 +305,10 @@ impl SignedDescriptor for OnlineNodeDescriptor {
         &self.public_key
     }
 
+    fn descriptor_network_id(&self) -> u32 {
+        self.network_id
+    }
+
     fn descriptor_signature(&self) -> &MessageVerification {
         &self.signature
     }

--- a/crates/node/src/online.rs
+++ b/crates/node/src/online.rs
@@ -1,6 +1,7 @@
 //! Signed online-node descriptors stored in the DHT.
 
 use rings_core::dht::Did;
+use rings_core::domain_tag;
 use rings_core::ecc::PublicKey;
 use rings_core::ecc::VerificationPublicKey;
 use rings_core::error::Error;
@@ -10,6 +11,7 @@ use rings_core::message::DhtProtocolMode;
 use rings_core::message::DomainTag;
 use rings_core::message::Encoded;
 use rings_core::message::Encoder;
+use rings_core::message::MessageSigner;
 use rings_core::message::MessageVerification;
 use rings_core::session::SessionSk;
 use serde::Deserialize;
@@ -28,7 +30,7 @@ pub const ONLINE_NODES_TOPIC: &str = "online_nodes";
 pub const ONLINE_NODE_CAPABILITY_STORAGE: &str = "storage";
 /// Message family of the online-node descriptor signature.
 const ONLINE_NODE_DESCRIPTOR_DOMAIN_TAG: DomainTag =
-    DomainTag::new("rings-node:online-node-descriptor:v1");
+    domain_tag!("rings-node:online-node-descriptor:v1");
 
 /// Runtime family advertised by a node descriptor.
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
@@ -195,10 +197,13 @@ pub struct OnlineNodeDescriptor {
 
 impl OnlineNodeDescriptor {
     /// Create and sign a descriptor.
-    pub fn new_signed(body: OnlineNodeDescriptorBody, session_sk: &SessionSk) -> Result<Self> {
+    pub fn new_signed(
+        body: OnlineNodeDescriptorBody,
+        signer: MessageSigner<&SessionSk>,
+    ) -> Result<Self> {
         sign_descriptor_body(
             body,
-            session_sk,
+            signer,
             "online node descriptor DID/public key/session mismatch",
         )
     }
@@ -256,14 +261,15 @@ impl OnlineNodeDescriptor {
         self.dht_protocol_mode().matches(expected)
     }
 
-    /// Verify the descriptor signature and DID/public-key binding.
+    /// Verify the descriptor signature under the receiver's overlay `network_id` and the
+    /// DID/public-key binding.
     ///
     /// This does not apply the embedded [`MessageVerification`] timestamp/TTL
     /// as a liveness rule. Online-node liveness is defined solely by the
     /// signed `expires_at_ms` descriptor field; use [`Self::is_live_at`] when
     /// expiry should be enforced.
-    pub fn verify_signature(&self) -> bool {
-        self.descriptor_verify_signature()
+    pub fn verify_signature(&self, network_id: u32) -> bool {
+        self.descriptor_verify_signature(network_id)
     }
 
     /// Returns whether this descriptor is expired at `now_ms`.
@@ -271,23 +277,25 @@ impl OnlineNodeDescriptor {
         self.descriptor_is_expired_at(now_ms)
     }
 
-    /// Returns whether this descriptor has a valid signature and is not expired.
-    pub fn is_live_at(&self, now_ms: u128) -> bool {
-        self.descriptor_is_live_at(now_ms)
+    /// Returns whether this descriptor verifies under the overlay `network_id` and is not
+    /// expired.
+    pub fn is_live_at(&self, now_ms: u128, network_id: u32) -> bool {
+        self.descriptor_is_live_at(now_ms, network_id)
     }
 
-    /// Select the newest valid descriptor per DID.
+    /// Select the newest descriptor per DID that verifies under the overlay `network_id`.
     pub fn latest_valid_by_did(
         descriptors: impl IntoIterator<Item = Self>,
         now_ms: u128,
+        network_id: u32,
         include_expired: bool,
     ) -> Vec<Self> {
-        latest_valid_by_did(descriptors, now_ms, include_expired)
+        latest_valid_by_did(descriptors, now_ms, network_id, include_expired)
     }
 }
 
 impl SignedDescriptor for OnlineNodeDescriptor {
-    const DOMAIN_TAG: DomainTag = ONLINE_NODE_DESCRIPTOR_DOMAIN_TAG;
+    type Body = OnlineNodeDescriptorBody;
 
     fn descriptor_did(&self) -> Did {
         self.did
@@ -295,10 +303,6 @@ impl SignedDescriptor for OnlineNodeDescriptor {
 
     fn descriptor_public_key(&self) -> &VerificationPublicKey {
         &self.public_key
-    }
-
-    fn descriptor_network_id(&self) -> u32 {
-        self.network_id
     }
 
     fn descriptor_signature(&self) -> &MessageVerification {
@@ -336,6 +340,7 @@ mod tests {
     use rings_core::session::SessionSk;
 
     use super::*;
+    use crate::tests::TEST_NETWORK_ID;
 
     fn descriptor_at(heartbeat_at_ms: u128, expires_at_ms: u128) -> Result<OnlineNodeDescriptor> {
         let key = SecretKey::random();
@@ -357,20 +362,20 @@ mod tests {
                 expires_at_ms,
                 version: "test".to_string(),
             },
-            &session_sk,
+            MessageSigner::new(&session_sk, TEST_NETWORK_ID),
         )
     }
 
     #[test]
     fn test_descriptor_signature_covers_mutable_fields() -> Result<()> {
         let mut descriptor = descriptor_at(20, 30)?;
-        assert!(descriptor.verify_signature());
+        assert!(descriptor.verify_signature(TEST_NETWORK_ID));
 
         descriptor.node_type = OnlineNodeType::Browser;
-        assert!(!descriptor.verify_signature());
+        assert!(!descriptor.verify_signature(TEST_NETWORK_ID));
         descriptor = descriptor_at(20, 30)?;
         descriptor.storage_redundancy = 7;
-        assert!(!descriptor.verify_signature());
+        assert!(!descriptor.verify_signature(TEST_NETWORK_ID));
         Ok(())
     }
 
@@ -381,7 +386,7 @@ mod tests {
         let decoded = OnlineNodeDescriptor::from_encoded(&encoded)?;
 
         assert_eq!(decoded, descriptor);
-        assert!(decoded.verify_signature());
+        assert!(decoded.verify_signature(TEST_NETWORK_ID));
         Ok(())
     }
 
@@ -408,7 +413,7 @@ mod tests {
                 expires_at_ms: 100,
                 version: "old".to_string(),
             },
-            &session_sk,
+            MessageSigner::new(&session_sk, TEST_NETWORK_ID),
         )?;
         let newer = OnlineNodeDescriptor::new_signed(
             OnlineNodeDescriptorBody {
@@ -426,7 +431,7 @@ mod tests {
                 expires_at_ms: 100,
                 version: "new".to_string(),
             },
-            &session_sk,
+            MessageSigner::new(&session_sk, TEST_NETWORK_ID),
         )?;
         let other_live = descriptor_at(25, 100)?;
         let expired = descriptor_at(30, 40)?;
@@ -439,6 +444,7 @@ mod tests {
                 expired.clone(),
             ],
             50,
+            TEST_NETWORK_ID,
             false,
         );
 
@@ -451,6 +457,7 @@ mod tests {
         let with_expired = OnlineNodeDescriptor::latest_valid_by_did(
             vec![older, newer, other_live, expired],
             50,
+            TEST_NETWORK_ID,
             true,
         );
         assert_eq!(with_expired.len(), 3);

--- a/crates/node/src/online.rs
+++ b/crates/node/src/online.rs
@@ -7,6 +7,7 @@ use rings_core::error::Error;
 use rings_core::error::Result;
 use rings_core::message::Decoder;
 use rings_core::message::DhtProtocolMode;
+use rings_core::message::DomainTag;
 use rings_core::message::Encoded;
 use rings_core::message::Encoder;
 use rings_core::message::MessageVerification;
@@ -25,6 +26,9 @@ use crate::descriptor::SignedDescriptorBody;
 pub const ONLINE_NODES_TOPIC: &str = "online_nodes";
 /// Capability label for nodes that provide DHT storage.
 pub const ONLINE_NODE_CAPABILITY_STORAGE: &str = "storage";
+/// Message family of the online-node descriptor signature.
+const ONLINE_NODE_DESCRIPTOR_DOMAIN_TAG: DomainTag =
+    DomainTag::new("rings-node:online-node-descriptor:v1");
 
 /// Runtime family advertised by a node descriptor.
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
@@ -95,12 +99,18 @@ impl OnlineNodeDescriptorBody {
 impl SignedDescriptorBody for OnlineNodeDescriptorBody {
     type Descriptor = OnlineNodeDescriptor;
 
+    const DOMAIN_TAG: DomainTag = ONLINE_NODE_DESCRIPTOR_DOMAIN_TAG;
+
     fn body_did(&self) -> Did {
         self.did
     }
 
     fn body_public_key(&self) -> &VerificationPublicKey {
         &self.public_key
+    }
+
+    fn body_network_id(&self) -> u32 {
+        self.network_id
     }
 
     fn body_signing_data(&self) -> Result<Vec<u8>> {
@@ -277,12 +287,18 @@ impl OnlineNodeDescriptor {
 }
 
 impl SignedDescriptor for OnlineNodeDescriptor {
+    const DOMAIN_TAG: DomainTag = ONLINE_NODE_DESCRIPTOR_DOMAIN_TAG;
+
     fn descriptor_did(&self) -> Did {
         self.did
     }
 
     fn descriptor_public_key(&self) -> &VerificationPublicKey {
         &self.public_key
+    }
+
+    fn descriptor_network_id(&self) -> u32 {
+        self.network_id
     }
 
     fn descriptor_signature(&self) -> &MessageVerification {

--- a/crates/node/src/processor/config.rs
+++ b/crates/node/src/processor/config.rs
@@ -89,6 +89,11 @@ impl ProcessorConfig {
         self.session_sk.clone()
     }
 
+    /// Return the overlay this node joins.
+    pub fn network_id(&self) -> u32 {
+        self.network_id
+    }
+
     /// Enables only the standard HTTPS-over-TCP onion exit service.
     pub fn enable_https_onion_exit(mut self) -> Self {
         self.advertise_onion_exit = true;

--- a/crates/node/src/processor/mod.rs
+++ b/crates/node/src/processor/mod.rs
@@ -241,6 +241,7 @@ impl Processor {
         Ok(OnlineNodeDescriptor::latest_valid_by_did(
             descriptors,
             get_epoch_ms(),
+            self.swarm.network_id(),
             include_expired,
         ))
     }
@@ -311,10 +312,9 @@ impl Processor {
         include_expired: bool,
     ) -> Vec<OnionExitDescriptor> {
         OnionExitDescriptor::latest_valid_by_service_did(
-            Self::onion_exit_descriptors_from_entry(entry)
-                .into_iter()
-                .filter(|descriptor| descriptor.matches_network(self.swarm.network_id())),
+            Self::onion_exit_descriptors_from_entry(entry),
             get_epoch_ms(),
+            self.swarm.network_id(),
             include_expired,
         )
         .into_iter()
@@ -326,10 +326,9 @@ impl Processor {
         let now_ms = get_epoch_ms();
         Self::onion_exit_descriptors_from_entry(entry)
             .into_iter()
-            .filter(|descriptor| descriptor.matches_network(self.swarm.network_id()))
             .any(|descriptor| {
                 (service.is_empty() || descriptor.offers_service(service))
-                    && descriptor.verify_signature()
+                    && descriptor.verify_signature(self.swarm.network_id())
                     && descriptor.is_expired_at(now_ms)
             })
     }

--- a/crates/node/src/processor/mod.rs
+++ b/crates/node/src/processor/mod.rs
@@ -438,8 +438,13 @@ impl Processor {
     /// browser IndexedDB request futures while their JavaScript callbacks are
     /// still pending.
     pub async fn listen_with(&self, stop: StopToken) {
-        let stabilizer = self.swarm.stabilizer();
-        let stabilizer = Arc::new(stabilizer);
+        let stabilizer = match self.swarm.stabilizer() {
+            Ok(stabilizer) => Arc::new(stabilizer),
+            Err(error) => {
+                tracing::error!(error = ?error, "cannot start stabilization: swarm callback unavailable");
+                return;
+            }
+        };
         if self.registration_tasks.is_empty() {
             stabilizer.wait_with(self.stabilize_interval, stop).await;
         } else {

--- a/crates/node/src/processor/mod.rs
+++ b/crates/node/src/processor/mod.rs
@@ -438,13 +438,7 @@ impl Processor {
     /// browser IndexedDB request futures while their JavaScript callbacks are
     /// still pending.
     pub async fn listen_with(&self, stop: StopToken) {
-        let stabilizer = match self.swarm.stabilizer() {
-            Ok(stabilizer) => Arc::new(stabilizer),
-            Err(error) => {
-                tracing::error!(error = ?error, "cannot start stabilization: swarm callback unavailable");
-                return;
-            }
-        };
+        let stabilizer = Arc::new(self.swarm.stabilizer());
         if self.registration_tasks.is_empty() {
             stabilizer.wait_with(self.stabilize_interval, stop).await;
         } else {

--- a/crates/node/src/processor/tests/common.rs
+++ b/crates/node/src/processor/tests/common.rs
@@ -1,3 +1,5 @@
+use rings_core::message::MessageSigner;
+
 use super::*;
 
 // Native WebRTC tests share process-global ICE/UDP resources and timing-sensitive
@@ -313,7 +315,7 @@ pub(super) fn onion_exit_descriptor_for_processor_with_node_type_service(
             expires_at_ms: now_ms + 90_000,
             version: crate::util::build_version(),
         },
-        &processor.session_sk,
+        MessageSigner::new(&processor.session_sk, processor.swarm.network_id()),
     )
     .map_err(Error::CoreError)
 }
@@ -343,7 +345,7 @@ pub(super) fn online_relay_descriptor_for_processor(
             expires_at_ms: now_ms + 90_000,
             version: crate::util::build_version(),
         },
-        &processor.session_sk,
+        MessageSigner::new(&processor.session_sk, processor.swarm.network_id()),
     )
     .map_err(Error::CoreError)
 }

--- a/crates/node/src/processor/tests/common.rs
+++ b/crates/node/src/processor/tests/common.rs
@@ -455,8 +455,8 @@ pub(super) async fn wait_for_mutual_dht_topology(
             return Ok(());
         }
 
-        let stabilizer = processor.swarm.stabilizer()?;
-        let other_stabilizer = other.swarm.stabilizer()?;
+        let stabilizer = processor.swarm.stabilizer();
+        let other_stabilizer = other.swarm.stabilizer();
         futures::try_join!(stabilizer.stabilize(), other_stabilizer.stabilize(),)
             .map_err(Error::CoreError)?;
         let remaining = deadline

--- a/crates/node/src/processor/tests/common.rs
+++ b/crates/node/src/processor/tests/common.rs
@@ -455,8 +455,8 @@ pub(super) async fn wait_for_mutual_dht_topology(
             return Ok(());
         }
 
-        let stabilizer = processor.swarm.stabilizer();
-        let other_stabilizer = other.swarm.stabilizer();
+        let stabilizer = processor.swarm.stabilizer()?;
+        let other_stabilizer = other.swarm.stabilizer()?;
         futures::try_join!(stabilizer.stabilize(), other_stabilizer.stabilize(),)
             .map_err(Error::CoreError)?;
         let remaining = deadline

--- a/crates/node/src/processor/tests/test_gateway.rs
+++ b/crates/node/src/processor/tests/test_gateway.rs
@@ -243,18 +243,21 @@ async fn prepare_two_hop_public_gateway(config: GatewayConfig) -> Result<TwoHopG
     let client_onion = NativeOnionCircuitHandle::install(
         &client_provider.extensions(),
         client.session_sk().clone(),
+        client.swarm.network_id(),
         false,
         None,
     )?;
     let _relay_onion = NativeOnionCircuitHandle::install(
         &relay_provider.extensions(),
         relay.session_sk().clone(),
+        relay.swarm.network_id(),
         true,
         None,
     )?;
     let _exit_onion = NativeOnionCircuitHandle::install(
         &exit_provider.extensions(),
         exit.session_sk().clone(),
+        exit.swarm.network_id(),
         false,
         Some(NativeOnionTcpExitConfig::tcp(exit_policy.clone())),
     )?;

--- a/crates/node/src/processor/tests/test_network.rs
+++ b/crates/node/src/processor/tests/test_network.rs
@@ -92,10 +92,12 @@ async fn test_online_node_registry_lists_two_publishers_over_network() -> Result
     let nodes =
         wait_for_online_node_dids(&publisher, &expected, "publisher sees both publishers").await?;
 
-    assert!(nodes.iter().all(OnlineNodeDescriptor::verify_signature));
+    assert!(nodes
+        .iter()
+        .all(|descriptor| descriptor.verify_signature(publisher.swarm.network_id())));
     assert!(other_nodes
         .iter()
-        .all(OnlineNodeDescriptor::verify_signature));
+        .all(|descriptor| descriptor.verify_signature(owner.swarm.network_id())));
     Ok(())
 }
 

--- a/crates/node/src/processor/tests/test_onion.rs
+++ b/crates/node/src/processor/tests/test_onion.rs
@@ -24,7 +24,9 @@ async fn test_onion_exit_lookup_uses_dedicated_exit_registry() -> Result<()> {
     let exits = processor.lookup_onion_exits("web", false).await?;
 
     assert_eq!(exits, vec![exit_descriptor]);
-    assert!(exits.iter().all(OnionExitDescriptor::verify_signature));
+    assert!(exits
+        .iter()
+        .all(|descriptor| descriptor.verify_signature(processor.swarm.network_id())));
     assert!(!exits
         .iter()
         .any(|descriptor| descriptor.did == relay_only.did()));

--- a/crates/node/src/processor/tests/test_registry.rs
+++ b/crates/node/src/processor/tests/test_registry.rs
@@ -1,3 +1,5 @@
+use rings_core::message::MessageSigner;
+
 use super::common::*;
 use super::*;
 
@@ -207,7 +209,7 @@ async fn test_online_node_descriptor_publishes_and_lists_signed_self() -> Result
         nodes[0].dht_virtual_nodes,
         processor.swarm.dht_virtual_nodes()
     );
-    assert!(nodes[0].verify_signature());
+    assert!(nodes[0].verify_signature(processor.swarm.network_id()));
     assert!(!nodes[0].is_expired_at(get_epoch_ms()));
     Ok(())
 }
@@ -421,7 +423,10 @@ async fn test_online_node_lookup_filters_expired_descriptors_by_default() -> Res
             expires_at_ms: now_ms.saturating_sub(30_000),
             version: crate::util::build_version(),
         },
-        &expired_processor.session_sk,
+        MessageSigner::new(
+            &expired_processor.session_sk,
+            expired_processor.swarm.network_id(),
+        ),
     )
     .map_err(Error::CoreError)?;
 
@@ -512,7 +517,7 @@ async fn test_online_node_lookup_filters_other_storage_redundancy_modes() -> Res
             expires_at_ms: now_ms.saturating_add(60_000),
             version: crate::util::build_version(),
         },
-        &foreign.session_sk,
+        MessageSigner::new(&foreign.session_sk, foreign.swarm.network_id()),
     )
     .map_err(Error::CoreError)?;
 
@@ -549,6 +554,8 @@ async fn test_online_node_registry_lists_multiple_nodes() -> Result<()> {
         .iter()
         .any(|descriptor| descriptor.did == published.did));
     assert!(nodes.iter().any(|descriptor| descriptor.did == other.did()));
-    assert!(nodes.iter().all(OnlineNodeDescriptor::verify_signature));
+    assert!(nodes
+        .iter()
+        .all(|descriptor| descriptor.verify_signature(processor.swarm.network_id())));
     Ok(())
 }

--- a/crates/node/src/provider/browser/provider.rs
+++ b/crates/node/src/provider/browser/provider.rs
@@ -18,6 +18,7 @@ use rings_core::ecc::PublicKey;
 use rings_core::lifecycle::StopSource;
 use rings_core::measure::PeerQuality;
 use rings_core::message::DhtProtocolMode;
+use rings_core::message::MessageSigner;
 use rings_core::storage::idb::IdbStorage;
 use rings_core::utils::js_utils;
 use rings_core::utils::js_value;
@@ -193,6 +194,7 @@ impl BrowserOnionDirectoryReader {
                     .map_err(|error| Error::RemoteRpcError(error.to_string()))?;
                 Ok(crate::rpc_dto::online_node_descriptors_from_infos(
                     response.nodes,
+                    self.processor.swarm.network_id(),
                 ))
             }
         }
@@ -213,6 +215,7 @@ impl BrowserOnionDirectoryReader {
                     .map_err(|error| Error::RemoteRpcError(error.to_string()))?;
                 Ok(crate::rpc_dto::onion_exit_descriptors_from_infos(
                     response.exits,
+                    self.processor.swarm.network_id(),
                 ))
             }
         }
@@ -928,8 +931,10 @@ impl Provider {
             self.processor.session_sk().clone(),
             BrowserOnionCircuitHandler::new(
                 runtime,
-                self.processor.session_sk().clone(),
-                self.processor.swarm.network_id(),
+                MessageSigner::new(
+                    self.processor.session_sk().clone(),
+                    self.processor.swarm.network_id(),
+                ),
             ),
             link_sender,
         )

--- a/crates/node/src/provider/browser/provider.rs
+++ b/crates/node/src/provider/browser/provider.rs
@@ -926,7 +926,11 @@ impl Provider {
         let link_sender = runtime.link_sender();
         OnionCircuitShell::with_link_sender(
             self.processor.session_sk().clone(),
-            BrowserOnionCircuitHandler::new(runtime, self.processor.session_sk().clone()),
+            BrowserOnionCircuitHandler::new(
+                runtime,
+                self.processor.session_sk().clone(),
+                self.processor.swarm.network_id(),
+            ),
             link_sender,
         )
     }

--- a/crates/node/src/registration.rs
+++ b/crates/node/src/registration.rs
@@ -17,6 +17,7 @@ use rings_core::ecc::VerificationPublicKey;
 use rings_core::lifecycle::StopToken;
 use rings_core::message::Encoded;
 use rings_core::message::Encoder;
+use rings_core::message::MessageSigner;
 use rings_core::session::SessionSk;
 use rings_core::utils::get_epoch_ms;
 
@@ -159,6 +160,11 @@ impl<'a> RegistrationContext<'a> {
     /// Return the local session signing key.
     pub fn session_sk(&self) -> &SessionSk {
         self.processor.session_sk()
+    }
+
+    /// The authority that signs this node's descriptors: its session key inside its overlay.
+    pub fn message_signer(&self) -> MessageSigner<&SessionSk> {
+        MessageSigner::new(self.session_sk(), self.network_id())
     }
 
     pub(crate) async fn fetch_storage_entry(&self, entry_key: Did) -> Result<Option<entry::Entry>> {
@@ -552,7 +558,7 @@ impl OnlineNodeRegistration {
                 expires_at_ms: now_ms + self.ttl.as_millis(),
                 version: crate::util::build_version(),
             },
-            context.session_sk(),
+            context.message_signer(),
         )
         .map_err(Error::CoreError)
     }
@@ -574,7 +580,7 @@ impl OnlineNodeRegistration {
                         .decode::<OnlineNodeDescriptor>()
                         .is_ok_and(|descriptor| {
                             descriptor.did == context.did()
-                                || (descriptor.verify_signature()
+                                || (descriptor.verify_signature(context.network_id())
                                     && descriptor.is_expired_at(now_ms))
                         })
                 },
@@ -582,7 +588,8 @@ impl OnlineNodeRegistration {
                     observed
                         .decode::<OnlineNodeDescriptor>()
                         .is_ok_and(|descriptor| {
-                            descriptor.verify_signature() && !descriptor.is_expired_at(now_ms)
+                            descriptor.verify_signature(context.network_id())
+                                && !descriptor.is_expired_at(now_ms)
                         })
                 },
             )

--- a/crates/node/src/rpc_dto.rs
+++ b/crates/node/src/rpc_dto.rs
@@ -232,11 +232,12 @@ pub(crate) fn online_node_descriptor_from_info(
 #[cfg(all(feature = "browser", target_family = "wasm"))]
 pub(crate) fn online_node_descriptors_from_infos(
     descriptors: impl IntoIterator<Item = OnlineNodeDescriptorInfo>,
+    network_id: u32,
 ) -> Vec<OnlineNodeDescriptor> {
     descriptors
         .into_iter()
         .filter_map(|descriptor| online_node_descriptor_from_info(descriptor).ok())
-        .filter(OnlineNodeDescriptor::verify_signature)
+        .filter(|descriptor| descriptor.verify_signature(network_id))
         .collect()
 }
 
@@ -282,12 +283,13 @@ pub(crate) fn onion_exit_descriptors_from_info(
 #[cfg(all(feature = "browser", target_family = "wasm"))]
 pub(crate) fn onion_exit_descriptors_from_infos(
     descriptors: impl IntoIterator<Item = OnionExitDescriptorInfo>,
+    network_id: u32,
 ) -> Vec<OnionExitDescriptor> {
     descriptors
         .into_iter()
         .filter_map(|descriptor| onion_exit_descriptors_from_info(descriptor).ok())
         .flatten()
-        .filter(OnionExitDescriptor::verify_signature)
+        .filter(|descriptor| descriptor.verify_signature(network_id))
         .collect()
 }
 

--- a/crates/node/src/tests/mod.rs
+++ b/crates/node/src/tests/mod.rs
@@ -1,3 +1,6 @@
+/// Overlay every test fixture is published for and verified against.
+pub(crate) const TEST_NETWORK_ID: u32 = 1;
+
 #[cfg(feature = "node")]
 pub mod native;
 #[cfg(all(feature = "browser", target_family = "wasm"))]

--- a/examples/native/Cargo.toml
+++ b/examples/native/Cargo.toml
@@ -12,7 +12,7 @@ async-trait = { workspace = true }
 base64 = "0.13"
 bytes = "1.2.1"
 rings-core = { workspace = true }
-rings-node = { path = "../../crates/node", version = "0.20.2", default-features = false, features = ["node"] }
+rings-node = { path = "../../crates/node", version = "0.21.0", default-features = false, features = ["node"] }
 rings-rpc = { workspace = true }
 serde_json = "1.0.70"
 tokio = { version = "1.13.0", features = ["macros", "rt-multi-thread", "time"] }

--- a/examples/relay/Cargo.toml
+++ b/examples/relay/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 rings-core = { workspace = true }
-rings-node = { path = "../../crates/node", version = "0.20.2", default-features = false, features = ["node"] }
+rings-node = { path = "../../crates/node", version = "0.21.0", default-features = false, features = ["node"] }
 tokio = { version = "1.13.0", features = ["io-util", "macros", "net", "rt-multi-thread", "time"] }
 
 [[example]]

--- a/frontend/Cargo.lock
+++ b/frontend/Cargo.lock
@@ -2683,7 +2683,6 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "chrono",
- "dashmap",
  "ecdsa",
  "ed25519 1.5.3",
  "ed25519-dalek",

--- a/frontend/Cargo.lock
+++ b/frontend/Cargo.lock
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "rings-codec"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "postcard",
  "serde",
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "rings-core"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "rings-derive"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "rings-measure"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "rings-network-policy"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "thiserror 1.0.69",
  "url",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "rings-node"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "rings-rpc"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "rings-transport"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "rings-webview"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ringsnetwork/rings-node",
-  "version": "0.20.2",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ringsnetwork/rings-node",
-      "version": "0.20.2",
+      "version": "0.21.0",
       "license": "GPL-3.0",
       "devDependencies": {
         "@biomejs/biome": "2.5.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "RND <dev@ringsnetwork.io>"
   ],
   "description": "Rings is a structured peer-to-peer network implementation using WebRTC, Chord algorithm, and full WebAssembly (WASM) support.\n",
-  "version": "0.20.2",
+  "version": "0.21.0",
   "license": "GPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #704, closes #701, closes #725, closes #726.

## Signature domain separation (#704)

Every `MessageVerification` now signs a domain-separated transcript

```
len(tag) || tag || network_id || ts_ms || ttl_ms || data
```

where the domain `(tag, network_id)` names the message family and the overlay. Every signature is
issued by a `MessageSigner` (a session key acting inside one overlay) and verified against the
*receiver's* domain, never a value carried in the message, so:

- a signature issued inside overlay `A` does not verify inside overlay `B` even when the session
  key is shared;
- the `Transaction` and `MessagePayload` signatures over the same transaction hash are no longer
  interchangeable, and node descriptors / onion backward payloads sign under their own tags;
- node descriptors are signed by the node's `MessageSigner` and verified under the receiver's
  `network_id`; signing a body that states another overlay is refused, so a verified descriptor's
  stated overlay is the overlay it was signed for (the former `matches_network` post-filters are
  gone).

API shape:

- `DomainTag` (built with `domain_tag!`, which checks the length-prefix law at compile time),
  `SigningDomain`, and `MessageSigner<S: Borrow<SessionSk>>` are exported from
  `rings_core::message`. `MessageSigner<&SessionSk>` is the `Copy` form signing functions take;
  `MessageSigner<SessionSk>` is what long-lived runtimes (chunked transfers, onion exits) store, so
  the key/overlay pairing is never split across two fields.
- `Transaction::new*`, `MessagePayload::new*`, `PayloadSender`, and the descriptor constructors take
  a `MessageSigner`; `MessageVerificationExt::verify` and the descriptor `verify_signature` /
  `is_live_at` / `latest_valid_by_*` take the receiver's `network_id`.

This is a wire-incompatible change (signatures from earlier builds no longer verify), hence the
bump to 0.21.0.

## Storage bounds (#701)

1. **Native storage enforces its byte budget.** `SledStorage` keeps an in-memory index of file
   sizes in write order (rebuilt from the directory on open, stale `.tmp` files removed). A `put`
   beyond the budget retires the least recently written *other* keys until the value fits; a value
   larger than the whole budget is rejected with `Error::StorageValueExceedsCapacity`; the index is
   updated only after the file-system operation succeeded, so a failed write leaves index and
   directory consistent; the budget is restored on open. A record the current schema cannot decode
   (written by an earlier build) is retired on the read that discovers it. `MemStorage::bounded`
   gives the local fetched-entry cache least-recently-written eviction at `LOCAL_CACHE_CAPACITY`
   entries. Both backends share one `WriteOrderedMap`.

2. **Entries carry a retention bound.** `Entry::expires_at_ms` is stamped at the operation boundary
   (`EntryOperation::stamped(now, actor)`) with `DEFAULT_TTL_MS` and joins by `max`, so the product
   of the payload lattice and the bound lattice stays a join-semilattice. Every storage read goes
   through `PeerRing::live_storage_entry` / `live_storage_entries`, which retire an expired value
   and report it absent, so hand-off, republish, lookup, and ack-delete never see an expired value.
   A stored value without a bound is treated as not live. The retention model lives in
   `dht/entry/retention.rs`.

3. **Admission bounds peer-supplied deltas.** `Entry::validate_admissible_at(now)` requires a live
   bound at most `now + MAX_TTL_MS + TS_OFFSET_TOLERANCE_MS`, every version (dots, tombstones,
   register) at most `now + TS_OFFSET_TOLERANCE_MS`, and every payload element at most
   `ENTRY_PAYLOAD_MAX_BYTES` (32 KiB). It is enforced on the *peer-supplied delta* at the two
   write funnels (`PeerRing::operate_storage_entry` for operations, `join_storage_entry` for
   replicated values), pre-checked in the sync batch so a failing entry rejects the batch before
   any earlier entry is written (one admission clock per batch), and applied in `local_cache_put`.
   A `u128::MAX` register can no longer pin a key; a locally derived compaction floor is never
   mistaken for a peer clock running ahead.

   The per-payload size bound is element-intrinsic, so filtering by it is a lattice morphism and,
   with the existing `ENTRY_DATA_MAX_LEN` count cap, bounds a carrier at their product, which a
   compile-time law keeps inside one transport message. A byte
   budget over the whole carrier was tried and rejected: "the newest payloads that fit" depends on
   the sizes of payloads a replica may already have dropped, so it is not a lattice morphism and
   replicas diverge (three-element counterexample in the review).

4. **One storage transition per ring.** Every read-modify-write of a slot (`operate_storage_entry`,
   `join_storage_entry`, the ack-gated `remove_storage_entry_confirmed_by`, and the retirement a
   read performs) runs under `PeerRing::storage_transition`. The inbound actor and the stabilizer
   write the same slots concurrently (a hold arriving while the recipient drains its inbox), and
   the store orders single puts only, so two interleaved read-modify-writes used to overwrite each
   other; a test with a yielding store double shows the lost hold without the transition.

## Relay inbox (#725)

`EntryKind::RelayMessage` gains its producer, its witness, its authority, and its policy:

- **Producer.** A `CustomMessage` reaching the node responsible for its destination's ring
  position (`destination ∈ (predecessor, self]`; a node with successors but no known predecessor
  is uninformed, not responsible) while the destination has no connection attempt at all is
  *held*: wrapped in a `HeldMessage` under the holder's signature (domain
  `rings-core:relay-inbox:held-message:v1`, timestamp = hold instant) and written into the inbox
  carrier `destination + 1` by an ordinary `Extend`. Relay carriers are placed by the ring
  geometry in every storage mode, so the placement law holds with virtual nodes enabled (the
  production default); a relay carrier has exactly one placement, its DID, under any configured
  redundancy (`kind.replication` bounds the affine set a placed operation or synced entry may
  name), and its own storage namespace (`StorageKey = (kind, placement)`; relay slots render as
  `relay:<placement>`, data slots keep the bare placement), so a data topic any node parks at
  `d + 1` through `storage_store` cannot shadow the inbox kept for `d`. A lookup reads the data
  slot only.
- **Witness** (`dht/entry/inbox.rs`). An element is admissible iff it decodes as a `HeldMessage`
  whose payload is a `CustomMessage` whose transaction and relay are both addressed to
  `inbox_destination(entry.did)` (so the recipient has nothing to forward), held no later than the
  receiver's clock, whose holder signature verifies inside the receiver's overlay, and whose
  payload verifies *as of the hold instant* (`MessageVerificationExt::verify_at`, which judges
  proof liveness and session validity at a given instant). Admissibility is therefore monotone
  in time. A reset floor is rejected, and a delta larger than the inbox is refused before the
  first signature is verified.
- **Write law** (checked by the shell, which knows the writer). A hold (`Extend`) only from the
  node the owner itself routes the destination to (`PeerRing::inbox_hold_authority`, the local
  answer of `find_successor`), every element held by that node, and only while the held message's
  sender proof is still live by the owner's own clock: the holder signs the hold instant, so this
  freshness bound is what makes it honest and bounds replay by the sender's proof lifetime.
  Authority is judged before any signature is verified. A removal (`Tombstone`, per add dot) only
  from the recipient; a relocation only as an `OwnershipHandoff` whose *authenticated* sender
  (the transaction signer, never the relay path) is the receiver's predecessor, otherwise the
  carrier is skipped without an ack; no other operation. A relay carrier is never fetched,
  cached, replicated, or returned to a lookup.
- **Policy.** The newest `RELAY_INBOX_MAX_LEN` (64) messages per inbox and as many tombstones;
  retention 24 h after the last hold, at most 7 d; data topics keep 10 min / 100 min.
- **Delivery.** The storage maintenance phase emits one intent toward the application layer,
  `dht::InboxDelivery::deliver_inbox`, and `Swarm::stabilizer` injects the swarm's interpreter
  (`swarm::inbox::SwarmInboxDelivery`), so the DHT never reaches into the delivery pipeline. The
  interpreter reads the local inbox, retires the elements that fail the witness, and then,
  element by element, delivers through the logical stage of the inbound pipeline
  (`swarm::callback::LocalDelivery` over `LogicalInbound`, the connection-independent stage the
  per-connection `InboundProcessor` also runs: application validation, dispatch, `on_inbound`,
  each under the inbound deadline) and tombstones the delivered element by its dot, so a pass cut
  short by its step deadline resumes where it stopped. A removal never extends a carrier's
  retention, so a drained inbox expires when its last hold would have. The callback (`SwarmCallbackSlot`) is resolved at delivery
  time, so `Swarm::stabilizer` is infallible and `set_callback` after `listen` is honoured.
  Delivery is at least once.
- Tests: witness and authority laws (`dht/entry/test_inbox.rs`), dot-based retirement against a
  stale copy, caps, and two end-to-end cases (`tests/default/test_inbox.rs`): the peer returns
  through its successor or straight through its predecessor; in both the owner's pass hands the
  carrier over, the recipient drains it, and the owner's copy is removed by the ack.

## Ownership hand-off follows the successor head (#726)

The hand-off used to run only inside `HandleMsg<NotifyPredecessorReport>`, one of three inputs
that can move the successor head (the others: `correct_stabilize`'s topology query and a directly
connected peer admitted as head). Placement is a function of the ring state, so:

- **Head law (pure).** `topology::step` emits `TopologyAction::SuccessorHeadChanged(h)` iff the
  head moved to `h`, once per transition, after the event's own actions; `topology::successor_head`
  is the single definition of the head, shared with `find_successor`.
- **Request, not send.** The action lowers to `CoreEffect::RequestStorageRepair`, which only
  records the repair intent (`request_storage_repair`). A send at admission time was tried and
  rejected: it can precede the peer's own admission of this node and is dropped as coming from an
  unadmitted connection.
- **Storage maintenance phase.** Two steps: `deliver_inbox`, then `repair_storage`, which
  restores placement in one bounded pass (offer the live entries beyond `(self, head]` to the
  head as an `OwnershipHandoff` with ack-gated cleanup, republish to missing affine owners
  additively) through the existing repair window (tracked sends,
  `STORAGE_REPAIR_FRESH_CONNECTION_GRACE_MS`, one delivery per step). The maintenance loop runs the
  phase when requested and periodically, so the inbox drain, previously reachable only through the
  one-shot `stabilize()`, now runs in production as well. A head change is the local
  `PeerRingAction::StorageRepairDue`.
- The report handler only connects; the `SendStorageSync` effect, whose sole producer it was, is
  gone.

Tests: head law in `topology/tests.rs`; `test_stabilization/test_storage_handoff.rs` (direct
connection moves the head, admission sets the request, the pass hands off after the grace, the
ack removes the local copy); a second inbox end-to-end test where the returning peer connects
straight to its predecessor.

## Tests

- `verify.rs`: transcript layout, overlay binding, tag binding, ext-verify uses the type's tag,
  owned/borrowed authorities sign identically, over-long tag label rejected.
- `test_payload.rs`: transaction/payload signatures not interchangeable; foreign overlay rejected.
- `test_entry.rs`: stamping law, `max` join of bounds across every operation, liveness, admission
  bounds for lifetime, versions, and payload size, normalization/affine preserve the bound, legacy
  value without bound is not live.
- `dht/storage/tests`: live reads retire expired values, write funnel rejects pinned register /
  expired / over-long bound, join keeps the later bound, cache shares admission and retention.
- `memory.rs` / `test_sled.rs` / `write_ordered.rs`: eviction order, rewrite does not evict,
  oversize rejected without change, reopen restores the budget in modification order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
