### PR TITLE
Generate decode-boundary tests in CI (#741)

### DIFF
--- a/.github/workflows/decode-boundary-smoke.yml
+++ b/.github/workflows/decode-boundary-smoke.yml
@@ -1,0 +1,49 @@
+name: Decode Boundary Smoke
+
+# Longer scheduled run for the crate-owned decode-boundary tests. The tests generate inputs at
+# runtime from the seed printed by this workflow, so the repository never carries generated corpus
+# files or a separate fuzz workspace.
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: 1.97.0
+
+permissions:
+  contents: read
+
+jobs:
+  decode_boundary_smoke:
+    name: Decode boundary smoke (scheduled)
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
+
+      - name: Setup rust toolchain
+        run: |
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
+          rustup show
+
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
+      - name: Generate decode-boundary inputs
+        run: |
+          python3 - <<'PY' | tee -a "$GITHUB_ENV"
+          import secrets
+
+          print(f"RINGS_DECODE_BOUNDARY_SEED={secrets.randbits(64)}")
+          print("RINGS_DECODE_BOUNDARY_CASES=4096")
+          PY
+
+      - name: Run generated decode-boundary tests
+        run: |
+          cargo test -p rings-core --features dummy --no-default-features decode_boundary -- --nocapture
+          cargo test -p rings-transport --no-default-features --features dummy decode_boundary -- --nocapture
+          cargo test -p rings-node --no-default-features --features node decode_boundary -- --nocapture

--- a/.github/workflows/qaci.yml
+++ b/.github/workflows/qaci.yml
@@ -88,6 +88,40 @@ jobs:
       - name: Build documentation book
         run: mdbook build docs
 
+  # Decode-boundary smoke tests live with the crates that own each boundary. CI generates a seed
+  # and case count per run, prints them for replay, and never checks generated corpus files into
+  # the repository.
+  decode_boundary_smoke:
+    name: Decode boundary smoke
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
+
+      - name: Setup rust toolchain
+        run: |
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
+          rustup show
+
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
+      - name: Generate decode-boundary inputs
+        run: |
+          python3 - <<'PY' | tee -a "$GITHUB_ENV"
+          import secrets
+
+          print(f"RINGS_DECODE_BOUNDARY_SEED={secrets.randbits(64)}")
+          print("RINGS_DECODE_BOUNDARY_CASES=1024")
+          PY
+
+      - name: Run generated decode-boundary tests
+        run: |
+          cargo test -p rings-core --features dummy --no-default-features decode_boundary -- --nocapture
+          cargo test -p rings-transport --no-default-features --features dummy decode_boundary -- --nocapture
+          cargo test -p rings-node --no-default-features --features node decode_boundary -- --nocapture
+
   miri_core:
     name: Miri core invariants
     timeout-minutes: 45

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -219,6 +219,13 @@ itself, against an adversary that can occupy many positions on the identifier ri
 What a relayed message reveals to each hop is stated under the communication layer
 contract above.
 
+The decoders that admit relayed bytes have generated decode-boundary smoke tests in
+their owning crates. `rings-core` covers the base58-check envelope, postcard wire
+envelope, message body decode, chunk framing, and chunk reassembly bounds;
+`rings-transport` covers SDP `a=max-message-size` parsing; `rings-node` covers
+the JSON-RPC body decoder and authorization classification. CI generates each run's
+seed and case count, so the repository does not carry generated corpora.
+
 ### Connection Admission
 
 Each node bounds the number of peers holding any logical connection record,
@@ -253,7 +260,9 @@ cannot carry a gated one past the check. Both listeners accept only
 external listener binds a non-loopback address only under an explicit opt-in. The token
 is therefore a control credential, not an admission credential: a seed admits arbitrary
 peers without sharing it, and the overlay's admission story is the one described in the
-sections above.
+sections above. The body decoder and the classification are covered by generated
+decode-boundary tests whose invariant is that a body that does not decode, an invalid
+call, or an unknown method never classifies as public.
 
 ### DHT Storage
 

--- a/crates/core/src/base58_check.rs
+++ b/crates/core/src/base58_check.rs
@@ -1,0 +1,53 @@
+use base58_monero::base58::CHECKSUM_SIZE;
+use base58_monero::Error;
+use tiny_keccak::Hasher;
+use tiny_keccak::Keccak;
+
+/// Decode base58-check without exposing the upstream short-input panic.
+pub(crate) fn decode(value: &str) -> Result<Vec<u8>, Error> {
+    let bytes = base58_monero::decode(value)?;
+    let payload_len = bytes
+        .len()
+        .checked_sub(CHECKSUM_SIZE)
+        .ok_or(Error::InvalidChecksum)?;
+    let payload = bytes.get(..payload_len).ok_or(Error::InvalidChecksum)?;
+    let checksum = bytes.get(payload_len..).ok_or(Error::InvalidChecksum)?;
+
+    let mut expected = [0u8; 32];
+    let mut hasher = Keccak::v256();
+    hasher.update(payload);
+    hasher.finalize(&mut expected);
+
+    if expected.get(..CHECKSUM_SIZE) == Some(checksum) {
+        Ok(payload.to_vec())
+    } else {
+        Err(Error::InvalidChecksum)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decoded_inputs_shorter_than_checksum_are_rejected() {
+        for len in 0..CHECKSUM_SIZE {
+            let encoded = base58_monero::encode(&vec![0u8; len]).unwrap();
+            assert!(decode(&encoded).is_err(), "decoded length {len}");
+        }
+    }
+
+    #[test]
+    fn valid_checked_inputs_round_trip() {
+        for payload in [&[][..], &[0][..], b"rings"] {
+            let encoded = base58_monero::encode_check(payload).unwrap();
+            assert_eq!(decode(&encoded).unwrap(), payload);
+        }
+    }
+
+    #[test]
+    fn invalid_checksum_is_rejected() {
+        let encoded = base58_monero::encode(&[0u8; CHECKSUM_SIZE]).unwrap();
+        assert!(decode(&encoded).is_err());
+    }
+}

--- a/crates/core/src/ecc/keys.rs
+++ b/crates/core/src/ecc/keys.rs
@@ -462,7 +462,7 @@ fn with_key_rng<R>(f: impl FnOnce(&mut Hc128Rng) -> R) -> R {
 }
 
 fn public_key_from_b58m_exact<const SIZE: usize>(value: &str) -> Result<PublicKey<SIZE>> {
-    let bytes = base58_monero::decode_check(value).map_err(|_| Error::PublicKeyBadFormat)?;
+    let bytes = crate::base58_check::decode(value).map_err(|_| Error::PublicKeyBadFormat)?;
     PublicKey::from_exact_u8(&bytes)
 }
 

--- a/crates/core/src/ecc/types.rs
+++ b/crates/core/src/ecc/types.rs
@@ -32,7 +32,7 @@ impl PublicKey<33> {
     /// monero and bitcoin style b58
     pub fn try_from_b58m(value: &str) -> Result<PublicKey<33>> {
         let value: &[u8] =
-            &base58_monero::decode_check(value).map_err(|_| Error::PublicKeyBadFormat)?;
+            &crate::base58_check::decode(value).map_err(|_| Error::PublicKeyBadFormat)?;
         Self::from_u8(value)
     }
 
@@ -103,7 +103,7 @@ impl<'de, const SIZE: usize> serde::de::Visitor<'de> for PublicKeyVisitor<SIZE> 
     fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
     where E: serde::de::Error {
         let value =
-            base58_monero::decode_check(value).map_err(|_| E::custom(Error::PublicKeyBadFormat))?;
+            crate::base58_check::decode(value).map_err(|_| E::custom(Error::PublicKeyBadFormat))?;
         if SIZE == 33 {
             let key = PublicKey::<33>::from_u8(&value).map_err(E::custom)?;
             return PublicKey::from_exact_u8(&key.0).map_err(E::custom);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -70,6 +70,7 @@
 )]
 
 pub mod algebra;
+mod base58_check;
 pub mod dht;
 pub mod ecc;
 pub mod error;

--- a/crates/core/src/message/encoder/mod.rs
+++ b/crates/core/src/message/encoder/mod.rs
@@ -1,6 +1,5 @@
 use std::ops::Deref;
 
-use base58_monero as b58m;
 use bytes::Bytes;
 use serde::Deserialize;
 use serde::Serialize;
@@ -41,7 +40,7 @@ impl Deref for Encoded {
 impl Encoder for String {
     fn encode(&self) -> Result<Encoded> {
         Ok(Encoded(
-            b58m::encode_check(self.as_bytes()).map_err(|_| Error::Encode)?,
+            base58_monero::encode_check(self.as_bytes()).map_err(|_| Error::Encode)?,
         ))
     }
 }
@@ -62,7 +61,7 @@ impl Encoder for &str {
 impl Encoder for &[u8] {
     fn encode(&self) -> Result<Encoded> {
         Ok(Encoded(
-            b58m::encode_check(self).map_err(|_| Error::Encode)?,
+            base58_monero::encode_check(self).map_err(|_| Error::Encode)?,
         ))
     }
 }
@@ -70,7 +69,7 @@ impl Encoder for &[u8] {
 impl Encoder for Vec<u8> {
     fn encode(&self) -> Result<Encoded> {
         Ok(Encoded(
-            b58m::encode_check(self).map_err(|_| Error::Encode)?,
+            base58_monero::encode_check(self).map_err(|_| Error::Encode)?,
         ))
     }
 }
@@ -83,7 +82,7 @@ impl Encoder for Bytes {
 
 impl Decoder for Vec<u8> {
     fn from_encoded(encoded: &Encoded) -> Result<Self> {
-        b58m::decode_check(encoded.deref()).map_err(|_| Error::Decode)
+        crate::base58_check::decode(encoded.deref()).map_err(|_| Error::Decode)
     }
 }
 

--- a/crates/core/src/session/signing_key.rs
+++ b/crates/core/src/session/signing_key.rs
@@ -31,7 +31,7 @@ impl FromStr for SessionSk {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        let s = base58_monero::decode_check(s).map_err(|_| Error::Decode)?;
+        let s = crate::base58_check::decode(s).map_err(|_| Error::Decode)?;
         serde_json::from_slice(&s).map_err(Error::Deserialize)
     }
 }

--- a/crates/core/src/tests/default/mod.rs
+++ b/crates/core/src/tests/default/mod.rs
@@ -42,6 +42,8 @@ mod test_dht_schedule;
 #[cfg(feature = "dummy")]
 mod test_chunk_e2e;
 #[cfg(all(feature = "dummy", not(target_family = "wasm")))]
+mod test_decode_boundaries;
+#[cfg(all(feature = "dummy", not(target_family = "wasm")))]
 mod test_inbox;
 mod test_message_handler;
 #[cfg(all(feature = "std", not(feature = "dummy")))]

--- a/crates/core/src/tests/default/test_decode_boundaries.rs
+++ b/crates/core/src/tests/default/test_decode_boundaries.rs
@@ -1,0 +1,277 @@
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use bytes::Bytes;
+use uuid::Uuid;
+
+use crate::chunk::Chunk;
+use crate::chunk::ChunkMeta;
+use crate::chunk::MessageReassembler;
+use crate::chunk::ReassemblyLimits;
+use crate::consts::DEFAULT_TTL_MS;
+use crate::dht::Did;
+use crate::ecc::SecretKey;
+use crate::message::Encoded;
+use crate::message::Encoder;
+use crate::message::Message;
+use crate::message::MessagePayload;
+use crate::message::MessageSigner;
+use crate::message::MessageVerificationExt;
+use crate::session::SessionSk;
+use crate::tests::TEST_NETWORK_ID;
+use crate::utils::get_epoch_ms;
+
+const SEED_ENV: &str = "RINGS_DECODE_BOUNDARY_SEED";
+const CASES_ENV: &str = "RINGS_DECODE_BOUNDARY_CASES";
+const DEFAULT_CASES: usize = 128;
+
+#[test]
+fn generated_message_decode_boundary_inputs_are_total() {
+    let mut generator = DecodeBoundaryGenerator::named("core-message");
+    let cases = generated_case_count();
+    eprintln!(
+        "{SEED_ENV}={} {CASES_ENV}={cases} target=core-message",
+        generator.seed()
+    );
+
+    for _ in 0..cases {
+        let raw = generator.bytes(4096);
+        exercise_message_decode_boundary(&raw);
+        if let Some(payload) = generated_payload(&mut generator) {
+            exercise_payload_wire_forms(&payload);
+        }
+    }
+}
+
+#[test]
+fn generated_chunk_decode_boundary_sequences_respect_bounds() {
+    let mut generator = DecodeBoundaryGenerator::named("core-chunk");
+    let cases = generated_case_count();
+    let limits = generated_reassembly_limits();
+    let mut reassembler = MessageReassembler::with_limits(limits);
+    eprintln!(
+        "{SEED_ENV}={} {CASES_ENV}={cases} target=core-chunk",
+        generator.seed()
+    );
+
+    for _ in 0..cases {
+        if generator.one_in(5) {
+            reassembler.remove_expired();
+        }
+        let chunk = if generator.one_in(3) {
+            Chunk::from_wire(&generator.bytes(512)).ok()
+        } else {
+            Some(generator.chunk(get_epoch_ms()))
+        };
+        if let Some(chunk) = chunk {
+            let output = reassembler.handle(chunk);
+            assert!(reassembler.pending_count() <= limits.max_pending_messages.max(1));
+            if let Some(bytes) = output {
+                assert!(bytes.len() <= limits.max_message_bytes.max(1));
+            }
+        }
+    }
+}
+
+fn exercise_message_decode_boundary(data: &[u8]) {
+    if let Ok(payload) = MessagePayload::from_wire(data) {
+        judge_payload(&payload);
+    }
+    let text = String::from_utf8_lossy(data);
+    let encoded = Encoded::from_encoded_str(&text);
+    let _bytes = encoded.decode::<Vec<u8>>();
+    if let Ok(payload) = encoded.decode::<MessagePayload>() {
+        judge_payload(&payload);
+    }
+}
+
+fn exercise_payload_wire_forms(payload: &MessagePayload) {
+    if let Ok(wire) = payload.to_wire() {
+        exercise_message_decode_boundary(&wire);
+    }
+    if let Ok(encoded) = payload.encode() {
+        let text = encoded.to_string();
+        exercise_message_decode_boundary(text.as_bytes());
+    }
+}
+
+fn judge_payload(payload: &MessagePayload) {
+    let _verified = payload.verify(TEST_NETWORK_ID);
+    let _message = payload.transaction.data::<Message>();
+}
+
+fn generated_payload(generator: &mut DecodeBoundaryGenerator) -> Option<MessagePayload> {
+    let session = SessionSk::new_with_seckey(&generator.secret_key()).ok()?;
+    let peer: Did = generator.secret_key().address().into();
+    MessagePayload::new_send(
+        Message::custom(&generator.bytes(256)).ok()?,
+        MessageSigner::new(&session, TEST_NETWORK_ID),
+        peer,
+        peer,
+    )
+    .ok()
+}
+
+fn generated_reassembly_limits() -> ReassemblyLimits {
+    ReassemblyLimits {
+        max_pending_messages: 4,
+        max_chunk_data_len: 128,
+        max_message_bytes: 512,
+        max_chunks_per_message: 16,
+        max_total_buffered_cost: 4096,
+        slot_overhead: 8,
+        max_completed_ids: 8,
+    }
+}
+
+fn generated_case_count() -> usize {
+    std::env::var(CASES_ENV)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .map(|cases| cases.clamp(1, 50_000))
+        .unwrap_or(DEFAULT_CASES)
+}
+
+struct DecodeBoundaryGenerator {
+    seed: u64,
+    state: u64,
+}
+
+impl DecodeBoundaryGenerator {
+    fn named(label: &str) -> Self {
+        let seed = std::env::var(SEED_ENV)
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or_else(time_seed);
+        let state = fold_label(seed, label);
+        Self { seed, state }
+    }
+
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = splitmix64(self.state);
+        self.state
+    }
+
+    fn one_in(&mut self, modulus: u64) -> bool {
+        self.next_u64().is_multiple_of(modulus.max(1))
+    }
+
+    fn bytes(&mut self, max_len: usize) -> Vec<u8> {
+        let len = self.usize(max_len.saturating_add(1));
+        let mut bytes = Vec::with_capacity(len);
+        for _ in 0..len {
+            bytes.push(self.byte());
+        }
+        bytes
+    }
+
+    fn byte(&mut self) -> u8 {
+        u8::try_from(self.next_u64() & 0xff).unwrap_or(0)
+    }
+
+    fn usize(&mut self, upper: usize) -> usize {
+        let upper = u64::try_from(upper).unwrap_or(u64::MAX).max(1);
+        usize::try_from(self.next_u64() % upper).unwrap_or(0)
+    }
+
+    fn secret_key(&mut self) -> SecretKey {
+        loop {
+            let candidate = hex::encode(self.array_32());
+            if let Ok(key) = SecretKey::try_from(candidate.as_str()) {
+                return key;
+            }
+        }
+    }
+
+    fn array_16(&mut self) -> [u8; 16] {
+        let mut bytes = [0_u8; 16];
+        self.fill(&mut bytes);
+        bytes
+    }
+
+    fn array_32(&mut self) -> [u8; 32] {
+        let mut bytes = [0_u8; 32];
+        self.fill(&mut bytes);
+        bytes
+    }
+
+    fn fill(&mut self, bytes: &mut [u8]) {
+        for byte in bytes {
+            *byte = self.byte();
+        }
+    }
+
+    fn chunk(&mut self, now: u128) -> Chunk {
+        let total = self.total();
+        Chunk {
+            chunk: [self.position(total), total],
+            data: Bytes::from(self.bytes(256)),
+            meta: ChunkMeta {
+                id: Uuid::from_bytes(self.array_16()),
+                ts_ms: self.timestamp(now),
+                ttl_ms: self.ttl_ms(),
+            },
+        }
+    }
+
+    fn total(&mut self) -> usize {
+        match self.usize(5) {
+            0 => 0,
+            1 => usize::MAX,
+            _ => self.usize(32).saturating_add(1),
+        }
+    }
+
+    fn position(&mut self, total: usize) -> usize {
+        match self.usize(4) {
+            0 => total,
+            1 => usize::MAX,
+            _ => self.usize(total.saturating_add(4)),
+        }
+    }
+
+    fn timestamp(&mut self, now: u128) -> u128 {
+        match self.usize(4) {
+            0 => now,
+            1 => now.saturating_sub(u128::from(DEFAULT_TTL_MS).saturating_add(1)),
+            2 => now.saturating_add(60_000),
+            _ => now.saturating_sub(u128::from(self.next_u64() % 10_000)),
+        }
+    }
+
+    fn ttl_ms(&mut self) -> u64 {
+        match self.usize(4) {
+            0 => 0,
+            1 => DEFAULT_TTL_MS,
+            2 => u64::MAX,
+            _ => self.next_u64() % 10_000,
+        }
+    }
+}
+
+fn time_seed() -> u64 {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO);
+    let nanos = u64::try_from(duration.as_nanos()).unwrap_or(duration.as_secs());
+    nanos ^ u64::from(std::process::id())
+}
+
+fn fold_label(seed: u64, label: &str) -> u64 {
+    label
+        .bytes()
+        .fold(seed, |state, byte| splitmix64(state ^ u64::from(byte)))
+}
+
+fn splitmix64(mut state: u64) -> u64 {
+    state = state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    let mut mixed = state;
+    mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    mixed ^ (mixed >> 31)
+}

--- a/crates/node/src/native/api_auth.rs
+++ b/crates/node/src/native/api_auth.rs
@@ -321,7 +321,17 @@ fn parse_allowed_origin(origin: &str) -> Result<HeaderValue, ApiSecurityError> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+    use std::time::SystemTime;
+    use std::time::UNIX_EPOCH;
+
+    use rings_rpc::method::Method as RpcMethod;
+
     use super::*;
+
+    const SEED_ENV: &str = "RINGS_DECODE_BOUNDARY_SEED";
+    const CASES_ENV: &str = "RINGS_DECODE_BOUNDARY_CASES";
+    const DEFAULT_CASES: usize = 128;
 
     fn token() -> String {
         "0123456789abcdef0123456789abcdef".to_string()
@@ -383,6 +393,169 @@ mod tests {
             params: jsonrpc_core::Params::None,
             id: jsonrpc_core::Id::Num(1),
         })
+    }
+
+    #[test]
+    fn generated_jsonrpc_decode_boundary_bodies_classify_without_public_fail_open() {
+        let mut generator = DecodeBoundaryGenerator::named("node-jsonrpc");
+        let cases = generated_case_count();
+        eprintln!(
+            "{SEED_ENV}={} {CASES_ENV}={cases} target=node-jsonrpc",
+            generator.seed()
+        );
+
+        for _ in 0..cases {
+            let body = generated_jsonrpc_body(&mut generator);
+            let decoded = crate::native::endpoint::DecodedJsonRpc::decode(&body);
+            let external = ApiListener::External.required_authorization(decoded.request());
+            let internal = ApiListener::Internal.required_authorization(decoded.request());
+            assert_eq!(internal, AuthorizationClass::Gated);
+            match decoded.request() {
+                None => assert_eq!(external, AuthorizationClass::Gated),
+                Some(request) => assert_eq!(
+                    external == AuthorizationClass::Public,
+                    every_call_is_public(request)
+                ),
+            }
+        }
+    }
+
+    fn generated_jsonrpc_body(generator: &mut DecodeBoundaryGenerator) -> Vec<u8> {
+        match generator.usize(6) {
+            0 => generator.bytes(2048),
+            1 => method_call(generator, true).into_bytes(),
+            2 => method_call(generator, false).into_bytes(),
+            3 => batch_call(generator).into_bytes(),
+            4 => br#"{"jsonrpc":"2.0","id":4}"#.to_vec(),
+            _ => br#"[{"jsonrpc":"2.0","id":1}]"#.to_vec(),
+        }
+    }
+
+    fn method_call(generator: &mut DecodeBoundaryGenerator, include_id: bool) -> String {
+        let method = generator.method();
+        if include_id {
+            format!(
+                r#"{{"jsonrpc":"2.0","id":{},"method":"{method}","params":[]}}"#,
+                generator.next_u64()
+            )
+        } else {
+            format!(r#"{{"jsonrpc":"2.0","method":"{method}","params":[]}}"#)
+        }
+    }
+
+    fn batch_call(generator: &mut DecodeBoundaryGenerator) -> String {
+        format!(
+            "[{},{}]",
+            method_call(generator, true),
+            method_call(generator, true)
+        )
+    }
+
+    fn every_call_is_public(request: &jsonrpc_core::Request) -> bool {
+        match request {
+            jsonrpc_core::Request::Single(call) => call_is_public(call),
+            jsonrpc_core::Request::Batch(calls) => calls.iter().all(call_is_public),
+        }
+    }
+
+    fn call_is_public(call: &jsonrpc_core::Call) -> bool {
+        match call {
+            jsonrpc_core::Call::MethodCall(call) => method_is_public(call.method.as_str()),
+            jsonrpc_core::Call::Notification(notification) => {
+                method_is_public(notification.method.as_str())
+            }
+            jsonrpc_core::Call::Invalid { .. } => false,
+        }
+    }
+
+    fn method_is_public(name: &str) -> bool {
+        matches!(
+            RpcMethod::try_from(name),
+            Ok(RpcMethod::NodeDid | RpcMethod::AnswerOffer)
+        )
+    }
+
+    fn generated_case_count() -> usize {
+        std::env::var(CASES_ENV)
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .map(|cases| cases.clamp(1, 50_000))
+            .unwrap_or(DEFAULT_CASES)
+    }
+
+    struct DecodeBoundaryGenerator {
+        seed: u64,
+        state: u64,
+    }
+
+    impl DecodeBoundaryGenerator {
+        fn named(label: &str) -> Self {
+            let seed = std::env::var(SEED_ENV)
+                .ok()
+                .and_then(|value| value.parse::<u64>().ok())
+                .unwrap_or_else(time_seed);
+            let state = fold_label(seed, label);
+            Self { seed, state }
+        }
+
+        fn seed(&self) -> u64 {
+            self.seed
+        }
+
+        fn next_u64(&mut self) -> u64 {
+            self.state = splitmix64(self.state);
+            self.state
+        }
+
+        fn bytes(&mut self, max_len: usize) -> Vec<u8> {
+            let len = self.usize(max_len.saturating_add(1));
+            let mut bytes = Vec::with_capacity(len);
+            for _ in 0..len {
+                bytes.push(self.byte());
+            }
+            bytes
+        }
+
+        fn byte(&mut self) -> u8 {
+            u8::try_from(self.next_u64() & 0xff).unwrap_or(0)
+        }
+
+        fn usize(&mut self, upper: usize) -> usize {
+            let upper = u64::try_from(upper).unwrap_or(u64::MAX).max(1);
+            usize::try_from(self.next_u64() % upper).unwrap_or(0)
+        }
+
+        fn method(&mut self) -> &'static str {
+            match self.usize(5) {
+                0 => "nodeDid",
+                1 => "answerOffer",
+                2 => "nodeInfo",
+                3 => "disconnect",
+                _ => "generatedUnknown",
+            }
+        }
+    }
+
+    fn time_seed() -> u64 {
+        let duration = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO);
+        let nanos = u64::try_from(duration.as_nanos()).unwrap_or(duration.as_secs());
+        nanos ^ u64::from(std::process::id())
+    }
+
+    fn fold_label(seed: u64, label: &str) -> u64 {
+        label
+            .bytes()
+            .fold(seed, |state, byte| splitmix64(state ^ u64::from(byte)))
+    }
+
+    fn splitmix64(mut state: u64) -> u64 {
+        state = state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut mixed = state;
+        mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        mixed ^ (mixed >> 31)
     }
 
     #[test]

--- a/crates/node/src/native/endpoint/mod.rs
+++ b/crates/node/src/native/endpoint/mod.rs
@@ -82,14 +82,15 @@ struct ListenerSecurity {
 /// The layer attaches it as a request extension and forwards an empty body, so the route
 /// handler dispatches the decoded request instead of parsing again. A body that failed to
 /// decode carries the JSON-RPC parse error the handler must answer with. Invariant: every
-/// request reaching the JSON-RPC route carries this extension, because [`secure_router`] is the
-/// only constructor of a served router.
+/// request reaching the JSON-RPC route carries this extension, because `secure_router` is the
+/// only constructor of a served router. Test-only decode-boundary checks drive this exact
+/// decoder, not a re-implementation of it.
 #[derive(Clone)]
-struct DecodedJsonRpc(Result<jsonrpc_core::Request, jsonrpc_core::Error>);
+pub(crate) struct DecodedJsonRpc(Result<jsonrpc_core::Request, jsonrpc_core::Error>);
 
 impl DecodedJsonRpc {
     /// Decode a body the way `MetaIoHandler::handle_request` does, keeping its parse error.
-    fn decode(bytes: &[u8]) -> Self {
+    pub(crate) fn decode(bytes: &[u8]) -> Self {
         Self(
             serde_json::from_slice(bytes)
                 .map_err(|_| jsonrpc_core::Error::new(ErrorCode::ParseError)),
@@ -97,7 +98,7 @@ impl DecodedJsonRpc {
     }
 
     /// Return the decoded request, or `None` for a body that did not decode.
-    fn request(&self) -> Option<&jsonrpc_core::Request> {
+    pub(crate) fn request(&self) -> Option<&jsonrpc_core::Request> {
         self.0.as_ref().ok()
     }
 }

--- a/crates/transport/src/core/sdp.rs
+++ b/crates/transport/src/core/sdp.rs
@@ -211,12 +211,20 @@ pub fn parse_sdp_max_message_size(sdp: &str) -> Option<u32> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+    use std::time::SystemTime;
+    use std::time::UNIX_EPOCH;
+
     use super::lex;
     use super::parse;
     use super::parse_attribute;
     use super::parse_sdp_max_message_size;
     use super::Attribute;
     use super::Line;
+
+    const SEED_ENV: &str = "RINGS_DECODE_BOUNDARY_SEED";
+    const CASES_ENV: &str = "RINGS_DECODE_BOUNDARY_CASES";
+    const DEFAULT_CASES: usize = 128;
 
     /// A minimal but realistic data-channel SDP, with a `body` of media-section attribute lines.
     fn data_channel_sdp(body: &str) -> String {
@@ -225,8 +233,179 @@ mod tests {
              o=- 0 0 IN IP4 0.0.0.0\r\n\
              m=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n\
              a=setup:actpass\r\n\
-             {body}"
+            {body}"
         )
+    }
+
+    #[test]
+    fn generated_sdp_decode_boundary_inputs_are_total() {
+        let mut generator = DecodeBoundaryGenerator::named("transport-sdp");
+        let cases = generated_case_count();
+        eprintln!(
+            "{SEED_ENV}={} {CASES_ENV}={cases} target=transport-sdp",
+            generator.seed()
+        );
+
+        for _ in 0..cases {
+            let bytes = generator.bytes(4096);
+            let lossy = String::from_utf8_lossy(&bytes);
+            let _raw = parse_sdp_max_message_size(&lossy);
+            let sdp = generator.sdp();
+            let _structured = parse_sdp_max_message_size(&sdp);
+        }
+    }
+
+    fn generated_case_count() -> usize {
+        std::env::var(CASES_ENV)
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .map(|cases| cases.clamp(1, 50_000))
+            .unwrap_or(DEFAULT_CASES)
+    }
+
+    struct DecodeBoundaryGenerator {
+        seed: u64,
+        state: u64,
+    }
+
+    impl DecodeBoundaryGenerator {
+        fn named(label: &str) -> Self {
+            let seed = std::env::var(SEED_ENV)
+                .ok()
+                .and_then(|value| value.parse::<u64>().ok())
+                .unwrap_or_else(time_seed);
+            let state = fold_label(seed, label);
+            Self { seed, state }
+        }
+
+        fn seed(&self) -> u64 {
+            self.seed
+        }
+
+        fn next_u64(&mut self) -> u64 {
+            self.state = splitmix64(self.state);
+            self.state
+        }
+
+        fn bytes(&mut self, max_len: usize) -> Vec<u8> {
+            let len = self.usize(max_len.saturating_add(1));
+            let mut bytes = Vec::with_capacity(len);
+            for _ in 0..len {
+                bytes.push(self.byte());
+            }
+            bytes
+        }
+
+        fn byte(&mut self) -> u8 {
+            u8::try_from(self.next_u64() & 0xff).unwrap_or(0)
+        }
+
+        fn usize(&mut self, upper: usize) -> usize {
+            let upper = u64::try_from(upper).unwrap_or(u64::MAX).max(1);
+            usize::try_from(self.next_u64() % upper).unwrap_or(0)
+        }
+
+        fn sdp(&mut self) -> String {
+            let mut text = String::new();
+            for _ in 0..self.usize(24).saturating_add(1) {
+                text.push_str(&self.sdp_line());
+            }
+            text
+        }
+
+        fn sdp_line(&mut self) -> String {
+            match self.usize(6) {
+                0 => format!("{}={}\r\n", self.line_kind(), self.text(96)),
+                1 => format!(
+                    "m={} {} {} {}\r\n",
+                    self.media(),
+                    self.port(),
+                    self.proto(),
+                    self.format_token()
+                ),
+                2 => format!("a=max-message-size:{}\r\n", self.next_u64()),
+                3 => format!("a={}:{}\r\n", self.text(32), self.text(64)),
+                4 => "a=sctp-port:5000\r\n".to_string(),
+                _ => self.text(128),
+            }
+        }
+
+        fn text(&mut self, max_len: usize) -> String {
+            let len = self.usize(max_len.saturating_add(1));
+            (0..len)
+                .map(|_| char::from(32_u8.saturating_add(self.byte() % 95)))
+                .collect()
+        }
+
+        fn line_kind(&mut self) -> char {
+            match self.usize(6) {
+                0 => 'v',
+                1 => 'o',
+                2 => 'm',
+                3 => 'a',
+                4 => '=',
+                _ => 'x',
+            }
+        }
+
+        fn media(&mut self) -> &'static str {
+            match self.usize(4) {
+                0 => "application",
+                1 => "Application",
+                2 => "audio",
+                _ => "video",
+            }
+        }
+
+        fn port(&mut self) -> &'static str {
+            match self.usize(4) {
+                0 => "0",
+                1 => "9",
+                2 => "65535",
+                _ => "port",
+            }
+        }
+
+        fn proto(&mut self) -> &'static str {
+            match self.usize(5) {
+                0 => "UDP/DTLS/SCTP",
+                1 => "TCP/DTLS/SCTP",
+                2 => "udp/dtls/sctp",
+                3 => "UDP/DTLS/SCTPX",
+                _ => "RTP/AVP",
+            }
+        }
+
+        fn format_token(&mut self) -> &'static str {
+            match self.usize(4) {
+                0 => "webrtc-datachannel",
+                1 => "WEBRTC-DATACHANNEL",
+                2 => "5000",
+                _ => "webrtc-datachannel-x",
+            }
+        }
+    }
+
+    fn time_seed() -> u64 {
+        let duration = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO);
+        let nanos = u64::try_from(duration.as_nanos()).unwrap_or(duration.as_secs());
+        nanos ^ u64::from(std::process::id())
+    }
+
+    fn fold_label(seed: u64, label: &str) -> u64 {
+        label
+            .bytes()
+            .fold(seed, |state, byte| splitmix64(state ^ u64::from(byte)))
+    }
+
+    fn splitmix64(mut state: u64) -> u64 {
+        state = state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut mixed = state;
+        mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        mixed ^ (mixed >> 31)
     }
 
     #[test]

--- a/llms.txt
+++ b/llms.txt
@@ -48,7 +48,8 @@ This file follows https://llmstxt.org/. It is for coding agents that build on Ri
 - Frontend (from `frontend/`): `cargo check --target wasm32-unknown-unknown`; `cargo clippy --target wasm32-unknown-unknown --all-targets -- -D warnings`; `cargo test --release --target wasm32-unknown-unknown`; `trunk serve --release true` to run it. Extension: `npm ci --ignore-scripts && npm run package:frontend-extension` from the root.
 - FFI: `cargo build -p rings-node --features ffi`; `RINGS_FFI_REQUIRE_LIBRARY=1 pytest examples/ffi/tests`.
 - Docs: `mdbook build docs`; `mdbook serve docs` to preview; a chapter listed in `SUMMARY.md` without a file fails the build.
-- Gates a change must pass (`.github/workflows/qaci.yml`): clippy with `-D warnings` on the native, wasm, and ffi feature sets; `cargo +nightly fmt --check`; rustdoc with `-D warnings`; `taplo format --check`; typos; cargo-deny; Miri on core invariants; the native, wasm, frontend, dweb, and gateway test suites; the docs build.
+- Decode-boundary smoke: set `RINGS_DECODE_BOUNDARY_SEED` and `RINGS_DECODE_BOUNDARY_CASES`, then run the `decode_boundary` test filters for `rings-core`, `rings-transport`, and `rings-node`; CI generates these values instead of committing corpora.
+- Gates a change must pass (`.github/workflows/qaci.yml`): clippy with `-D warnings` on the native, wasm, and ffi feature sets; `cargo +nightly fmt --check`; rustdoc with `-D warnings`; `taplo format --check`; typos; cargo-deny; Miri on core invariants; the native, wasm, frontend, dweb, gateway, and generated decode-boundary test suites; the docs build.
 
 ## Conventions
 


### PR DESCRIPTION
Closes #741. No version bump.

## What lands

- Replaces checked-in seed corpus with generated decode-boundary tests.
- Keeps decode-boundary checks inside the crates that own each surface: core message/chunk framing, transport SDP parsing, and native JSON-RPC/auth classification.
- Generates randomized boundary inputs at CI/test runtime through `RINGS_DECODE_BOUNDARY_SEED` and `RINGS_DECODE_BOUNDARY_CASES`; the seed is printed so failures can be replayed without committing generated inputs.
- Adds `crates/core/src/base58_check.rs` so Rings guards the upstream short-input base58-check panic before production decode paths use checked payloads.
- Updates QACI plus a scheduled Decode Boundary Smoke workflow to run the generated boundary tests.

## Cleanup

- The PR branch has been rewritten on current `master` into one clean commit.
- The current PR diff contains only the crate-owned generated boundary tests, the safe base58-check wrapper, CI workflow wiring, and matching docs updates.
- No generated input files or separate fuzz workspace remain in the current PR head.

## Validation

Local validation before publication covered formatting, TOML formatting, actionlint, typos, decode-boundary tests for `rings-core`, `rings-transport`, and `rings-node`, targeted clippy, and cargo-deny. Remote QACI and CodeQL passed on the same tree before the history cleanup; after rewriting the branch to remove stale commits, GitHub Actions is rerunning on commit `9da3cb8a`.