### PR TITLE
rings init emits a complete, disabled gateway section; gateway enabled defaults to false (#732)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.21.2
+
+### Breaking changes
+
+- A `gateway:` section that omits `enabled` is now disabled. Earlier builds started the native
+  TUN gateway whenever the section was present; a hand-written section from one of them needs
+  `enabled: true` to keep starting its gateway. `rings run --gateway` still enables the section
+  for one run.
+
+### Added
+
+- `rings init` writes a complete `gateway:` section with `enabled: false` and every field stated,
+  so plain `rings run` behaves as before while `rings run --gateway` works on the generated file
+  without editing. The plan and its defaults come from the gateway crate:
+  `GatewayPlan::interface_only` (one RFC 6598 host address, no capture routes,
+  `Mtu::IPV6_MINIMUM`) and `GatewayConfig::with_default_limits`; the node composes them in
+  `NativeGatewayConfig::disabled_default` and selects a runner through `Config::enabled_gateway`.
+- `rings run --gateway` on a config without the section now names `rings init` and prints the
+  exact section to append.
+
 ## 0.21.0
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "rings-codec"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "postcard",
  "serde",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "rings-core"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "rings-derive"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rings-gateway"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "async-trait",
  "ipnet",
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "rings-measure"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "rings-native-example"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "rings-network-policy"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "thiserror 1.0.69",
  "url",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "rings-node"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "rings-relay-example"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "rings-core",
  "rings-node",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "rings-rpc"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "rings-transport"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3503,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "rings-webview"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.21.1"
+version = "0.21.2"
 edition = "2021"
 license = "GPL-3.0-only"
 authors = ["RND <dev@ringsnetwork.io>"]
@@ -20,15 +20,15 @@ repository = "https://github.com/RingsNetwork/rings"
 async-trait = "0.1.77"
 js-sys = "0.3.98"
 jsonrpc-core = "18.0.0"
-rings-codec = { path = "crates/codec", version = "0.21.1" }
-rings-core = { path = "crates/core", version = "0.21.1", default-features = false }
-rings-derive = { path = "crates/derive", version = "0.21.1", default-features = false }
-rings-gateway = { path = "crates/gateway", version = "0.21.1" }
-rings-measure = { path = "crates/measure", version = "0.21.1" }
-rings-network-policy = { path = "crates/network-policy", version = "0.21.1" }
-rings-node = { path = "crates/node", version = "0.21.1" }
-rings-rpc = { path = "crates/rpc", version = "0.21.1", default-features = false }
-rings-transport = { path = "crates/transport", version = "0.21.1" }
+rings-codec = { path = "crates/codec", version = "0.21.2" }
+rings-core = { path = "crates/core", version = "0.21.2", default-features = false }
+rings-derive = { path = "crates/derive", version = "0.21.2", default-features = false }
+rings-gateway = { path = "crates/gateway", version = "0.21.2" }
+rings-measure = { path = "crates/measure", version = "0.21.2" }
+rings-network-policy = { path = "crates/network-policy", version = "0.21.2" }
+rings-node = { path = "crates/node", version = "0.21.2" }
+rings-rpc = { path = "crates/rpc", version = "0.21.2", default-features = false }
+rings-transport = { path = "crates/transport", version = "0.21.2" }
 serde-wasm-bindgen = "0.6.5"
 wasm-bindgen = "0.2.121"
 wasm-bindgen-futures = "0.4.71"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -181,6 +181,18 @@ In an authenticated-open overlay, a Sybil operator can try to appear in multiple
 route positions unless the deployment adds independent admission or diversity
 controls.
 
+### Native Gateway
+
+The native TUN gateway is configured by the `gateway:` section that `rings init` writes into
+every new config file. Presence of that section is not consent to touch the host's routing:
+a gateway starts only under an explicit `enabled: true` or `rings run --gateway`, and a section
+that omits `enabled` is inert. Earlier builds treated a present section as enabled, so a config
+written by hand for one of them now needs `enabled: true` to keep starting its gateway. The
+generated plan assigns one RFC 6598 host address and captures no destination, so enabling it
+creates the interface without steering traffic until the operator lists a prefix. The
+capabilities a TUN device needs (`CAP_NET_ADMIN`, the Unix helper, a relaxed service sandbox)
+are never granted by the configuration and remain an operator decision.
+
 ## Required Work Before Stronger Claims
 
 Before Rings can claim Sybil-resistant permissionless membership, the project

--- a/crates/gateway/README.md
+++ b/crates/gateway/README.md
@@ -8,6 +8,7 @@ or kill-switch mode.
 The crate is intentionally unavailable to WebAssembly targets. Browser builds remain Rings
 clients and do not contain the native gateway or server runtime.
 
+<!-- ANCHOR: operator-guide -->
 ## Traffic-selection contract
 
 The operator owns traffic selection. Let `C` be the normalized set in `included_routes`:
@@ -203,6 +204,7 @@ GET /gateway/status
 It reports interface, lifecycle, normalized capture routes, active-flow count, last error, and
 Onion-exit availability without granting route mutation authority.
 
+<!-- ANCHOR_END: operator-guide -->
 ## Library model API
 
 The lifecycle, parser, flow-table, and `TcpStack` types are public deterministic model and embedding

--- a/crates/gateway/README.md
+++ b/crates/gateway/README.md
@@ -113,6 +113,12 @@ gateway. UDP or fragmented IPv4 packets that enter a listed prefix are dropped; 
 rejected at configuration time. Unlisted IPv4, all IPv6, and ordinary DNS traffic remain outside
 gateway policy.
 
+`rings init` writes a complete `gateway:` section with `enabled: false`: the interface-only plan
+(`GatewayPlan::interface_only`, one RFC 6598 host address, no capture routes, the IPv6 minimum
+MTU) under the default runtime limits. The section starts nothing by itself; the gateway runs only
+under an explicit `enabled: true` or `rings run --gateway`, and a section that omits `enabled` is
+inert.
+
 ```yaml
 # STUN remains ordinary discovery. TURN is optional and never a gateway prerequisite.
 ice_servers: stun://stun.l.google.com:19302
@@ -143,6 +149,7 @@ still exists, but Rings installs no destination route:
 
 ```yaml
 gateway:
+  enabled: true
   plan:
     addresses: ["100.64.0.1/32"]
     included_routes: []

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -4,6 +4,7 @@ use std::net::Ipv4Addr;
 use std::time::Duration;
 
 use ipnet::IpNet;
+use ipnet::Ipv4Net;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -11,6 +12,13 @@ use crate::ConfigError;
 
 const MIN_IPV4_MTU: u32 = 576;
 const MAX_IPV4_PACKET: u32 = 65_535;
+/// Minimum link MTU every IPv6 link must carry (RFC 8200 §5). A tunnel sized to it fits any
+/// underlay a node can run on, so it is the MTU a generated plan starts from.
+const IPV6_MINIMUM_LINK_MTU: u16 = 1_280;
+/// Host address a generated plan assigns to the virtual interface. It is drawn from the shared
+/// address space of RFC 6598 (`100.64.0.0/10`), reserved for carrier-grade NAT, so it collides
+/// neither with the RFC 1918 ranges that LANs and VPNs assign from nor with public unicast space.
+const DEFAULT_INTERFACE_ADDRESS: Ipv4Addr = Ipv4Addr::new(100, 64, 0, 1);
 pub(crate) const MAX_GATEWAY_FLOWS: usize = 16_384;
 const MAX_TCP_BUFFER_BYTES: usize = 1_024 * 1_024;
 // smoltcp receive/transmit buffers plus the two directions of Tokio's duplex bridge.
@@ -23,17 +31,32 @@ const MAX_TOTAL_FLOW_BUFFER_BYTES: usize = 1_024 * 1_024 * 1_024;
 pub struct Mtu(u16);
 
 impl Mtu {
+    /// The IPv6 minimum link MTU, the largest MTU every underlay is required to carry.
+    ///
+    /// Law: `Mtu::try_from(u32::from(Mtu::IPV6_MINIMUM)) = Ok(Mtu::IPV6_MINIMUM)`; the
+    /// compile-time assertion below checks the constant against the same predicate the
+    /// validator applies, so this constant can never name an MTU that `TryFrom` would refuse.
+    pub const IPV6_MINIMUM: Self = Self(IPV6_MINIMUM_LINK_MTU);
+
     /// Return the validated MTU as a host integer.
     pub const fn get(self) -> u16 {
         self.0
     }
 }
 
+/// The predicate `TryFrom<u32> for Mtu` decides: `MIN_IPV4_MTU ≤ value ≤ MAX_IPV4_PACKET`.
+const fn within_ipv4_bounds(value: u32) -> bool {
+    MIN_IPV4_MTU <= value && value <= MAX_IPV4_PACKET
+}
+
+// The widening cast is lossless; `u32::from` is not usable in a constant expression.
+const _: () = assert!(within_ipv4_bounds(IPV6_MINIMUM_LINK_MTU as u32));
+
 impl TryFrom<u32> for Mtu {
     type Error = ConfigError;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
-        if !(MIN_IPV4_MTU..=MAX_IPV4_PACKET).contains(&value) {
+        if !within_ipv4_bounds(value) {
             return Err(ConfigError::InvalidMtu(value));
         }
         u16::try_from(value)
@@ -65,6 +88,21 @@ pub struct GatewayPlan {
 }
 
 impl GatewayPlan {
+    /// The plan a freshly initialised node starts from: the default host address on the virtual
+    /// interface, no capture routes, and the IPv6-minimum MTU.
+    ///
+    /// It satisfies [`GatewayPlan::validate`] and captures nothing (`C = ∅` in the
+    /// traffic-selection contract), so a gateway enabled over it creates the packet interface
+    /// without steering any destination into it until an operator lists one in
+    /// `included_routes` or installs a route externally.
+    pub fn interface_only() -> Self {
+        Self {
+            addresses: vec![IpNet::V4(Ipv4Net::from(DEFAULT_INTERFACE_ADDRESS))],
+            included_routes: Vec::new(),
+            mtu: Mtu::IPV6_MINIMUM,
+        }
+    }
+
     /// Return the primary IPv4 interface address and prefix.
     pub fn first_ipv4_address(&self) -> Result<(Ipv4Addr, u8), ConfigError> {
         self.addresses
@@ -202,6 +240,20 @@ mod duration_seconds {
 }
 
 impl GatewayConfig {
+    /// The given plan under the runtime limits a serialized document receives when it omits them.
+    ///
+    /// Law: for every plan `p`, `with_default_limits(p)` equals the deserialization of a document
+    /// stating only `plan: p`, so a config written from this constructor and one written by hand
+    /// with the limits left out denote the same runtime.
+    pub fn with_default_limits(plan: GatewayPlan) -> Self {
+        Self {
+            plan,
+            max_flows: default_max_flows(),
+            flow_idle_timeout: default_flow_idle_timeout(),
+            tcp_buffer_bytes: default_tcp_buffer_bytes(),
+        }
+    }
+
     /// Validate runtime limits and the underlying tunnel plan.
     pub fn validate(&self) -> Result<(), ConfigError> {
         if self.max_flows == 0 {
@@ -395,6 +447,43 @@ mod tests {
         assert_eq!(config.max_flows, default_max_flows());
         assert_eq!(config.flow_idle_timeout, default_flow_idle_timeout());
         assert_eq!(config.tcp_buffer_bytes, default_tcp_buffer_bytes());
+    }
+
+    #[test]
+    fn ipv6_minimum_mtu_is_a_fixed_point_of_the_validator() {
+        assert_eq!(
+            Mtu::try_from(u32::from(Mtu::IPV6_MINIMUM)),
+            Ok(Mtu::IPV6_MINIMUM)
+        );
+    }
+
+    #[test]
+    fn interface_only_plan_is_valid_and_captures_nothing() {
+        let candidate = GatewayPlan::interface_only();
+        assert_eq!(candidate.validate(), Ok(()));
+        assert_eq!(
+            candidate.first_ipv4_address(),
+            Ok((DEFAULT_INTERFACE_ADDRESS, 32))
+        );
+        assert!(candidate.included_routes.is_empty());
+        assert_eq!(candidate.mtu, Mtu::IPV6_MINIMUM);
+    }
+
+    #[test]
+    fn default_limits_agree_with_the_serde_defaults() {
+        let json = r#"{
+            "plan": {
+                "addresses": ["100.64.0.1/32"],
+                "included_routes": [],
+                "mtu": 1280
+            }
+        }"#;
+        let config: GatewayConfig = serde_json::from_str(json).expect("valid gateway JSON");
+        assert_eq!(
+            config,
+            GatewayConfig::with_default_limits(GatewayPlan::interface_only())
+        );
+        assert_eq!(config.validate(), Ok(()));
     }
 
     #[test]

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -67,11 +67,11 @@ rings <command> [options]
 
 - `help`: displays the usage information.
 - `init`: creates a default configuration file, `~/.rings/config.yaml` unless `--location` says otherwise. This file can be edited to customize the behavior of the rings-node daemon. The generated file states every section explicitly, including a complete `gateway:` section with `enabled: false` (see [Native gateway](#native-gateway)).
-- `run`: runs the rings-node daemon. This command starts the daemon process, which will validate transactions, maintain the blockchain, and participate in consensus to earn rewards. By default, the daemon will use the "config.toml" file in the current directory for configuration. Use the "-c" or "--config" option to specify a custom configuration file.
+- `run`: runs the rings-node daemon. By default, the daemon will use `~/.rings/config.yaml` for configuration. Use the "-c" or "--config" option to specify a custom configuration file.
 
 ### Options
 
-- `-c, --config <FILE>`: specifies a custom configuration file to use instead of the default "config.toml". The configuration file is used to specify the network configuration, account settings, and other parameters that control the behavior of the rings-node daemon.
+- `-c, --config <FILE>`: specifies a custom configuration file to use instead of the default `~/.rings/config.yaml`. The configuration file is used to specify the network configuration, account settings, and other parameters that control the behavior of the rings-node daemon.
 - `-h, --help`: displays the usage information.
 - `-V, --version`: displays the version information for rings-node.
 

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -66,7 +66,7 @@ rings <command> [options]
 ### Commands
 
 - `help`: displays the usage information.
-- `init`: creates a default configuration file named "config.toml" in the current directory. This file can be edited to customize the behavior of the rings-node daemon.
+- `init`: creates a default configuration file, `~/.rings/config.yaml` unless `--location` says otherwise. This file can be edited to customize the behavior of the rings-node daemon. The generated file states every section explicitly, including a complete `gateway:` section with `enabled: false` (see [Native gateway](#native-gateway)).
 - `run`: runs the rings-node daemon. This command starts the daemon process, which will validate transactions, maintain the blockchain, and participate in consensus to earn rewards. By default, the daemon will use the "config.toml" file in the current directory for configuration. Use the "-c" or "--config" option to specify a custom configuration file.
 
 ### Options
@@ -105,3 +105,36 @@ Connecting to a remote peer needs no token by default, because its handshake is 
 operator who fronts the external listener with a proxy that demands the token can still be
 dialled: `rings connect node` accepts `--remote-api-token-file`, and seed entries may include an
 optional `api_token` field.
+
+### Native gateway
+
+`rings init` writes a complete `gateway:` section so the generated file is the one place an
+operator edits. The section is inert as written: the gateway starts only under an explicit
+`enabled: true` or `rings run --gateway`, and a hand-written section that omits `enabled` is also
+inert. `rings run` on the generated file therefore creates no TUN device.
+
+```yaml
+gateway:
+  enabled: false
+  plan:
+    addresses:
+    - 100.64.0.1/32          # RFC 6598 shared address space; collides with neither LAN nor VPN ranges
+    included_routes: []      # nothing is captured until a destination prefix is listed here
+    mtu: 1280                # the IPv6 minimum link MTU, which every underlay carries
+  max_flows: 1024
+  flow_idle_timeout: 300
+  tcp_buffer_bytes: 65536
+  interface_name: null
+  route_ledger_path: /home/operator/.rings/gateway-routes.json   # resolved from $HOME at init time
+  unix_helper_socket: /home/operator/.rings/gateway-helper.sock  # must match the helper's --socket
+  wintun_dll_path: null
+  status_refresh_secs: 2
+  onion_service: tcp
+  onion_hop_count: 0
+  onion_allow_short_paths: false
+```
+
+`rings run --gateway` enables the section for that run without editing the file. On a config
+written before this section existed, `--gateway` fails and prints the section to append. The
+[rings-gateway](../gateway/README.md) README covers the capture contract, the Unix helper, and
+the capabilities a TUN device needs; none of that is granted by the section itself.

--- a/crates/node/bin/rings.rs
+++ b/crates/node/bin/rings.rs
@@ -223,7 +223,7 @@ struct RunCommand {
     #[arg(
         long,
         action = ArgAction::SetTrue,
-        help = "Enable the native TUN gateway configured by the gateway section",
+        help = "Start the native TUN gateway from the config's gateway section for this run; the section alone never starts it (rings init writes it with enabled: false)",
         env
     )]
     pub gateway: bool,
@@ -791,7 +791,11 @@ async fn foreground_run(args: RunCommand) -> anyhow::Result<()> {
     }
     if args.gateway {
         let Some(gateway) = c.gateway.as_mut() else {
-            anyhow::bail!("--gateway requires a gateway section in the node config file");
+            anyhow::bail!(
+                "--gateway requires a gateway section in {config_path}; `rings init` writes one \
+                 into a new config file, or append this to the existing file:\n{}",
+                config::NativeGatewayConfig::disabled_default().to_yaml_section()?
+            );
         };
         gateway.enabled = true;
     }
@@ -818,7 +822,7 @@ async fn foreground_run(args: RunCommand) -> anyhow::Result<()> {
     let onion_http_proxy_allow_short_paths = c.onion_http_proxy_allow_short_paths;
     let onion_http_proxy_header_timeout_secs = c.onion_http_proxy_header_timeout_secs;
     let onion_http_proxy_max_connections = c.onion_http_proxy_max_connections;
-    let gateway_config = c.gateway.clone().filter(|gateway| gateway.enabled);
+    let gateway_config = c.enabled_gateway().cloned();
 
     let (data_storage, measure_storage) = if let Some(storage_path) = args.storage_path {
         let storage_path = Path::new(&storage_path);

--- a/crates/node/src/native/config.rs
+++ b/crates/node/src/native/config.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::path::PathBuf;
 
 use rings_gateway::GatewayConfig;
+use rings_gateway::GatewayPlan;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -50,17 +51,29 @@ pub const DEFAULT_STORAGE_CAPACITY: u32 = 200000000;
 /// Default interval for refreshing gateway status.
 pub const DEFAULT_GATEWAY_STATUS_REFRESH_SECS: u64 = 2;
 
-/// Native foreground-gateway configuration.
+/// Native foreground-gateway configuration: the `gateway:` section of the node config file.
+///
+/// `rings init` writes this section in full through [`NativeGatewayConfig::disabled_default`],
+/// so the generated file is the one place an operator edits and `rings run --gateway` works on
+/// it unchanged. Presence of the section is not consent to start a TUN device:
+///
+/// ```text
+/// gateway starts ⟺ section present ∧ (enabled = true ∨ --gateway)
+/// ```
+///
+/// A section that omits `enabled` is therefore inert, and a config without the section loads
+/// with `gateway = None`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NativeGatewayConfig {
-    /// Whether `rings run` starts the gateway when this section is present.
-    #[serde(default = "default_true")]
+    /// Whether plain `rings run` starts the gateway. Absent means `false`; only an explicit
+    /// `enabled: true` or `rings run --gateway` starts a TUN device.
+    #[serde(default)]
     pub enabled: bool,
     /// Platform-neutral routing, TCP, and flow limits.
     #[serde(flatten)]
     pub runtime: GatewayConfig,
     /// Requested Wintun interface name; on Unix the helper's `--interface` is authoritative.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub interface_name: Option<String>,
     /// Durable journal used directly on Windows; on Unix the helper's `--ledger` is authoritative.
     #[serde(default = "default_gateway_route_ledger_path")]
@@ -69,7 +82,7 @@ pub struct NativeGatewayConfig {
     #[serde(default = "default_gateway_unix_helper_socket")]
     pub unix_helper_socket: String,
     /// Optional explicit Wintun DLL path on Windows; overrides `RINGS_GATEWAY_WINTUN_DLL`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub wintun_dll_path: Option<String>,
     /// Interval for refreshing Onion exit availability in gateway status.
     #[serde(default = "default_gateway_status_refresh_secs")]
@@ -85,8 +98,36 @@ pub struct NativeGatewayConfig {
     pub onion_allow_short_paths: bool,
 }
 
-const fn default_true() -> bool {
-    true
+impl NativeGatewayConfig {
+    /// The section `rings init` writes: the gateway crate's interface-only plan under its default
+    /// limits, the node's default paths, and `enabled: false`, with every field stated so the
+    /// generated file documents the whole surface. Optional fields are written as `null`.
+    pub fn disabled_default() -> Self {
+        Self {
+            enabled: false,
+            runtime: GatewayConfig::with_default_limits(GatewayPlan::interface_only()),
+            interface_name: None,
+            route_ledger_path: default_gateway_route_ledger_path(),
+            unix_helper_socket: default_gateway_unix_helper_socket(),
+            wintun_dll_path: None,
+            status_refresh_secs: default_gateway_status_refresh_secs(),
+            onion_service: OnionServiceName::tcp(),
+            onion_hop_count: 0,
+            onion_allow_short_paths: false,
+        }
+    }
+
+    /// Render this section as the top-level `gateway:` mapping of a config file, so a message
+    /// telling an operator what to add quotes the shape `rings init` writes rather than a copy.
+    pub fn to_yaml_section(&self) -> Result<String> {
+        serde_yaml::to_string(&GatewaySection { gateway: self }).map_err(|_| Error::EncodeError)
+    }
+}
+
+/// A config document consisting of the `gateway:` section alone.
+#[derive(Serialize)]
+struct GatewaySection<'a> {
+    gateway: &'a NativeGatewayConfig,
 }
 
 const fn default_gateway_status_refresh_secs() -> u64 {
@@ -192,7 +233,9 @@ pub struct Config {
     /// Maximum simultaneous HTTP CONNECT proxy connections.
     #[serde(default = "crate::onion::proxy::http::default_max_connect_connections")]
     pub onion_http_proxy_max_connections: usize,
-    /// Optional native TUN gateway started in the same foreground lifecycle.
+    /// Native TUN gateway section; `rings init` writes it disabled, and it starts a gateway in
+    /// the same foreground lifecycle only under `enabled: true` or `--gateway`. Older configs
+    /// without the section load as `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gateway: Option<NativeGatewayConfig>,
     /// Virtual DHT positions per storage owner.
@@ -318,7 +361,7 @@ impl Config {
                 crate::onion::proxy::http::default_connect_header_timeout_secs(),
             onion_http_proxy_max_connections:
                 crate::onion::proxy::http::default_max_connect_connections(),
-            gateway: None,
+            gateway: Some(NativeGatewayConfig::disabled_default()),
             dht_virtual_nodes: DEFAULT_STORAGE_VIRTUAL_POSITIONS_PER_OWNER,
             external_ip: None,
             webrtc_udp_port_min: None,
@@ -326,6 +369,14 @@ impl Config {
             data_storage: DEFAULT_DATA_STORAGE_CONFIG.clone(),
             measure_storage: DEFAULT_MEASURE_STORAGE_CONFIG.clone(),
         }
+    }
+
+    /// The gateway section `rings run` starts a runner from, if any.
+    ///
+    /// Law: `enabled_gateway() = Some(g) ⟺ gateway = Some(g) ∧ g.enabled`. `--gateway` sets
+    /// `enabled` before this is consulted, so the flag and the field select the same runner.
+    pub fn enabled_gateway(&self) -> Option<&NativeGatewayConfig> {
+        self.gateway.as_ref().filter(|gateway| gateway.enabled)
     }
 
     /// Writes this configuration to a YAML file and returns the written path.
@@ -464,6 +515,151 @@ measure_storage:
         let cfg: Config = serde_yaml::from_str(yaml).unwrap();
 
         assert_eq!(cfg.dht_virtual_nodes, 0);
+    }
+
+    const CONFIG_WITHOUT_GATEWAY_SECTION: &str = r#"
+network_id: 1
+session_sk: session_sk
+internal_api_port: 50000
+external_api_addr: 127.0.0.1:50001
+endpoint_url: http://127.0.0.1:50000
+ice_servers: stun://stun.l.google.com:19302
+stabilize_interval: 15
+external_ip: null
+webrtc_udp_port_min: null
+webrtc_udp_port_max: null
+data_storage:
+  path: /Users/foo/.rings/data
+  capacity: 200000000
+measure_storage:
+  path: /Users/foo/.rings/measure
+  capacity: 200000000
+"#;
+
+    /// A hand-written section stating only what the gateway crate requires.
+    const GATEWAY_SECTION_WITHOUT_ENABLED: &str = r#"
+gateway:
+  plan:
+    addresses:
+    - 100.64.0.1/32
+    included_routes: []
+    mtu: 1280
+"#;
+
+    const GATEWAY_SECTION_ENABLED: &str = r#"
+gateway:
+  enabled: true
+  plan:
+    addresses:
+    - 100.64.0.1/32
+    included_routes: []
+    mtu: 1280
+"#;
+
+    fn config_from(document: &str) -> Config {
+        match serde_yaml::from_str(document) {
+            Ok(config) => config,
+            Err(error) => panic!("config document must parse: {error}"),
+        }
+    }
+
+    #[test]
+    fn generated_config_round_trips_with_the_gateway_disabled() {
+        let root = std::env::temp_dir().join(format!("rings-config-{}", uuid::Uuid::new_v4()));
+        let path = root.join("config.yaml");
+        let written = Config::new("session_sk").write_fs(&path);
+        let restored = written.and_then(Config::read_fs);
+        let _ = fs::remove_file(&path);
+        let _ = fs::remove_dir(root);
+
+        let restored = match restored {
+            Ok(config) => config,
+            Err(error) => panic!("generated config must round-trip: {error:?}"),
+        };
+        let Some(gateway) = restored.gateway.as_ref() else {
+            panic!("generated config must carry a gateway section");
+        };
+        assert!(!gateway.enabled);
+        assert_eq!(gateway.runtime.validate(), Ok(()));
+        assert!(restored.enabled_gateway().is_none());
+    }
+
+    #[test]
+    fn generated_gateway_section_states_every_field() {
+        let document = match serde_yaml::to_value(Config::new("session_sk")) {
+            Ok(document) => document,
+            Err(error) => panic!("generated config must serialize: {error}"),
+        };
+        let keys = document
+            .get("gateway")
+            .and_then(serde_yaml::Value::as_mapping)
+            .map(|section| {
+                section
+                    .keys()
+                    .filter_map(serde_yaml::Value::as_str)
+                    .collect::<Vec<_>>()
+            });
+
+        assert_eq!(
+            keys,
+            Some(vec![
+                "enabled",
+                "plan",
+                "max_flows",
+                "flow_idle_timeout",
+                "tcp_buffer_bytes",
+                "interface_name",
+                "route_ledger_path",
+                "unix_helper_socket",
+                "wintun_dll_path",
+                "status_refresh_secs",
+                "onion_service",
+                "onion_hop_count",
+                "onion_allow_short_paths",
+            ])
+        );
+    }
+
+    #[test]
+    fn gateway_section_without_enabled_is_inert() {
+        let document = format!("{CONFIG_WITHOUT_GATEWAY_SECTION}{GATEWAY_SECTION_WITHOUT_ENABLED}");
+        let config = config_from(&document);
+
+        assert!(matches!(config.gateway, Some(ref gateway) if !gateway.enabled));
+        assert!(config.enabled_gateway().is_none());
+    }
+
+    #[test]
+    fn explicitly_enabled_gateway_section_selects_a_runner() {
+        let document = format!("{CONFIG_WITHOUT_GATEWAY_SECTION}{GATEWAY_SECTION_ENABLED}");
+        let config = config_from(&document);
+
+        assert!(config.enabled_gateway().is_some());
+    }
+
+    #[test]
+    fn enabling_the_generated_section_selects_a_runner() {
+        let mut config = Config::new("session_sk");
+        assert!(config.enabled_gateway().is_none());
+
+        if let Some(gateway) = config.gateway.as_mut() {
+            gateway.enabled = true;
+        }
+
+        assert!(config.enabled_gateway().is_some());
+    }
+
+    #[test]
+    fn rendered_yaml_section_completes_a_config_without_one() {
+        let section = match NativeGatewayConfig::disabled_default().to_yaml_section() {
+            Ok(section) => section,
+            Err(error) => panic!("section must render: {error:?}"),
+        };
+        assert!(section.starts_with("gateway:\n"));
+
+        let config = config_from(&format!("{CONFIG_WITHOUT_GATEWAY_SECTION}{section}"));
+
+        assert!(matches!(config.gateway, Some(ref gateway) if !gateway.enabled));
     }
 
     #[test]

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,6 +6,7 @@
 
 - [Native Node](install-a-native-node.md)
 - [Host a Native Node](host-a-native-node.md)
+- [Native Gateway](native-gateway.md)
 
 # Wasm Node (WebAssembly for Browsers)
 

--- a/docs/src/advanced-topic/config.yaml.md
+++ b/docs/src/advanced-topic/config.yaml.md
@@ -1,38 +1,159 @@
 # config.yaml
 
-Here is an example of how your config.yaml file might look:
-
-
-<pre class="language-yaml"><code class="lang-yaml"><strong># cat ./config.yaml
-</strong><strong>
-</strong>bind: 127.0.0.1:50000
-endpoint_url: http://127.0.0.1:50000
-ecdsa_key: &#x3C;your private key>
-ice_servers: stun://stun.l.google.com:19302
-stabilize_timeout: 3
-external_ip: null
-backend: []
-data_storage:
-  path: /Users/foo/.rings/data
-  capacity: 200000000
-measure_storage:
-  path: /Users/foo/.rings/measure
-  capacity: 200000000
-</code></pre>
-
-We can see that there are several optional configurations available:
-
-* `bind`: Interface for binding the Rings Network RPC service.
-* `endpoint_url`: Interface for binding the Rings Network endpoint service, which supports creating WebRTC connection links via HTTP handshake.
-* `ecdsa_key`: The key used for identity verification in Rings Network, generated based on the secp256k1 elliptic curve.
-* `ice_servers`: STUN or TURN servers used for creating WebRTC connections. These servers are typically public services, such as the Google public STUN service. Multiple servers can be specified, for example:
+`rings init` writes the node configuration to `~/.rings/config.yaml` (or the path given to
+`--location`) with every section stated explicitly, so the generated file is the one place an
+operator edits. This is the file it writes, with `$HOME` expanded to `/home/operator`:
 
 ```yaml
-ice_servers: turn://ethereum.org:9090;stun://foo:bar@stun.l.google.com:19302
+network_id: 1
+session_sk: /home/operator/.rings/session_sk
+internal_api_port: 50000
+external_api_addr: 127.0.0.1:50001
+endpoint_url: http://127.0.0.1:50000
+allow_remote_external_api: false
+ice_servers: stun://stun.l.google.com:19302
+stabilize_interval: 15
+online_node_heartbeat_interval_secs: 30
+online_node_ttl_secs: 90
+online_node_type: Native
+advertise_presence: true
+advertise_onion_relay: false
+advertise_onion_exit: false
+onion_exit_heartbeat_interval_secs: 30
+onion_exit_ttl_secs: 90
+onion_exit_services:
+- name: tcp
+  transport: Tcp
+- name: https
+  transport: Tcp
+onion_exit_policy:
+  allowed_targets: []
+  denied_targets: []
+  max_circuits: 0
+  max_streams_per_circuit: 0
+  max_bytes_per_minute: 0
+onion_http_proxy_service: tcp
+onion_http_proxy_hop_count: 0
+onion_http_proxy_allow_short_paths: false
+onion_http_proxy_header_timeout_secs: 10
+onion_http_proxy_max_connections: 1024
+gateway:
+  enabled: false
+  plan:
+    addresses:
+    - 100.64.0.1/32
+    included_routes: []
+    mtu: 1280
+  max_flows: 1024
+  flow_idle_timeout: 300
+  tcp_buffer_bytes: 65536
+  interface_name: null
+  route_ledger_path: /home/operator/.rings/gateway-routes.json
+  unix_helper_socket: /home/operator/.rings/gateway-helper.sock
+  wintun_dll_path: null
+  status_refresh_secs: 2
+  onion_service: tcp
+  onion_hop_count: 0
+  onion_allow_short_paths: false
+dht_virtual_nodes: 160
+data_storage:
+  path: /home/operator/.rings/data
+  capacity: 200000000
+measure_storage:
+  path: /home/operator/.rings/measure
+  capacity: 200000000
 ```
 
-* `stabilize_timeout`: Timeout for each stabilization process in Rings Network, which helps maintain network stability.
-* `external_id`: External IP address bound to Rings Network.
-* `backend`: Rings Network can provide backend services, such as decentralizing a local service by forwarding information from Rings Network to it.
-* `data_storage`: Rings Network is a DHT-based network, so it requires local data caching to ensure the smooth operation of lookup and other services. Users can specify the storage path and capacity (in bytes) for data storage.
-* `measure_storage`: Rings Network uses a measure service to assess the network's robustness. It records scores given by nodes to neighboring nodes. Users can specify the storage path and capacity (in bytes) for measure data.
+Every field has the meaning below. Fields absent from a file take the value shown above, except
+where noted.
+
+## Identity and network
+
+* `network_id`: the Rings overlay this node joins. Signatures are bound to it, so nodes on
+  different overlays do not verify each other's messages.
+* `session_sk`: path of the session secret key file that `rings init` writes next to the config.
+  The session key is derived from your ECDSA key and signs every message on your behalf; keep the
+  file private. Passing a raw key string here instead of a path is deprecated.
+* `ice_servers`: STUN or TURN servers used to establish WebRTC connections, separated by `;`.
+  STUN is ordinary discovery; TURN is optional and never a gateway prerequisite.
+
+  ```yaml
+  ice_servers: turn://user:pass@turn.example.org:3478;stun://stun.l.google.com:19302
+  ```
+
+* `stabilize_interval`: seconds between Chord stabilization rounds.
+* `dht_virtual_nodes`: virtual DHT positions this node owns for storage placement; `0` disables
+  virtual positions.
+* `external_ip`, `webrtc_udp_port_min`, `webrtc_udp_port_max`: optional reachability hints, an
+  externally visible address and a UDP port range for ICE. The two port bounds must be given
+  together.
+
+## Control API
+
+* `internal_api_port`: loopback JSON-RPC listener for the `rings` CLI and local tooling; every
+  route requires the Bearer token.
+* `external_api_addr`: JSON-RPC listener peers dial for the HTTP handshake. `nodeDid` and
+  `answerOffer` are public; status and registry reads require the token.
+* `endpoint_url`: the internal endpoint the CLI connects to.
+* `api_token_path`: optional path of the Bearer token file; by default `api-token` next to the
+  config file. Relative paths are resolved next to the config file.
+* `api_allowed_origins`: exact browser origins permitted to call the authenticated API; empty
+  denies every browser origin.
+* `allow_remote_external_api`: required to bind `external_api_addr` to a non-loopback address.
+
+## Presence and onion registries
+
+* `online_node_heartbeat_interval_secs`, `online_node_ttl_secs`, `online_node_type`,
+  `advertise_presence`: how this node publishes its online-node descriptor.
+* `advertise_onion_relay`: advertise onion relay capability.
+* `advertise_onion_exit`, `onion_exit_heartbeat_interval_secs`, `onion_exit_ttl_secs`,
+  `onion_exit_services`, `onion_exit_policy`: whether and how this node serves as an onion exit.
+  An empty `allowed_targets` list is a closed policy that admits no target, so advertising an
+  exit requires at least one allowed target; deny entries override allows; a `0` limit is
+  unspecified.
+
+## HTTP CONNECT proxy
+
+* `onion_http_proxy_addr`: optional local HTTP CONNECT listener that routes client TCP streams
+  through onion exits; absent means no proxy.
+* `onion_http_proxy_service`, `onion_http_proxy_hop_count`,
+  `onion_http_proxy_allow_short_paths`, `onion_http_proxy_header_timeout_secs`,
+  `onion_http_proxy_max_connections`: exit service, route length, and limits of that proxy.
+
+## Gateway
+
+The `gateway` section configures the native TUN gateway described in
+[Native Gateway](../native-gateway.md). Presence of the section is not consent to start a TUN
+device:
+
+```text
+gateway starts ⟺ section present ∧ (enabled = true ∨ rings run --gateway)
+```
+
+* `enabled`: whether plain `rings run` starts the gateway. Absent means `false`.
+* `plan.addresses`: IPv4 `/32` host addresses of the virtual interface. The generated
+  `100.64.0.1/32` is drawn from the RFC 6598 shared address space, so it collides with neither
+  LAN nor VPN ranges.
+* `plan.included_routes`: the only destination prefixes routed into the gateway. Empty captures
+  nothing; a default route or a set covering all of IPv4 is rejected.
+* `plan.mtu`: interface MTU. The generated `1280` is the IPv6 minimum link MTU, which every
+  underlay carries.
+* `max_flows`, `flow_idle_timeout`, `tcp_buffer_bytes`: concurrent TCP flow limit, per-flow idle
+  timeout in seconds, and per-flow buffer size.
+* `interface_name`, `wintun_dll_path`: Windows interface name and Wintun DLL path; `null` selects
+  the defaults. On Unix the foreground helper's `--interface` is authoritative.
+* `route_ledger_path`: durable route journal, used directly on Windows; on Unix the helper's
+  `--ledger` is authoritative.
+* `unix_helper_socket`: control socket of the `gateway-config-unix` foreground helper on Linux
+  and macOS; must match the helper's `--socket`.
+* `status_refresh_secs`: refresh interval of onion-exit availability in `/gateway/status`.
+* `onion_service`, `onion_hop_count`, `onion_allow_short_paths`: exit service and route length
+  used for captured flows.
+
+## Storage
+
+* `data_storage`: path and capacity in bytes of the DHT data store.
+* `measure_storage`: path and capacity in bytes of the peer measurement store.
+
+Files written before a field existed still load: an omitted field takes its default, and an
+omitted `gateway` section loads as no gateway at all.

--- a/docs/src/host-a-native-node.md
+++ b/docs/src/host-a-native-node.md
@@ -8,7 +8,7 @@ After installation, you can create your configuration by:
 rings init
 ```
 
-This command will generate a configuration file named config.yaml for you. The default path is $HOME/.rings/config.yaml. You can also customize the path by using `rings init --location <path>`. Additionally, you can specify the key used by the Rings node by using `rings init -k <your private key>`.
+This command will generate a configuration file named config.yaml for you. The default path is $HOME/.rings/config.yaml. You can also customize the path by using `rings init --location <path>`. Additionally, you can specify the key used by the Rings node by using `rings init -k <your private key>`. The generated file states every section explicitly, including a complete `gateway:` section with `enabled: false`, so it is the one place you edit; see [Native Gateway](native-gateway.md).
 
 By default, an ECDSA key pair will be automatically generated for you. The key pair in Rings Network is used for user identification and message signing. The key pair is utilized in various components of the network, so it is essential for users to ensure the security of their key pair. In the Native Node environment, since the private key is stored in plaintext, we strongly **discourage** the use of any asset-related key pair to host Rings Network.
 
@@ -26,27 +26,75 @@ rings run
 
 You can use `rings run --help` to check which settings are supported by the `run` command.
 
-```bash
+```text
 # rings run --help
-Starts a long-running node daemon.
+Runs a foreground, composable Rings node.
 
 Usage: rings run [OPTIONS]
 
 Options:
-  -b, --http-addr <HTTP_ADDR>
-          Rings node listen address. If not provided, use bind_addr in config file or 127.0.0.1:50000 [env: HTTP_ADDR=]
-  -s, --ice-servers <ICE_SERVERS>
+      --gateway
+          Start the native TUN gateway from the config's gateway section for this run; the section alone never starts it (rings init writes it with enabled: false) [env: GATEWAY=]
+      --external-api-addr <EXTERNAL_API_ADDR>
+          Rings node external api listen address. If not provided, use external_api_addr in config file or 127.0.0.1:50001 [env: EXTERNAL_API_ADDR=]
+      --internal-api-port <INTERNAL_API_PORT>
+          Rings node internal api listen port. If not provided, use internal_api_port in config file or 50000
+      --api-token-path <API_TOKEN_PATH>
+          API Bearer token file guarding the internal API and the external status and registry reads; the external handshake (nodeDid, answerOffer) is public. Relative paths are resolved next to the node config file [env: API_TOKEN_PATH=]
+      --api-allowed-origin <API_ALLOWED_ORIGINS>
+          Exact browser origin permitted to call the authenticated API; repeat as needed [env: API_ALLOWED_ORIGINS=]
+      --allow-remote-external-api
+          Explicitly permit external_api_addr to bind a non-loopback address [env: ALLOW_REMOTE_EXTERNAL_API=]
+      --ice-servers <ICE_SERVERS>
           ICE server list. If not provided, use ice_servers in config file or stun://stun.l.google.com:19302 [env: ICE_SERVERS=]
   -k, --key <ECDSA_KEY>
-          Your ECDSA key. If not provided, use ECDSA_KEY in env or ecdsa_key in config file [env: ECDSA_KEY=46886194468bb6e0faa36c12cebb6f0ca104ddbc8ec9d39246d718eba6e22d69]
-      --stabilize-timeout <STABILIZE_TIMEOUT>
-          Stabilize service timeout. If not provided, use stabilize_timeout in config file or 3 [env: STABILIZE_TIMEOUT=]
+          Your ECDSA key. If not provided, use ECDSA_KEY in env or ecdsa_key in config file [env: ECDSA_KEY=]
+      --stabilize-interval <STABILIZE_INTERVAL>
+          Stabilization interval in seconds. If not provided, use stabilize_interval in config file or 15 [env: STABILIZE_INTERVAL=]
       --external-ip <EXTERNAL_IP>
           external ip address [env: EXTERNAL_IP=]
+      --webrtc-udp-port-min <WEBRTC_UDP_PORT_MIN>
+          Minimum UDP port used by native WebRTC ICE gathering. Must be paired with --webrtc-udp-port-max. [env: WEBRTC_UDP_PORT_MIN=]
+      --webrtc-udp-port-max <WEBRTC_UDP_PORT_MAX>
+          Maximum UDP port used by native WebRTC ICE gathering. Must be paired with --webrtc-udp-port-min. [env: WEBRTC_UDP_PORT_MAX=]
       --storage-path <STORAGE_PATH>
           Storage files location. If not provided, use storage.path in config file or ~/.local/share/rings [env: STORAGE_PATH=]
       --storage-capacity <STORAGE_CAPACITY>
           Storage capacity. If not provider, use storage.capacity in config file or 200000000 [env: STORAGE_CAPACITY=] [default: 200000000]
+      --reassembly-profile <REASSEMBLY_PROFILE>
+          Inbound chunk reassembly memory profile [env: REASSEMBLY_PROFILE=] [default: production] [possible values: production, constrained]
+      --advertise-onion-relay
+          Advertise this node as an onion relay in the online-node registry [env: ADVERTISE_ONION_RELAY=]
+      --advertise-onion-exit
+          Publish this node as an onion exit in the application-layer exit registry [env: ADVERTISE_ONION_EXIT=]
+      --onion-exit-service <ONION_EXIT_SERVICE>
+          Exit service in name:transport form, e.g. https:tcp or web:tcp. May be repeated. [env: ONION_EXIT_SERVICE=]
+      --onion-exit-allow-target <ONION_EXIT_ALLOW_TARGET>
+          Allow-list target for onion exit policy. May be repeated. [env: ONION_EXIT_ALLOW_TARGET=]
+      --onion-exit-deny-target <ONION_EXIT_DENY_TARGET>
+          Deny-list target for onion exit policy. May be repeated. [env: ONION_EXIT_DENY_TARGET=]
+      --onion-exit-max-circuits <ONION_EXIT_MAX_CIRCUITS>
+          Maximum onion circuits this exit will serve [env: ONION_EXIT_MAX_CIRCUITS=]
+      --onion-exit-max-streams-per-circuit <ONION_EXIT_MAX_STREAMS_PER_CIRCUIT>
+          Maximum streams per onion circuit this exit will serve [env: ONION_EXIT_MAX_STREAMS_PER_CIRCUIT=]
+      --onion-exit-max-bytes-per-minute <ONION_EXIT_MAX_BYTES_PER_MINUTE>
+          Maximum bytes per minute this exit will serve [env: ONION_EXIT_MAX_BYTES_PER_MINUTE=]
+      --onion-exit-heartbeat-interval-secs <ONION_EXIT_HEARTBEAT_INTERVAL_SECS>
+          Onion-exit registry heartbeat interval in seconds [env: ONION_EXIT_HEARTBEAT_INTERVAL_SECS=]
+      --onion-exit-ttl-secs <ONION_EXIT_TTL_SECS>
+          Onion-exit registry descriptor TTL in seconds [env: ONION_EXIT_TTL_SECS=]
+      --onion-http-proxy-addr <ONION_HTTP_PROXY_ADDR>
+          Bind a local HTTP CONNECT proxy that routes client TCP streams through onion exits, e.g. 127.0.0.1:18080 [env: ONION_HTTP_PROXY_ADDR=]
+      --onion-http-proxy-service <ONION_HTTP_PROXY_SERVICE>
+          TCP onion-exit service used by the local HTTP CONNECT proxy, e.g. tcp or web [env: ONION_HTTP_PROXY_SERVICE=]
+      --onion-http-proxy-hop-count <ONION_HTTP_PROXY_HOP_COUNT>
+          Desired hop count for the local onion HTTP proxy. 0 uses node default. [env: ONION_HTTP_PROXY_HOP_COUNT=]
+      --onion-http-proxy-allow-short-paths
+          Allow the local onion HTTP proxy to use shorter routes when too few relays are live [env: ONION_HTTP_PROXY_ALLOW_SHORT_PATHS=]
+      --onion-http-proxy-header-timeout-secs <ONION_HTTP_PROXY_HEADER_TIMEOUT_SECS>
+          Maximum seconds to wait for one HTTP CONNECT header [env: ONION_HTTP_PROXY_HEADER_TIMEOUT_SECS=]
+      --onion-http-proxy-max-connections <ONION_HTTP_PROXY_MAX_CONNECTIONS>
+          Maximum concurrent local HTTP CONNECT proxy connections [env: ONION_HTTP_PROXY_MAX_CONNECTIONS=]
   -c, --config <CONFIG>
           Config file location [env: CONFIG=] [default: ~/.rings/config.yaml]
   -h, --help
@@ -57,7 +105,14 @@ Options:
 
 With the `rings run` command, you can override the configurations specified in the `config.yaml` file using command-line arguments. Additionally, you can use the `-c` parameter to specify a different config file, which is particularly useful when you need to run multiple instances of the Rings Network.
 
+## Enable the native gateway
 
+The generated `gateway:` section is disabled, so `rings run` creates no TUN device. To start the
+gateway for one run without editing the file:
 
+```bash
+rings run --gateway
+```
 
-
+To start it on every run, set `enabled: true` in the section. Either way the interface needs
+`CAP_NET_ADMIN` on Linux or the foreground helper; see [Native Gateway](native-gateway.md).

--- a/docs/src/install-a-native-node.md
+++ b/docs/src/install-a-native-node.md
@@ -33,11 +33,11 @@ rings <command> [options]
 #### Commands
 
 * `help`: displays the usage information.
-* `init`: creates a default configuration file named `config.toml` in the current directory. This file can be edited to customize the behavior of the rings-node daemon.
-* `run`: runs the rings-node daemon. This command starts the daemon process, which will validate transactions, maintain the blockchain, and participate in consensus to earn rewards. By default, the daemon will use the `config.toml` file in the current directory for configuration. Use the "-c" or "--config" option to specify a custom configuration file.
+* `init`: creates a default configuration file, `~/.rings/config.yaml` unless `--location` says otherwise. This file can be edited to customize the behavior of the rings-node daemon. The generated file states every section explicitly, including a complete `gateway:` section with `enabled: false` (see [Native Gateway](native-gateway.md)).
+* `run`: runs the rings-node daemon. By default, the daemon will use `~/.rings/config.yaml` for configuration. Use the "-c" or "--config" option to specify a custom configuration file.
 
 #### Options
 
-* `-c, --config <FILE>`: specifies a custom configuration file to use instead of the default `config.toml`. The configuration file is used to specify the network configuration, account settings, and other parameters that control the behavior of the rings-node daemon.
+* `-c, --config <FILE>`: specifies a custom configuration file to use instead of the default `~/.rings/config.yaml`. The configuration file is used to specify the network configuration, account settings, and other parameters that control the behavior of the rings-node daemon.
 * `-h, --help`: displays the usage information.
 * `-V, --version`: displays the version information for rings-node.

--- a/docs/src/native-gateway.md
+++ b/docs/src/native-gateway.md
@@ -1,0 +1,30 @@
+# Native Gateway
+
+A native node can forward explicitly selected IPv4/TCP destinations through Rings Onion
+circuits over a TUN device. The gateway is configured by the `gateway:` section of
+`config.yaml`, which `rings init` writes in full with `enabled: false`; see
+[config.yaml](advanced-topic/config.yaml.md#gateway) for the generated section.
+
+Presence of the section is not consent to start a TUN device:
+
+```text
+gateway starts ⟺ section present ∧ (enabled = true ∨ rings run --gateway)
+```
+
+A section that omits `enabled` is inert, so plain `rings run` on the generated file creates no
+interface. To run the gateway once without editing the file:
+
+```bash
+rings run --gateway
+```
+
+On a config written before the section existed, `--gateway` fails and prints the exact section
+to append. The generated plan assigns one host address from the RFC 6598 shared address space
+(`100.64.0.1/32`) and captures no destination, so enabling it creates the interface without
+steering traffic until you list a prefix in `included_routes`. A TUN device also needs
+`CAP_NET_ADMIN` on Linux or the foreground helper described below; the configuration grants
+neither.
+
+The rest of this page is the operator guide from the `rings-gateway` crate.
+
+{{#include ../../crates/gateway/README.md:operator-guide}}

--- a/examples/native/Cargo.toml
+++ b/examples/native/Cargo.toml
@@ -12,7 +12,7 @@ async-trait = { workspace = true }
 base64 = "0.13"
 bytes = "1.2.1"
 rings-core = { workspace = true }
-rings-node = { path = "../../crates/node", version = "0.21.1", default-features = false, features = ["node"] }
+rings-node = { path = "../../crates/node", version = "0.21.2", default-features = false, features = ["node"] }
 rings-rpc = { workspace = true }
 serde_json = "1.0.70"
 tokio = { version = "1.13.0", features = ["macros", "rt-multi-thread", "time"] }

--- a/examples/relay/Cargo.toml
+++ b/examples/relay/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 rings-core = { workspace = true }
-rings-node = { path = "../../crates/node", version = "0.21.1", default-features = false, features = ["node"] }
+rings-node = { path = "../../crates/node", version = "0.21.2", default-features = false, features = ["node"] }
 tokio = { version = "1.13.0", features = ["io-util", "macros", "net", "rt-multi-thread", "time"] }
 
 [[example]]

--- a/frontend/Cargo.lock
+++ b/frontend/Cargo.lock
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "rings-codec"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "postcard",
  "serde",
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "rings-core"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "rings-derive"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "rings-measure"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "rings-network-policy"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "thiserror 1.0.69",
  "url",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "rings-node"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "rings-rpc"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "rings-transport"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "rings-webview"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ringsnetwork/rings-node",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ringsnetwork/rings-node",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "GPL-3.0",
       "devDependencies": {
         "@biomejs/biome": "2.5.3",


### PR DESCRIPTION
## What

`rings init` now writes a complete `gateway:` section with `enabled: false` and every field stated, and a `gateway:` section that omits `enabled` parses as disabled.

## Why

Before this change `rings init` wrote no gateway section, `rings run --gateway` refused to start without one, and the only way to use the gateway was to hand-author the section including the fields that have no serde defaults (`plan.addresses`, `plan.mtu`). Worse, a present section defaulted to `enabled: true`, so an operator who copied a section and forgot `enabled` got a TUN device on plain `rings run`. The generated file is now the single place an operator edits: plain `rings run` behaves exactly as today (no gateway), and `rings run --gateway` works on the generated file without editing.

## Generated YAML

```yaml
gateway:
  enabled: false
  plan:
    addresses:
    - 100.64.0.1/32
    included_routes: []
    mtu: 1280
  max_flows: 1024
  flow_idle_timeout: 300
  tcp_buffer_bytes: 65536
  interface_name: null
  route_ledger_path: /home/operator/.rings/gateway-routes.json
  unix_helper_socket: /home/operator/.rings/gateway-helper.sock
  wintun_dll_path: null
  status_refresh_secs: 2
  onion_service: tcp
  onion_hop_count: 0
  onion_allow_short_paths: false
```

## Layering

The gateway crate owns its defaults; the node crate only composes and serializes them and holds no address or MTU literal.

- `Mtu::IPV6_MINIMUM` (1280, the IPv6 minimum link MTU, so the tunnel fits any underlay). The constant is checked at compile time against `within_ipv4_bounds`, the same predicate `TryFrom<u32>` applies, so it can never name an MTU the validator would refuse; no `expect`/`unwrap` on a production path.
- `GatewayPlan::interface_only()`: one RFC 6598 host address (`100.64.0.1/32`, carrier-grade NAT space, so it collides with neither RFC 1918 LAN/VPN ranges nor public unicast), no capture routes, `Mtu::IPV6_MINIMUM`. The address is built through `Ipv4Net::from(Ipv4Addr)`, which is infallible.
- `GatewayConfig::with_default_limits(plan)`: law `with_default_limits(p) = deserialize({plan: p})`, tested.
- `NativeGatewayConfig::disabled_default()` composes the above with the node's default paths; `Config::new` uses it. `to_yaml_section()` renders it under the top-level `gateway:` key for the CLI message, so the message cannot drift from what `rings init` writes.
- `Config::enabled_gateway()` is the named selection `foreground_run` uses: `enabled_gateway() = Some(g) ⟺ gateway = Some(g) ∧ g.enabled`.

## Behaviour change

`NativeGatewayConfig::enabled` now defaults to `false`. Law, stated in the doc comment: `gateway starts ⟺ section present ∧ (enabled = true ∨ --gateway)`. A hand-written section from an earlier build that relied on the implicit `true` now needs `enabled: true`. `--gateway` still sets `enabled = true` for one run. On a config without the section, `--gateway` still fails, but the message now names `rings init` and prints the exact section to append. Older configs without the section still load with `gateway: None` (`serde(default)` kept). `interface_name` and `wintun_dll_path` are now serialized as `null` instead of being skipped, so the generated file states every field; deserialization is unchanged.

## Docs swept in the same commit

- `crates/node/README.md`: `init` description (it also said `config.toml`; the file is `~/.rings/config.yaml`), new "Native gateway" section.
- `crates/gateway/README.md`: node configuration paragraph; the externally steered example now states `enabled: true`, which the new default requires.
- `SECURITY.md`: new "Native Gateway" subsection under Feature Boundaries.
- CLI help for `--gateway`; doc comments on `NativeGatewayConfig`, `enabled`, and `Config::gateway`.
- `CHANGELOG.md`: 0.21.2 entry (breaking change + added).
- mdBook (`docs/src`, second commit): new "Native Gateway" page that states the start law and `--gateway`, then includes the operator guide from the gateway README through mdBook anchors (HTML comments, invisible to rustdoc's include of the same file); `config.yaml` page rewritten around the file `rings init` writes today (it showed `bind`, `ecdsa_key`, `backend`, `stabilize_timeout`), with every field explained and a Gateway section; "Host a Native Node" gets a current `rings run --help` transcript and an "Enable the native gateway" section; "Install a Native Node" and the node README no longer say `config.toml`.
- Workspace bumped to 0.21.2 (`Cargo.toml`, both example manifests, both lockfiles, `package-lock.json`), as #731 did.

## Tests

Gateway crate (`crates/gateway/src/config.rs`):
- `ipv6_minimum_mtu_is_a_fixed_point_of_the_validator`: `Mtu::try_from(u32::from(Mtu::IPV6_MINIMUM)) == Ok(Mtu::IPV6_MINIMUM)`.
- `interface_only_plan_is_valid_and_captures_nothing`: `validate()` is `Ok`, `first_ipv4_address()` is `Ok((100.64.0.1, 32))`, no included routes, MTU is `IPV6_MINIMUM`.
- `default_limits_agree_with_the_serde_defaults`: `with_default_limits(interface_only())` equals a document stating only `plan`, and validates.

Node crate (`crates/node/src/native/config.rs`):
- `generated_config_round_trips_with_the_gateway_disabled`: `Config::new` → `write_fs` → `read_fs`; section present, `enabled == false`, runtime validates, `enabled_gateway()` is `None`.
- `generated_gateway_section_states_every_field`: the serialized `gateway` mapping has exactly the 13 expected keys in order.
- `gateway_section_without_enabled_is_inert`: a section stating only `plan` parses with `enabled == false` and selects no runner.
- `explicitly_enabled_gateway_section_selects_a_runner`: `enabled: true` selects one.
- `enabling_the_generated_section_selects_a_runner`: the `--gateway` path (`enabled = true` on the generated section) selects one.
- `rendered_yaml_section_completes_a_config_without_one`: the CLI message's YAML, appended to a section-less config, parses as a disabled section.
- The existing `test_deserialization_defaults_online_registration_fields` still asserts a config without the section loads as `None`.

All tests are pure or event-driven; no sleeps.

Non-goals, as in the issue: no change to the gateway runtime, route ledger, helper socket protocol, or systemd/capability handling.

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)
