### PR TITLE
Add community contribution guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,65 @@
+# Code of Conduct
+
+## Our Commitment
+
+The Rings Network community is committed to providing a welcoming, safe, and
+professional environment for everyone who participates in good faith. We value
+technical rigor, honest disagreement, curiosity, and respect for the people behind
+the work.
+
+## Expected Behavior
+
+Community members are expected to:
+
+- Discuss ideas and code without attacking the people presenting them.
+- Give clear, constructive feedback and receive it in good faith.
+- Respect differing backgrounds, viewpoints, experience levels, and communication
+  styles.
+- Ask for clarification before assuming bad intent.
+- Respect personal boundaries and the privacy of others.
+- Acknowledge mistakes, repair harm where possible, and learn from the experience.
+
+## Unacceptable Behavior
+
+The following behavior is not acceptable:
+
+- Harassment, intimidation, threats, stalking, or sustained unwanted attention.
+- Discriminatory, demeaning, or sexualized language or imagery.
+- Trolling, personal or political attacks, insults, or deliberate disruption of
+  community discussions.
+- Publishing another person's private information without explicit permission.
+- Retaliation against someone who reports a concern or participates in an
+  enforcement process.
+- Other conduct that would reasonably be considered inappropriate in a
+  professional community.
+
+## Scope
+
+This code applies in project-controlled spaces, including the repository, issues,
+pull requests, discussions, community chat, and project events. It also applies
+when someone officially represents Rings Network in public.
+
+## Reporting
+
+Report conduct concerns privately to [dev@ringsnetwork.io](mailto:dev@ringsnetwork.io)
+with `Code of Conduct` in the subject. Do not open a public issue containing
+sensitive details.
+
+Include relevant links, screenshots, or other context when it is safe to do so.
+Maintainers will review reports promptly, protect the reporter's privacy as far as
+possible, and avoid conflicts of interest. Anyone named in a report will not take
+part in deciding its outcome.
+
+## Enforcement
+
+Maintainers may remove or edit content, reject contributions, issue a private or
+public warning, restrict participation, or impose a temporary or permanent ban.
+The response will depend on the severity, context, and pattern of the behavior.
+
+Good-faith technical disagreement is not a violation. How that disagreement is
+expressed can be.
+
+## Attribution
+
+This policy is informed by the [Contributor Covenant, version 3.0](https://www.contributor-covenant.org/version/3/0/)
+and its enforcement guidance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,105 @@
+# Contributing to Rings
+
+Thank you for helping improve Rings. Contributions can include bug reports, design
+discussion, documentation, tests, and code.
+
+Participation in this project is governed by our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Before You Start
+
+- Search existing [issues](https://github.com/RingsNetwork/rings/issues) and
+  [pull requests](https://github.com/RingsNetwork/rings/pulls) before opening a
+  duplicate.
+- Use an issue to discuss large changes to protocols, public APIs, compatibility,
+  or architecture before investing in an implementation.
+- Report vulnerabilities according to [SECURITY.md](./SECURITY.md). Do not disclose
+  security-sensitive details in a public issue.
+
+## Development Setup
+
+Clone the repository and let `rustup` install the toolchain pinned in
+[`rust-toolchain.toml`](./rust-toolchain.toml):
+
+```sh
+git clone https://github.com/RingsNetwork/rings.git
+cd rings
+rustup show
+cargo build --all
+```
+
+Changes to the browser or extension code also require Node.js. Install its locked
+dependencies without running the package build during installation:
+
+```sh
+npm ci --ignore-scripts
+```
+
+The exact tool versions used by CI are defined in
+[`.github/workflows/qaci.yml`](./.github/workflows/qaci.yml).
+
+## Making Changes
+
+- Keep each pull request focused on one problem.
+- Add or update tests for behavior changes and bug fixes.
+- Update public API documentation and user-facing documentation when behavior
+  changes.
+- Preserve the security boundaries documented in [SECURITY.md](./SECURITY.md), or
+  update that document when a boundary intentionally changes.
+- Do not commit secrets, local configuration, build output, or generated artifacts
+  unless the repository explicitly tracks them.
+
+## Validation
+
+Run focused tests while iterating. Before opening a pull request, run the relevant
+checks below when practical.
+
+For Rust changes:
+
+```sh
+cargo +nightly-2026-07-02 fmt --all -- --check
+cargo clippy --all --tests -- -D warnings
+cargo test --release --all --all-targets
+```
+
+For browser or extension changes:
+
+```sh
+npm ci --ignore-scripts
+npm run build:frontend-extension-scripts
+```
+
+For documentation-book changes:
+
+```sh
+mdbook build docs
+```
+
+If a change touches TOML files or prose, also run `taplo format --check` or `typos`
+when those tools are installed. GitHub Actions runs the complete cross-platform,
+WASM, security, and release-target matrix; all required checks must pass before a
+change can be merged.
+
+## Commits and Pull Requests
+
+Create a branch from `master` and use descriptive commit messages. Keep unrelated
+formatting or refactoring out of the same change.
+
+When opening a pull request:
+
+- Explain the problem and the reason for the chosen approach.
+- Describe the old and new behavior.
+- List the tests and checks you ran.
+- Call out compatibility or breaking changes explicitly.
+- Link the relevant issue when one exists.
+- Use a draft pull request if the change is not ready for review.
+
+Respond to review feedback with follow-up commits or a clear explanation. Resolve
+review threads only after the concern has been addressed or agreement has been
+reached.
+
+## Licensing
+
+Review the project's [AGPL-3.0-only license](./LICENSE) before contributing. By
+submitting a contribution, you represent that you have the right to provide it for
+inclusion in the project. Accepted contributions are distributed as part of Rings
+under the repository's license.


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] Tests are not applicable because this is a documentation-only change
- [x] Docs have been added

## :large_blue_circle: What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Documentation and community-policy update.

## :brown_circle: What is the current behavior? (You can also link to an open issue here)

The repository does not have dedicated contribution guidelines or a code of conduct, so GitHub cannot surface those community-document tabs.

## :green_circle: What is the new behavior (if this is a feature change)?

- Adds `CODE_OF_CONDUCT.md` with project conduct, private reporting, and enforcement guidance.
- Adds `CONTRIBUTING.md` with setup, validation, pull-request, security, and licensing guidance tailored to the current Rust, WASM, and frontend workflows.
- Allows GitHub to surface the Code of conduct and Contributing tabs automatically.

## :radioactive: Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

## :information_source: Other information

Validated with `git diff origin/master...HEAD --check` and `typos CODE_OF_CONDUCT.md CONTRIBUTING.md`.