### PR TITLE
Prevent HTTPS exit Host authority confusion

### DIFF
--- a/crates/node/src/onion/https/mod.rs
+++ b/crates/node/src/onion/https/mod.rs
@@ -31,6 +31,8 @@ use self::limits::usize_to_u64;
 #[cfg(rings_native)]
 use self::native::execute_https_request;
 #[cfg(all(test, rings_native))]
+use self::native::is_native_transport_managed_header;
+#[cfg(all(test, rings_native))]
 use self::native::native_fetch_with_timeout;
 #[cfg(all(test, rings_native))]
 use self::native::select_native_https_egress;

--- a/crates/node/src/onion/https/native.rs
+++ b/crates/node/src/onion/https/native.rs
@@ -18,6 +18,30 @@ use crate::onion::OnionExitPolicy;
 
 const HTTPS_EXIT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Return whether the native exit, rather than the onion client, owns this request header.
+///
+/// The validated URL is the sole authority source. Message framing and hop-by-hop behavior also
+/// belong to reqwest so untrusted callers cannot override transport semantics.
+pub(super) fn is_native_transport_managed_header(name: &str) -> bool {
+    [
+        "host",
+        ":authority",
+        "connection",
+        "proxy-connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "content-length",
+        "upgrade",
+        "expect",
+    ]
+    .iter()
+    .any(|managed| name.eq_ignore_ascii_case(managed))
+}
+
 /// Mutually exclusive native HTTPS egress strategies.
 ///
 /// A direct request is allowed only after resolving and pinning public addresses. A proxied
@@ -132,6 +156,9 @@ pub(super) async fn native_fetch_with_timeout(
         .map_err(|error| Error::HttpRequestError(format!("build HTTPS proxy client: {error}")))?;
     let mut builder = client.request(method, url);
     for (name, value) in &request.headers {
+        if is_native_transport_managed_header(name) {
+            continue;
+        }
         builder = builder.header(name.as_str(), value.as_str());
     }
     if !request.body.is_empty() {

--- a/crates/node/src/onion/https/tests/test_https_proxy.rs
+++ b/crates/node/src/onion/https/tests/test_https_proxy.rs
@@ -428,6 +428,94 @@ async fn test_native_fetch_records_response_bytes_as_chunks_arrive() {
 
 #[cfg(rings_native)]
 #[test]
+fn test_native_transport_headers_are_not_caller_controlled() {
+    for name in [
+        "Host",
+        ":authority",
+        "Connection",
+        "Proxy-Connection",
+        "Keep-Alive",
+        "Proxy-Authenticate",
+        "Proxy-Authorization",
+        "TE",
+        "Trailer",
+        "Transfer-Encoding",
+        "Content-Length",
+        "Upgrade",
+        "Expect",
+    ] {
+        assert!(is_native_transport_managed_header(name), "{name}");
+    }
+    for name in ["Accept", "Authorization", "Content-Type", "X-Application"] {
+        assert!(!is_native_transport_managed_header(name), "{name}");
+    }
+}
+
+#[cfg(rings_native)]
+#[tokio::test]
+async fn test_native_fetch_uses_validated_url_authority_instead_of_caller_host() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let expected_host = format!("allowed.example:{}", address.port());
+    let expected_host_for_server = expected_host.clone();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let length = stream.read(&mut chunk).await.unwrap();
+            assert_ne!(length, 0, "request headers ended before their delimiter");
+            request.extend_from_slice(&chunk[..length]);
+        }
+        let request = String::from_utf8_lossy(&request).to_ascii_lowercase();
+        assert!(request.starts_with("post /probe http/1.1\r\n"));
+        assert!(request.contains(&format!("\r\nhost: {expected_host_for_server}\r\n")));
+        assert!(request.contains("\r\nx-application: preserved\r\n"));
+        assert!(request.contains("\r\ncontent-length: 2\r\n"));
+        assert!(!request.contains("blocked.example"));
+        assert!(!request.contains("content-length: 999"));
+        assert!(!request.contains("proxy-connection:"));
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+            .await
+            .unwrap();
+    });
+    let request = OnionHttpsRequest {
+        target: expected_host.clone(),
+        method: "POST".to_string(),
+        path: "/probe".to_string(),
+        headers: vec![
+            ("Host".to_string(), "blocked.example".to_string()),
+            (":authority".to_string(), "blocked.example".to_string()),
+            ("Content-Length".to_string(), "999".to_string()),
+            ("Proxy-Connection".to_string(), "keep-alive".to_string()),
+            ("X-Application".to_string(), "preserved".to_string()),
+        ],
+        body: b"ok".to_vec(),
+    };
+    let egress = NativeHttpsEgress::Direct {
+        host: "allowed.example".to_string(),
+        addresses: vec![address],
+    };
+
+    let response = native_fetch_with_timeout(
+        &format!("http://{expected_host}/probe"),
+        &request,
+        DEFAULT_HTTPS_RESPONSE_BODY_LIMIT_BYTES,
+        Duration::from_secs(1),
+        &egress,
+        |_| Ok(()),
+    )
+    .await
+    .unwrap();
+
+    server.await.unwrap();
+    assert_eq!(response.status, 200);
+    assert_eq!(response.body, b"ok");
+}
+
+#[cfg(rings_native)]
+#[test]
 fn test_native_egress_selection_pins_public_addresses_and_proxies_only_synthetic_dns() {
     let target = OnionProxyTarget::parse_authority("example.com:443").unwrap();
     let public = "8.8.8.8:443".parse().unwrap();


### PR DESCRIPTION
## Summary

- treat Host, :authority, framing, and hop-by-hop request headers as native transport-managed
- let reqwest construct Host exclusively from the policy-validated target URL
- preserve end-to-end application headers and add a raw-request regression test

## Validation

- cargo test -p rings-node --no-default-features --features node --lib
- cargo clippy -p rings-node --no-default-features --features node --lib -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::indexing_slicing
- cargo clippy -p rings-node --no-default-features --features node --tests -- -D warnings
- cargo check -p rings-node --all-features
- cargo +nightly-2026-07-02 fmt --all -- --check
- git diff --check

Fixes #751.