### PR TITLE
Reject oversized ElGamal AEAD wrapped keys

### DIFF
--- a/crates/core/src/ecc/elgamal/impls/secp256k1/mod.rs
+++ b/crates/core/src/ecc/elgamal/impls/secp256k1/mod.rs
@@ -90,12 +90,13 @@ impl Field {
 
 const AEAD_VERSION: u8 = 1;
 const AEAD_KEY_LEN: usize = 32;
+const AEAD_WRAPPED_KEY_BLOCKS: usize = AEAD_KEY_LEN.div_ceil(PLAINTEXT_BLOCK_SIZE);
 const AEAD_NONCE_LEN: usize = 12;
 const AEAD_HKDF_SALT: &[u8] = b"rings-core:secp256k1-elgamal-aead:salt:v1";
 const AEAD_HKDF_INFO: &[u8] = b"rings-core:secp256k1-elgamal-aead:chacha20poly1305:v1";
 
 /// KEM/DEM ciphertext using secp256k1 ElGamal to wrap a ChaCha20-Poly1305 key.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct AeadCiphertext {
     /// Version of the AEAD envelope format.
     pub version: u8,
@@ -105,6 +106,48 @@ pub struct AeadCiphertext {
     pub nonce: [u8; AEAD_NONCE_LEN],
     /// ChaCha20-Poly1305 ciphertext, including the authentication tag.
     pub ciphertext: Vec<u8>,
+}
+
+impl AeadCiphertext {
+    /// Prove that the envelope carries exactly the blocks needed for one fixed-size AEAD key.
+    ///
+    /// Deserialization calls this before producing an envelope, and [`decrypt_aead`] repeats the
+    /// check as defense in depth for values constructed in memory.
+    pub fn validate_wrapped_key(&self) -> Result<()> {
+        let actual = self.encrypted_key.len();
+        if actual != AEAD_WRAPPED_KEY_BLOCKS {
+            return Err(Error::AeadWrappedKeyBlockCount {
+                expected: AEAD_WRAPPED_KEY_BLOCKS,
+                actual,
+            });
+        }
+        Ok(())
+    }
+}
+
+impl<'de> Deserialize<'de> for AeadCiphertext {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where D: serde::Deserializer<'de> {
+        #[derive(Deserialize)]
+        struct WireEnvelope {
+            version: u8,
+            encrypted_key: Vec<CiphertextBlock>,
+            nonce: [u8; AEAD_NONCE_LEN],
+            ciphertext: Vec<u8>,
+        }
+
+        let envelope = WireEnvelope::deserialize(deserializer)?;
+        let sealed = Self {
+            version: envelope.version,
+            encrypted_key: envelope.encrypted_key,
+            nonce: envelope.nonce,
+            ciphertext: envelope.ciphertext,
+        };
+        sealed
+            .validate_wrapped_key()
+            .map_err(serde::de::Error::custom)?;
+        Ok(sealed)
+    }
 }
 
 #[derive(Serialize)]
@@ -440,6 +483,7 @@ pub fn decrypt_aead(
         )));
     }
 
+    sealed.validate_wrapped_key()?;
     let key_material = Zeroizing::new(decrypt_bytes(&sealed.encrypted_key, recipient_secret)?);
     let key = derive_aead_key(key_material.as_slice(), AeadErrorSide::Decrypt)?;
     let associated_data = aead_associated_data(&sealed.encrypted_key, aad)?;

--- a/crates/core/src/ecc/elgamal/impls/secp256k1/test_secp256k1.rs
+++ b/crates/core/src/ecc/elgamal/impls/secp256k1/test_secp256k1.rs
@@ -331,8 +331,48 @@ fn test_aead_rejects_empty_wrapped_key() {
 
     assert!(matches!(
         decrypt_aead(&sealed, b"aad", &key),
-        Err(Error::MessageDecryptionFailed(_))
+        Err(Error::AeadWrappedKeyBlockCount {
+            expected: AEAD_WRAPPED_KEY_BLOCKS,
+            actual: 0,
+        })
     ));
+}
+
+#[test]
+fn test_aead_rejects_oversized_wrapped_key_before_curve_conversion() {
+    let key =
+        SecretKey::try_from("65860affb4b570dba06db294aa7c676f68e04a5bf2721243ad3cbc05a79c68c0")
+            .unwrap();
+    let invalid_point = PublicKey([0u8; 33]);
+    let actual = AEAD_WRAPPED_KEY_BLOCKS + 1;
+    let sealed = AeadCiphertext {
+        version: AEAD_VERSION,
+        encrypted_key: vec![(invalid_point, invalid_point); actual],
+        nonce: [0u8; AEAD_NONCE_LEN],
+        ciphertext: Vec::new(),
+    };
+
+    assert!(matches!(
+        decrypt_aead(&sealed, b"aad", &key),
+        Err(Error::AeadWrappedKeyBlockCount {
+            expected: AEAD_WRAPPED_KEY_BLOCKS,
+            actual: observed,
+        }) if observed == actual
+    ));
+}
+
+#[test]
+fn test_aead_decode_rejects_oversized_wrapped_key() {
+    let invalid_point = PublicKey([0u8; 33]);
+    let sealed = AeadCiphertext {
+        version: AEAD_VERSION,
+        encrypted_key: vec![(invalid_point, invalid_point); AEAD_WRAPPED_KEY_BLOCKS + 1],
+        nonce: [0u8; AEAD_NONCE_LEN],
+        ciphertext: Vec::new(),
+    };
+    let encoded = rings_codec::serialize(&sealed).expect("encode invalid envelope fixture");
+
+    assert!(rings_codec::deserialize::<AeadCiphertext>(&encoded).is_err());
 }
 
 #[test]

--- a/crates/core/src/error/kind.rs
+++ b/crates/core/src/error/kind.rs
@@ -802,6 +802,15 @@ pub enum Error {
     #[error("Message decryption failed")]
     MessageDecryptionFailed(String),
 
+    /// An ElGamal AEAD envelope carries the wrong number of wrapped-key blocks.
+    #[error("ElGamal AEAD wrapped-key block count mismatch: expected {expected}, actual {actual}")]
+    AeadWrappedKeyBlockCount {
+        /// Number of blocks required to encode the fixed-size AEAD key.
+        expected: usize,
+        /// Number of blocks supplied by the envelope.
+        actual: usize,
+    },
+
     /// Message has {0} bytes which is too large
     #[error("Message has {0} bytes which is too large")]
     MessageTooLarge(usize),

--- a/crates/node/src/onion/circuit/cell.rs
+++ b/crates/node/src/onion/circuit/cell.rs
@@ -4,9 +4,10 @@
 //! the already-visible bucket across a circuit edge so that shrinking cells cannot reveal route
 //! position. An authenticated hostile peer can deliberately choose a larger bucket for a small
 //! hidden payload; a relay cannot canonicalize that choice without weakening the fixed-bucket
-//! privacy contract. The crypto admission gate therefore charges `bucket.plaintext_len()` before
-//! decryption. For a byte budget `L` and visible bucket size `b`, at most `floor(L / b)` such cells
-//! can be admitted in one limiter window, independent of their hidden encoded lengths.
+//! privacy contract. The wire decoder first proves that the ElGamal-wrapped key has its fixed block
+//! count; the crypto admission gate can then charge `bucket.plaintext_len()` before decryption. For
+//! a byte budget `L` and visible bucket size `b`, at most `floor(L / b)` such cells can be admitted
+//! in one limiter window, independent of their hidden encoded lengths.
 
 use bytes::Bytes;
 use rand::CryptoRng;

--- a/crates/node/src/onion/circuit/codec.rs
+++ b/crates/node/src/onion/circuit/codec.rs
@@ -147,3 +147,36 @@ pub(super) fn encode_local_message(message: OnionLocalMessage) -> Result<Bytes> 
         .map(Bytes::from)
         .map_err(|_| Error::EncodeError)
 }
+
+#[cfg(test)]
+mod tests {
+    use rings_core::ecc::SecretKey;
+    use rings_core::session::SessionSk;
+
+    use super::*;
+    use crate::onion::circuit::cell::seal_message;
+
+    #[test]
+    fn test_decode_rejects_oversized_wrapped_key_before_crypto_admission() {
+        let sender = SessionSk::new_with_seckey(&SecretKey::random()).expect("sender session");
+        let recipient =
+            SessionSk::new_with_seckey(&SecretKey::random()).expect("recipient session");
+        let payload = seal_message(
+            &OnionWireMessage::Cover,
+            recipient.session_public_key(),
+            Some(OnionCellBucket::KiB4),
+        )
+        .expect("seal cell");
+        let mut cell = rings_codec::deserialize::<OnionWireCell>(&payload).expect("decode cell");
+        let extra_block = cell
+            .sealed
+            .encrypted_key
+            .first()
+            .cloned()
+            .expect("wrapped-key block");
+        cell.sealed.encrypted_key.push(extra_block);
+        let oversized = rings_codec::serialize(&cell).expect("encode oversized cell");
+
+        assert!(decode_wire_message(sender.account_did(), &oversized).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- enforce the fixed two-block ElGamal wrapping of the 32-byte AEAD key during deserialization
- repeat the invariant check in `decrypt_aead` before curve conversion for in-memory values
- add core and onion decode regressions for oversized wrapped-key vectors

## Security invariant

Every decoded `AeadCiphertext` now has exactly `ceil(32 / 29) = 2` wrapped-key blocks. Therefore an admitted onion cell cannot hide unbounded ElGamal work behind a small visible bucket.

## Validation

- `cargo +nightly fmt --all -- --check`
- strict Clippy for all `rings-core` targets/features and `rings-node` node targets, including panic/indexing lints
- secp256k1 adapter tests: 18 passed, 1 ignored
- onion-circuit tests: 45 passed
- full node library tests: 339 passed, 1 ignored
- full core library run: 590 passed, 1 ignored; two unrelated WebRTC topology tests hit their 5-second timeout under parallel load, and both exact serial reruns passed

Fixes #749
