### PR TITLE
ci: deploy the browser frontend to GitHub Pages for rings.rs

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,101 @@
+# Publishes the browser frontend (`frontend/`, Trunk + Yew) to GitHub Pages, which serves
+# https://rings.rs once the repository's Pages custom domain is set to `rings.rs`.
+#
+# Separation of concerns — QACI already compiles, lints, and tests the frontend on every PR;
+# this workflow only *ships* it. It runs on master pushes that can change the browser build
+# (the frontend itself, or the crates it links) and on manual dispatch, so a green master is
+# what rings.rs serves. The deploy environment is `github-pages`, the one the Pages
+# integration owns; the `id-token` grant is the OIDC proof the Pages deployment API requires.
+#
+# Routing: the shell is hash-routed (`#node`, `#webview`, …), which static hosting serves
+# unchanged. The Onion WebView gateway is path-routed (`/webview`, `/webview/…`) and is answered
+# by the service worker once it is registered; a cold load of such a path has no worker yet, so
+# `404.html` is a copy of the (absolute-path) shell that boots the app and registers it.
+name: Deploy frontend to Pages
+
+on:
+  push:
+    branches:
+      - "master"
+    paths:
+      - "frontend/**"
+      - "crates/**"
+      - ".github/workflows/deploy-frontend.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One deployment at a time, never cancelled: the last queued run still deploys the newest
+# master, and an in-flight production deploy is left to finish.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: 1.97.0
+  WASM_BINDGEN_CLI_VERSION: 0.2.121
+  TRUNK_VERSION: 0.21.14
+
+jobs:
+  build:
+    name: Build frontend web app
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
+
+      - name: Setup rust toolchain
+        run: |
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
+          rustup target add wasm32-unknown-unknown
+          rustup show
+
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: frontend
+
+      # Trunk shells out to `wasm-bindgen`; pin the CLI to the crate version the frontend links
+      # so the build does not depend on what Trunk would download at run time.
+      - uses: jetli/wasm-bindgen-action@20b33e20595891ab1a0ed73145d8a21fc96e7c29 # v0.2.0
+        with:
+          version: ${{ env.WASM_BINDGEN_CLI_VERSION }}
+
+      - name: Install Trunk
+        uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b # v2.87.4
+        with:
+          tool: trunk@${{ env.TRUNK_VERSION }}
+
+      # The same script developers and QACI use, so the shipped build is the checked one.
+      - name: Build frontend web app
+        run: npm run build:frontend-web
+
+      - name: Add the SPA fallback for path-routed WebView URLs
+        run: cp frontend/dist/index.html frontend/dist/404.html
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: frontend/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -46,6 +46,16 @@ trunk serve --release true
 Then open the Trunk URL. Use the guide as the landing page, then open the node
 console for connection, onion proxy, and custom-message workflows.
 
+## Deploy to rings.rs
+
+The web app is published to GitHub Pages by `.github/workflows/deploy-frontend.yml`,
+which serves `https://rings.rs` through the repository's Pages custom domain. It runs
+on every master push that touches `frontend/` or `crates/` (and on manual dispatch),
+builds with `npm run build:frontend-web` (a release `trunk build` from the
+repository root), and uploads `frontend/dist`. The shell is hash-routed; the path-routed WebView gateway
+(`/webview`, `/webview/…`) is answered by the service worker, and `404.html` is a
+copy of the shell so a cold load of such a path boots the app and registers it.
+
 ## Package as a Chrome Extension
 
 Package the same Yew/Wasm application with the explicit repository script. A


### PR DESCRIPTION
## What

Adds `.github/workflows/deploy-frontend.yml`, which publishes the Trunk release build of `frontend/` (the Yew web app) to GitHub Pages through the `github-pages` environment, and documents the deployment in the frontend README.

## Why

QACI builds, lints, and tests the frontend on every PR, but nothing ships it. The repository's Pages configuration is a 2023 remnant: source `master:/docs` (no such directory), last build errored, `https://rings.rs/rings/` is a 404. `https://rings.rs` itself is currently served by `RingsNetwork/ringsnetwork.github.io` (a Next.js site last touched 2023-06).

## How

- Triggers: master pushes touching `frontend/**`, `crates/**`, or the workflow; plus `workflow_dispatch`. QACI remains the gate; this workflow only ships a green master.
- Build: the same `npm run build:frontend-web` script developers use (`trunk build --release`), with toolchain, `wasm-bindgen-cli`, and Trunk pinned to the QACI versions.
- Routing: the shell is hash-routed. The Onion WebView gateway is path-routed (`/webview`, `/webview/…`) and is answered by the service worker once registered, so `404.html` is a copy of the absolute-path shell to boot the app on a cold load of such a path.
- Permissions follow the repo convention: `contents: read` at the top, `pages: write` + `id-token: write` on the deploy job only. Actions are SHA-pinned. `concurrency: pages`, never cancelled.

Local `trunk build --release` verified: emitted `index.html` references `/rings-frontend-<hash>.js` and `_bg.wasm` by absolute path (about 10 MB wasm, 13 MB dist).

## Repository settings (admin, not in this PR)

Serving `rings.rs` from this deployment is a Pages setting, and one custom domain can be bound to only one repository in the org:

1. `RingsNetwork/ringsnetwork.github.io` → Settings → Pages: remove the custom domain `rings.rs`.
2. `RingsNetwork/rings` → Settings → Pages: source is already **GitHub Actions**; set custom domain `rings.rs`, keep **Enforce HTTPS**.
3. DNS needs no change: `rings.rs` is Cloudflare-proxied to GitHub Pages already.
4. Run the workflow once via **Run workflow** (or merge a frontend change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
