### PR TITLE
Add destination-scoped transaction replay protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.24.0
+
+### Breaking changes
+
+- Every signed `Transaction` now carries a mandatory destination-scoped `u64` sequence and uses
+  the `rings-core:message-verification:transaction:v2` signature domain. Payload wire bytes carry
+  an explicit `RINGS-TX-V2` marker; 0.23.x payloads fail closed before decoding. Mixed-version
+  overlays are unsupported.
+
+### Added
+
+- Final destinations persist a fixed 32-slot replay window per
+  `(network_id, origin_account_did, destination_did)` before application validation and dispatch.
+  Duplicate, fork, and stale sequence verdicts are typed and observable; gaps and bounded late
+  delivery are admitted. Sender allocators persist reservations before signing, session rotation
+  preserves the account stream, relays remain stateless, and both native and browser runtimes use
+  dedicated durable replay stores without LRU eviction.
+
 ## 0.23.0
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "rings-codec"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "postcard",
  "serde",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "rings-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "rings-derive"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rings-gateway"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "ipnet",
@@ -3355,11 +3355,11 @@ dependencies = [
 
 [[package]]
 name = "rings-logo"
-version = "0.23.0"
+version = "0.24.0"
 
 [[package]]
 name = "rings-measure"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "rings-native-example"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "rings-network-policy"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "thiserror 1.0.69",
  "url",
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "rings-node"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "rings-relay-example"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "rings-core",
  "rings-node",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "rings-rpc"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "rings-transport"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "rings-webview"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 authors = ["RND <dev@ringsnetwork.io>"]
@@ -20,15 +20,15 @@ repository = "https://github.com/RingsNetwork/rings"
 async-trait = "0.1.77"
 js-sys = "0.3.98"
 jsonrpc-core = "18.0.0"
-rings-codec = { path = "crates/codec", version = "0.23.0" }
-rings-core = { path = "crates/core", version = "0.23.0", default-features = false }
-rings-derive = { path = "crates/derive", version = "0.23.0", default-features = false }
-rings-gateway = { path = "crates/gateway", version = "0.23.0" }
-rings-measure = { path = "crates/measure", version = "0.23.0" }
-rings-network-policy = { path = "crates/network-policy", version = "0.23.0" }
-rings-node = { path = "crates/node", version = "0.23.0" }
-rings-rpc = { path = "crates/rpc", version = "0.23.0", default-features = false }
-rings-transport = { path = "crates/transport", version = "0.23.0" }
+rings-codec = { path = "crates/codec", version = "0.24.0" }
+rings-core = { path = "crates/core", version = "0.24.0", default-features = false }
+rings-derive = { path = "crates/derive", version = "0.24.0", default-features = false }
+rings-gateway = { path = "crates/gateway", version = "0.24.0" }
+rings-measure = { path = "crates/measure", version = "0.24.0" }
+rings-network-policy = { path = "crates/network-policy", version = "0.24.0" }
+rings-node = { path = "crates/node", version = "0.24.0" }
+rings-rpc = { path = "crates/rpc", version = "0.24.0", default-features = false }
+rings-transport = { path = "crates/transport", version = "0.24.0" }
 serde-wasm-bindgen = "0.6.5"
 wasm-bindgen = "0.2.121"
 wasm-bindgen-futures = "0.4.71"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -129,6 +129,27 @@ The obligations of this layer are leak-minimization obligations:
 - every signature bound to `network_id` and to a per-message-family domain tag, so
   an observation in one overlay is not a credential in another.
 
+### Transaction replay boundary
+
+Signed transactions use a destination-scoped sequence stream keyed by `network_id`, the origin
+account DID recovered from the delegated session, and the final destination DID. The final
+destination persists a fixed 32-sequence acceptance window before application validation and
+handler dispatch. Exact duplicates, conflicting transactions at one sequence, and sequences
+below the retained window are rejected as separate typed verdicts. Session-key rotation does not
+reset the account stream, sender timestamps do not order it, and intermediate Chord relays keep no
+origin replay state.
+
+This is an at-most-once dispatch guarantee only while the replay store is retained. A crash after
+the receiver commits a sequence but before handler dispatch can lose that event; replay storage
+and application effects are not one transaction, so exactly-once effects are not claimed. A gap
+is allowed and proves neither omission nor relay fault. Deleting the replay store deletes the
+guarantee, and there is no reset/incarnation protocol: capacity and persistence failures fail
+closed instead of evicting an old stream. Native daemon and browser-provider defaults use durable
+stores; custom builders must supply `ReplayStorage` to preserve the guarantee across restart.
+Concurrent devices or processes for one account/destination must delegate to one serialized
+allocator; sharing only the underlying store is not an atomic multi-writer protocol and may
+produce a typed fork.
+
 A leak on this layer is a communication-layer bug. Cover traffic and circuits do not
 fix it: they run above the relay and inherit whatever it exposes.
 

--- a/crates/core/src/dht/stabilization.rs
+++ b/crates/core/src/dht/stabilization.rs
@@ -26,7 +26,6 @@ use crate::message::FindSuccessorReportHandler;
 use crate::message::FindSuccessorSend;
 use crate::message::FindSuccessorThen;
 use crate::message::Message;
-use crate::message::MessagePayload;
 use crate::message::NotifyPredecessorSend;
 use crate::message::PayloadSender;
 use crate::message::PeerLivenessProbe;
@@ -645,8 +644,7 @@ impl Stabilizer {
         let msg = Message::NotifyPredecessorSend(NotifyPredecessorSend { did: self.dht.did });
         if self.dht.did != successor_min {
             for s in successor_list {
-                let payload =
-                    MessagePayload::new_send(msg.clone(), self.transport.message_signer(), s, s)?;
+                let payload = self.transport.signed_payload(msg.clone(), s, s).await?;
                 let tx_id = payload.transaction.tx_id;
                 let target_state = self
                     .transport
@@ -718,12 +716,10 @@ impl Stabilizer {
                         ),
                         strict: false,
                     });
-                    let payload = MessagePayload::new_send(
-                        msg.clone(),
-                        self.transport.message_signer(),
-                        closest_predecessor,
-                        closest_predecessor,
-                    )?;
+                    let payload = self
+                        .transport
+                        .signed_payload(msg.clone(), closest_predecessor, closest_predecessor)
+                        .await?;
                     let tx_id = payload.transaction.tx_id;
                     let next_hop_state = self
                         .transport

--- a/crates/core/src/error/kind.rs
+++ b/crates/core/src/error/kind.rs
@@ -64,6 +64,71 @@ pub enum Error {
     #[error("E2E frame sequence counter overflowed")]
     E2eFrameSequenceOverflow,
 
+    /// A sender exhausted the sequence space for one destination-scoped transaction stream.
+    #[error("Transaction sequence exhausted for {key:?}")]
+    TransactionSequenceExhausted {
+        /// Stream whose counter cannot advance without wrapping.
+        key: crate::message::StreamKey,
+    },
+
+    /// An exact signed transaction was already admitted at the final destination.
+    #[error("Transaction sequence {sequence} is a replay for {key:?}")]
+    TransactionReplay {
+        /// Destination-scoped stream.
+        key: crate::message::StreamKey,
+        /// Replayed sequence.
+        sequence: u64,
+    },
+
+    /// Two different signed transactions claimed one stream sequence.
+    #[error("Transaction sequence {sequence} forks {key:?}")]
+    TransactionSequenceFork {
+        /// Destination-scoped stream.
+        key: crate::message::StreamKey,
+        /// Conflicting sequence.
+        sequence: u64,
+        /// Previously retained and newly presented transaction digests.
+        evidence: Box<crate::message::TransactionForkEvidence>,
+    },
+
+    /// A transaction sequence fell below the retained replay window.
+    #[error(
+        "Transaction sequence {sequence} is stale for {key:?}; retained window starts at {retained_min}"
+    )]
+    TransactionSequenceStale {
+        /// Destination-scoped stream.
+        key: crate::message::StreamKey,
+        /// Rejected sequence.
+        sequence: u64,
+        /// Lowest sequence whose digest may still be retained.
+        retained_min: u64,
+    },
+
+    /// A new replay stream would exceed the fail-closed stream table bound.
+    #[error("Transaction replay stream capacity {capacity} exceeded")]
+    TransactionReplayStreamCapacityExceeded {
+        /// Maximum sender streams or receiver streams retained by one runtime.
+        capacity: usize,
+    },
+
+    /// The versioned replay snapshot violates its structural bounds.
+    #[error("Transaction replay state is invalid")]
+    TransactionReplayStateInvalid,
+
+    /// Durable replay state could not be loaded or committed.
+    #[error("Transaction replay persistence failed during {operation}: {source}")]
+    TransactionReplayPersistence {
+        /// Persistence operation that failed.
+        operation: &'static str,
+        /// Storage failure retained as the source.
+        #[source]
+        source: Box<Error>,
+    },
+
+    /// The payload does not carry the v2 hard-cutover wire marker.
+    #[error("Legacy transaction wire format is not accepted")]
+    LegacyTransactionWireFormat,
+
     /// E2E frame received after the authenticated final frame
     #[error("E2E frame received after the authenticated final frame")]
     E2eFrameAfterFinal,

--- a/crates/core/src/message/handlers/storage/tests/test_support.rs
+++ b/crates/core/src/message/handlers/storage/tests/test_support.rs
@@ -242,6 +242,7 @@ pub(super) fn storage_sync_report_payload(
     let transaction = Transaction::new(
         destination,
         request.transaction.tx_id,
+        request.transaction.sequence,
         Message::SyncEntriesWithSuccessorReport(report),
         signer,
     )?;

--- a/crates/core/src/message/mod.rs
+++ b/crates/core/src/message/mod.rs
@@ -26,6 +26,20 @@ pub use payload::MessagePayload;
 pub use payload::PayloadSender;
 pub use payload::Transaction;
 
+mod replay;
+pub use replay::observe;
+pub use replay::ReplayCounters;
+pub use replay::ReplaySnapshot;
+pub use replay::ReplayStorage;
+pub use replay::SequenceState;
+pub use replay::SequenceVerdict;
+pub use replay::StreamKey;
+pub use replay::TransactionDigest;
+pub use replay::TransactionForkEvidence;
+pub(crate) use replay::TransactionReplay;
+pub use replay::TRANSACTION_REPLAY_STREAM_CAPACITY;
+pub use replay::TRANSACTION_REPLAY_WINDOW;
+
 pub mod types;
 pub use types::*;
 

--- a/crates/core/src/message/payload/mod.rs
+++ b/crates/core/src/message/payload/mod.rs
@@ -2,7 +2,12 @@
 
 use std::fmt;
 use std::io::Write;
+use std::num::NonZeroU64;
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::LazyLock;
+#[cfg(test)]
+use std::sync::Mutex;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -22,6 +27,8 @@ use super::protocols::MessageRelay;
 use super::protocols::MessageSigner;
 use super::protocols::MessageVerification;
 use super::protocols::MessageVerificationExt;
+use super::replay::StreamKey;
+use super::replay::TransactionDigest;
 use crate::dht::Chord;
 use crate::dht::Did;
 use crate::dht::PeerRing;
@@ -34,11 +41,32 @@ use crate::session::SessionSk;
 
 /// Message family of the [`Transaction`] signature: the origin's authorship of a message.
 const TRANSACTION_DOMAIN_TAG: DomainTag =
-    domain_tag!("rings-core:message-verification:transaction:v1");
+    domain_tag!("rings-core:message-verification:transaction:v2");
 /// Message family of the [`MessagePayload`] signature: one hop's authorship of a forwarded
 /// envelope. Distinct from [`TRANSACTION_DOMAIN_TAG`] so the two signatures over the same
 /// transaction hash are never interchangeable.
 const PAYLOAD_DOMAIN_TAG: DomainTag = domain_tag!("rings-core:message-verification:payload:v1");
+/// Prefix that makes the v2 transaction cutover unambiguous before decoding any legacy shape.
+const TRANSACTION_V2_WIRE_PREFIX: &[u8] = b"RINGS-TX-V2\0";
+#[cfg(test)]
+static TEST_TRANSACTION_SEQUENCES: LazyLock<Mutex<std::collections::BTreeMap<StreamKey, u64>>> =
+    LazyLock::new(|| Mutex::new(std::collections::BTreeMap::new()));
+
+#[cfg(test)]
+fn next_test_transaction_sequence(key: StreamKey) -> Result<u64> {
+    let mut sequences = TEST_TRANSACTION_SEQUENCES
+        .lock()
+        .map_err(|_| Error::TransactionReplayStateInvalid)?;
+    let Some(last) = sequences.get_mut(&key) else {
+        sequences.insert(key, 0);
+        return Ok(0);
+    };
+    let next = last
+        .checked_add(1)
+        .ok_or(Error::TransactionSequenceExhausted { key })?;
+    *last = next;
+    Ok(next)
+}
 
 /// Compresses the given data byte slice using the gzip algorithm with the specified compression level.
 pub fn encode_data_gzip(data: &Bytes, level: u8) -> Result<Bytes> {
@@ -72,11 +100,12 @@ where T: DeserializeOwned {
     Ok(m)
 }
 
-fn hash_transaction(destination: Did, tx_id: uuid::Uuid, data: &[u8]) -> [u8; 32] {
+fn hash_transaction(destination: Did, tx_id: uuid::Uuid, sequence: u64, data: &[u8]) -> [u8; 32] {
     let mut msg = vec![];
 
     msg.extend_from_slice(destination.as_bytes());
     msg.extend_from_slice(tx_id.as_bytes());
+    msg.extend_from_slice(&sequence.to_be_bytes());
     msg.extend_from_slice(data);
 
     keccak256(&msg)
@@ -97,6 +126,8 @@ pub struct Transaction {
     /// The transaction ID.
     /// Remote peer should use same tx_id when response.
     pub tx_id: uuid::Uuid,
+    /// Monotonic sequence inside the origin account's destination-scoped stream.
+    pub sequence: u64,
     /// data
     pub data: Vec<u8>,
     /// This field holds a signature from a node,
@@ -109,6 +140,7 @@ impl fmt::Debug for Transaction {
         f.debug_struct("Transaction")
             .field("destination", &self.destination)
             .field("tx_id", &self.tx_id)
+            .field("sequence", &self.sequence)
             .field("data_bytes", &self.data.len())
             .finish()
     }
@@ -142,6 +174,7 @@ impl Transaction {
     pub fn new<T>(
         destination: Did,
         tx_id: uuid::Uuid,
+        sequence: u64,
         data: T,
         signer: MessageSigner<&SessionSk>,
     ) -> Result<Self>
@@ -149,11 +182,12 @@ impl Transaction {
         T: Serialize,
     {
         let data = rings_codec::serialize(&data).map_err(Error::CodecSerialize)?;
-        let msg_hash = hash_transaction(destination, tx_id, &data);
+        let msg_hash = hash_transaction(destination, tx_id, sequence, &data);
         let verification = signer.sign(TRANSACTION_DOMAIN_TAG, &msg_hash)?;
         Ok(Self {
             destination,
             tx_id,
+            sequence,
             data,
             verification,
         })
@@ -164,6 +198,17 @@ impl Transaction {
     /// is routed to; it is never the session id, which names a key, not a node.
     pub fn origin(&self) -> Did {
         self.verification.session.account_did()
+    }
+
+    /// Destination-scoped stream identity under the receiver's overlay.
+    pub fn stream_key(&self, network_id: u32) -> StreamKey {
+        StreamKey::new(network_id, self.origin(), self.destination)
+    }
+
+    /// Digest of this exact signed transaction, including its delegated session and signature.
+    pub fn digest(&self) -> Result<TransactionDigest> {
+        let wire = rings_codec::serialize(self).map_err(Error::CodecSerialize)?;
+        Ok(TransactionDigest::new(keccak256(&wire)))
     }
 
     /// Deserializes the data field into a `T` instance.
@@ -184,6 +229,7 @@ impl MessagePayload {
         let msg_hash = hash_transaction(
             transaction.destination,
             transaction.tx_id,
+            transaction.sequence,
             &transaction.data,
         );
         let verification = signer.sign(PAYLOAD_DOMAIN_TAG, &msg_hash)?;
@@ -195,7 +241,24 @@ impl MessagePayload {
     }
 
     /// Helps to create sending message from data: a fresh carrier with the full hop budget.
-    pub fn new_send<T>(
+    pub fn new_send_with_sequence<T>(
+        data: T,
+        signer: MessageSigner<&SessionSk>,
+        next_hop: Did,
+        destination: Did,
+        sequence: u64,
+    ) -> Result<Self>
+    where
+        T: Serialize,
+    {
+        let tx_id = crate::utils::new_uuid();
+        let transaction = Transaction::new(destination, tx_id, sequence, data, signer)?;
+        let relay = MessageRelay::new(next_hop, transaction.destination, HopBudget::MAX);
+        Self::new(transaction, signer, relay)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_send<T>(
         data: T,
         signer: MessageSigner<&SessionSk>,
         next_hop: Did,
@@ -204,28 +267,43 @@ impl MessagePayload {
     where
         T: Serialize,
     {
-        let tx_id = crate::utils::new_uuid();
-        let transaction = Transaction::new(destination, tx_id, data, signer)?;
-        let relay = MessageRelay::new(next_hop, transaction.destination, HopBudget::MAX);
-        Self::new(transaction, signer, relay)
+        let sequence = next_test_transaction_sequence(StreamKey::new(
+            signer.network_id(),
+            signer.account_did(),
+            destination,
+        ))?;
+        Self::new_send_with_sequence(data, signer, next_hop, destination, sequence)
     }
 
     /// Deserializes a `MessagePayload` instance from the Rings wire encoding.
     pub fn from_wire(data: &[u8]) -> Result<Self> {
-        rings_codec::deserialize(data).map_err(Error::CodecDeserialize)
+        let body = data
+            .strip_prefix(TRANSACTION_V2_WIRE_PREFIX)
+            .ok_or(Error::LegacyTransactionWireFormat)?;
+        rings_codec::deserialize(body).map_err(Error::CodecDeserialize)
     }
 
     /// Serializes the `MessagePayload` instance into the Rings wire encoding.
     pub fn to_wire(&self) -> Result<Bytes> {
-        rings_codec::serialize(self)
-            .map(Bytes::from)
-            .map_err(Error::CodecSerialize)
+        let body = rings_codec::serialize(self).map_err(Error::CodecSerialize)?;
+        let capacity = TRANSACTION_V2_WIRE_PREFIX
+            .len()
+            .checked_add(body.len())
+            .ok_or(Error::MessageSizeOverflow)?;
+        let mut wire = Vec::with_capacity(capacity);
+        wire.extend_from_slice(TRANSACTION_V2_WIRE_PREFIX);
+        wire.extend_from_slice(&body);
+        Ok(Bytes::from(wire))
     }
 
     /// Return the exact Rings wire size without allocating the wire buffer.
     pub(crate) fn wire_size(&self) -> Result<usize> {
         let bytes = rings_codec::serialized_size(self).map_err(Error::CodecSerialize)?;
-        usize::try_from(bytes).map_err(|_| Error::MessageSizeOverflow)
+        let body = usize::try_from(bytes).map_err(|_| Error::MessageSizeOverflow)?;
+        TRANSACTION_V2_WIRE_PREFIX
+            .len()
+            .checked_add(body)
+            .ok_or(Error::MessageSizeOverflow)
     }
 
     /// Returns whether `local` is the relay destination of this payload.
@@ -243,7 +321,7 @@ impl MessageVerificationExt for Transaction {
     const DOMAIN_TAG: DomainTag = TRANSACTION_DOMAIN_TAG;
 
     fn verification_data(&self) -> Result<Vec<u8>> {
-        Ok(hash_transaction(self.destination, self.tx_id, &self.data).to_vec())
+        Ok(hash_transaction(self.destination, self.tx_id, self.sequence, &self.data).to_vec())
     }
 
     fn verification(&self) -> &MessageVerification {
@@ -289,6 +367,13 @@ pub trait PayloadSender {
     /// Used to check if destination is already connected when `infer_next_hop`
     fn is_connected(&self, did: Did) -> bool;
 
+    /// Persistently reserve sender sequences for one final destination before signing.
+    async fn reserve_transaction_sequences(
+        &self,
+        destination: Did,
+        count: NonZeroU64,
+    ) -> Result<std::ops::RangeInclusive<u64>>;
+
     /// Send a message payload to a specified DID.
     async fn do_send_payload(&self, did: Did, payload: MessagePayload) -> Result<()>;
 
@@ -324,7 +409,17 @@ pub trait PayloadSender {
     where
         T: Serialize + Send,
     {
-        let payload = MessagePayload::new_send(msg, self.message_signer(), next_hop, destination)?;
+        let sequence = *self
+            .reserve_transaction_sequences(destination, NonZeroU64::MIN)
+            .await?
+            .start();
+        let payload = MessagePayload::new_send_with_sequence(
+            msg,
+            self.message_signer(),
+            next_hop,
+            destination,
+            sequence,
+        )?;
         let tx_id = payload.transaction.tx_id;
         self.send_payload(payload).await?;
         Ok(tx_id)
@@ -355,7 +450,12 @@ pub trait PayloadSender {
             .report(self.dht().did, origin, next_hop, HopBudget::MAX)?;
 
         let signer = self.message_signer();
-        let transaction = Transaction::new(origin, payload.transaction.tx_id, msg, signer)?;
+        let sequence = *self
+            .reserve_transaction_sequences(origin, NonZeroU64::MIN)
+            .await?
+            .start();
+        let transaction =
+            Transaction::new(origin, payload.transaction.tx_id, sequence, msg, signer)?;
 
         let pl = MessagePayload::new(transaction, signer, relay)?;
         self.send_payload(pl).await

--- a/crates/core/src/message/payload/mod.rs
+++ b/crates/core/src/message/payload/mod.rs
@@ -315,6 +315,11 @@ impl MessagePayload {
     pub(crate) fn should_forward_from(&self, local: Did) -> bool {
         !self.is_relay_destination_for(local)
     }
+
+    /// Verify both the immutable origin transaction and the current payload carrier.
+    pub(crate) fn verify_transaction_and_payload(&self, network_id: u32) -> bool {
+        self.transaction.verify(network_id) && MessageVerificationExt::verify(self, network_id)
+    }
 }
 
 impl MessageVerificationExt for Transaction {

--- a/crates/core/src/message/payload/test_payload.rs
+++ b/crates/core/src/message/payload/test_payload.rs
@@ -97,6 +97,7 @@ fn test_origin_is_the_account_behind_the_signing_session() -> Result<()> {
     let transaction = Transaction::new(
         destination,
         uuid::Uuid::new_v4(),
+        0,
         Message::custom(b"origin")?,
         MessageSigner::new(&session_sk, TEST_NETWORK_ID),
     )?;
@@ -274,4 +275,29 @@ fn test_payload_signed_for_another_overlay_is_rejected() {
 
     assert!(!payload.verify(TEST_NETWORK_ID + 1));
     assert!(!payload.transaction.verify(TEST_NETWORK_ID + 1));
+}
+
+#[test]
+fn test_transaction_sequence_is_inside_both_signature_transcripts() {
+    let next_hop = SecretKey::random().address().into();
+    let mut payload = new_test_payload(next_hop);
+    assert!(payload.verify(TEST_NETWORK_ID));
+    assert!(payload.transaction.verify(TEST_NETWORK_ID));
+
+    payload.transaction.sequence = payload.transaction.sequence.saturating_add(1);
+    assert!(!payload.transaction.verify(TEST_NETWORK_ID));
+    assert!(!payload.verify(TEST_NETWORK_ID));
+}
+
+#[test]
+fn test_unprefixed_transaction_shape_is_rejected_by_hard_cutover() -> Result<()> {
+    let next_hop = SecretKey::random().address().into();
+    let payload = new_test_payload(next_hop);
+    let legacy_wire = rings_codec::serialize(&payload).map_err(Error::CodecSerialize)?;
+
+    assert!(matches!(
+        MessagePayload::from_wire(&legacy_wire),
+        Err(Error::LegacyTransactionWireFormat)
+    ));
+    Ok(())
 }

--- a/crates/core/src/message/replay.rs
+++ b/crates/core/src/message/replay.rs
@@ -452,6 +452,7 @@ mod tests {
         TransactionDigest::new([value; 32])
     }
 
+    #[cfg(not(target_family = "wasm"))]
     fn stream(destination: Did) -> StreamKey {
         StreamKey::new(7, SecretKey::random().address().into(), destination)
     }
@@ -564,6 +565,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(target_family = "wasm"))]
     #[tokio::test]
     async fn sender_allocators_are_independent_per_destination() -> Result<()> {
         let origin: Did = SecretKey::random().address().into();
@@ -579,6 +581,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(target_family = "wasm"))]
     #[tokio::test]
     async fn sender_and_receiver_state_survive_runtime_recreation() -> Result<()> {
         let destination: Did = SecretKey::random().address().into();
@@ -601,6 +604,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(target_family = "wasm"))]
     #[tokio::test]
     async fn counter_exhaustion_fails_closed() -> Result<()> {
         let key = stream(SecretKey::random().address().into());
@@ -619,6 +623,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(target_family = "wasm"))]
     #[tokio::test]
     async fn load_failure_fails_closed_and_is_counted() {
         let runtime = TransactionReplay::new(Box::new(FailingStorage));
@@ -634,6 +639,7 @@ mod tests {
         assert_eq!(runtime.counters().persistence_failure, 1);
     }
 
+    #[cfg(not(target_family = "wasm"))]
     #[tokio::test]
     async fn store_failure_fails_closed_before_admission_and_is_counted() {
         let runtime = TransactionReplay::new(Box::new(StoreFailingStorage));
@@ -649,6 +655,7 @@ mod tests {
         assert_eq!(runtime.counters().persistence_failure, 1);
     }
 
+    #[cfg(not(target_family = "wasm"))]
     #[tokio::test]
     async fn new_sender_stream_fails_closed_at_the_table_bound() -> Result<()> {
         assert_eq!(TRANSACTION_REPLAY_STREAM_CAPACITY, 4096);
@@ -672,8 +679,10 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(target_family = "wasm"))]
     struct FailingStorage;
 
+    #[cfg(not(target_family = "wasm"))]
     #[async_trait::async_trait]
     impl KvStorageInterface<ReplaySnapshot> for FailingStorage {
         async fn get(&self, _key: &str) -> Result<Option<ReplaySnapshot>> {
@@ -701,8 +710,10 @@ mod tests {
         }
     }
 
+    #[cfg(not(target_family = "wasm"))]
     struct StoreFailingStorage;
 
+    #[cfg(not(target_family = "wasm"))]
     #[async_trait::async_trait]
     impl KvStorageInterface<ReplaySnapshot> for StoreFailingStorage {
         async fn get(&self, _key: &str) -> Result<Option<ReplaySnapshot>> {
@@ -730,8 +741,10 @@ mod tests {
         }
     }
 
+    #[cfg(not(target_family = "wasm"))]
     struct SharedStorage(std::sync::Arc<crate::storage::MemStorage<ReplaySnapshot>>);
 
+    #[cfg(not(target_family = "wasm"))]
     #[async_trait::async_trait]
     impl KvStorageInterface<ReplaySnapshot> for SharedStorage {
         async fn get(&self, key: &str) -> Result<Option<ReplaySnapshot>> {

--- a/crates/core/src/message/replay.rs
+++ b/crates/core/src/message/replay.rs
@@ -1,0 +1,761 @@
+//! Destination-scoped replay protection for signed transactions.
+//!
+//! The stream identity is `(network_id, origin account DID, destination DID)`. A receiver keeps
+//! a fixed-width window per stream, so delivery may be reordered within the window without
+//! turning a normal gap into an omission claim. The state transition is pure in [`observe`];
+//! [`TransactionReplay`] is the effect boundary that serializes transitions and persists an
+//! admitted state before returning it to the inbound dispatcher.
+//!
+//! Persistence is one versioned snapshot under one storage key. Sender and receiver tables each
+//! have a hard stream-count bound and never evict: once the bound is reached, a new stream fails
+//! closed. Existing stream records remain durable until an operator explicitly removes the
+//! replay store. Deleting that store deletes the corresponding replay guarantee.
+
+use std::collections::BTreeMap;
+use std::num::NonZeroU64;
+use std::ops::RangeInclusive;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+use futures::lock::Mutex;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::dht::Did;
+use crate::error::Error;
+use crate::error::Result;
+use crate::storage::KvStorageInterface;
+
+/// Number of out-of-order sequence slots retained for one destination-scoped stream.
+pub const TRANSACTION_REPLAY_WINDOW: usize = 32;
+const TRANSACTION_REPLAY_WINDOW_U64: u64 = 32;
+const TRANSACTION_REPLAY_BACKTRACK: u64 = 31;
+/// Maximum sender streams and maximum receiver streams retained by one runtime.
+pub const TRANSACTION_REPLAY_STREAM_CAPACITY: usize = 4096;
+const TRANSACTION_REPLAY_SNAPSHOT_KEY: &str = "rings-core:transaction-replay:v2";
+
+/// A destination-scoped transaction stream.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct StreamKey {
+    /// Overlay in which the transaction signature is valid.
+    pub network_id: u32,
+    /// Account DID recovered from the transaction's delegated session.
+    pub origin_account: Did,
+    /// Final logical destination of the transaction.
+    pub destination: Did,
+}
+
+impl StreamKey {
+    /// Name one account-to-destination stream inside an overlay.
+    pub const fn new(network_id: u32, origin_account: Did, destination: Did) -> Self {
+        Self {
+            network_id,
+            origin_account,
+            destination,
+        }
+    }
+}
+
+/// Digest of one exact signed transaction.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct TransactionDigest(pub(crate) [u8; 32]);
+
+impl TransactionDigest {
+    /// Construct a digest from its canonical 32-byte representation.
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Return the canonical digest bytes.
+    pub const fn into_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+/// The two exact signed-transaction digests retained for a sequence fork.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TransactionForkEvidence {
+    /// Digest already retained for the sequence.
+    pub accepted: TransactionDigest,
+    /// Digest presented by the conflicting transaction.
+    pub incoming: TransactionDigest,
+}
+
+/// Fixed-width accepted-sequence window for one stream.
+///
+/// `accepted.last()` is sequence `high`; preceding slots descend toward
+/// `high.saturating_sub(31)`. Slots below sequence zero are necessarily empty.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SequenceState {
+    high: u64,
+    accepted: [Option<TransactionDigest>; TRANSACTION_REPLAY_WINDOW],
+}
+
+impl SequenceState {
+    fn first(sequence: u64, digest: TransactionDigest) -> Self {
+        let mut accepted = [None; TRANSACTION_REPLAY_WINDOW];
+        if let Some(slot) = accepted.last_mut() {
+            *slot = Some(digest);
+        }
+        Self {
+            high: sequence,
+            accepted,
+        }
+    }
+
+    /// Highest sequence observed for this stream.
+    pub const fn high(&self) -> u64 {
+        self.high
+    }
+
+    /// Lowest sequence whose digest may still be retained.
+    pub const fn retained_min(&self) -> u64 {
+        self.high.saturating_sub(TRANSACTION_REPLAY_BACKTRACK)
+    }
+
+    fn is_valid(&self) -> bool {
+        let retained_slots = self
+            .high
+            .checked_add(1)
+            .and_then(|count| usize::try_from(count).ok())
+            .unwrap_or(TRANSACTION_REPLAY_WINDOW)
+            .min(TRANSACTION_REPLAY_WINDOW);
+        let unused_slots = TRANSACTION_REPLAY_WINDOW.saturating_sub(retained_slots);
+        self.accepted.iter().take(unused_slots).all(Option::is_none)
+            && self.accepted.last().is_some_and(Option::is_some)
+    }
+
+    fn advance(&mut self, sequence: u64, digest: TransactionDigest) {
+        let gap = sequence.saturating_sub(self.high);
+        if gap >= TRANSACTION_REPLAY_WINDOW_U64 {
+            self.accepted.fill(None);
+        } else if let Ok(gap) = usize::try_from(gap) {
+            self.accepted.rotate_left(gap);
+            let retained = TRANSACTION_REPLAY_WINDOW.saturating_sub(gap);
+            for slot in self.accepted.iter_mut().skip(retained) {
+                *slot = None;
+            }
+        }
+        self.high = sequence;
+        if let Some(slot) = self.accepted.last_mut() {
+            *slot = Some(digest);
+        }
+    }
+
+    fn observe_retained(&mut self, sequence: u64, digest: TransactionDigest) -> SequenceVerdict {
+        let distance = self.high.saturating_sub(sequence);
+        let Ok(distance) = usize::try_from(distance) else {
+            return SequenceVerdict::Stale {
+                retained_min: self.retained_min(),
+            };
+        };
+        let Some(index) = TRANSACTION_REPLAY_WINDOW.checked_sub(distance.saturating_add(1)) else {
+            return SequenceVerdict::Stale {
+                retained_min: self.retained_min(),
+            };
+        };
+        let Some(slot) = self.accepted.get_mut(index) else {
+            return SequenceVerdict::Stale {
+                retained_min: self.retained_min(),
+            };
+        };
+        match *slot {
+            None => {
+                *slot = Some(digest);
+                SequenceVerdict::Late
+            }
+            Some(accepted) if accepted == digest => SequenceVerdict::Replay,
+            Some(accepted) => SequenceVerdict::Fork {
+                accepted,
+                incoming: digest,
+            },
+        }
+    }
+}
+
+/// Typed result of observing one sequence and exact signed-transaction digest.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SequenceVerdict {
+    /// No retained state existed; this transaction established the stream baseline.
+    First,
+    /// The sequence advanced the high watermark, possibly across a normal delivery gap.
+    Advance,
+    /// The sequence filled an empty slot inside the retained reordering window.
+    Late,
+    /// The same exact signed transaction was already retained at this sequence.
+    Replay,
+    /// A different signed transaction was already retained at this sequence.
+    Fork {
+        /// Digest retained for the sequence.
+        accepted: TransactionDigest,
+        /// Digest presented by the new transaction.
+        incoming: TransactionDigest,
+    },
+    /// The sequence fell below the retained window.
+    Stale {
+        /// Lowest sequence that may still be retained.
+        retained_min: u64,
+    },
+}
+
+impl SequenceVerdict {
+    /// Whether this observation may cross the application dispatch boundary.
+    pub const fn permits_dispatch(self) -> bool {
+        matches!(self, Self::First | Self::Advance | Self::Late)
+    }
+}
+
+/// Apply the pure replay-window transition.
+///
+/// Transition shape: `Option<SequenceState> -> (sequence, digest) -> (SequenceState, verdict)`.
+/// Rejected observations return the original state unchanged.
+pub fn observe(
+    state: Option<SequenceState>,
+    sequence: u64,
+    digest: TransactionDigest,
+) -> (SequenceState, SequenceVerdict) {
+    let Some(mut state) = state else {
+        return (
+            SequenceState::first(sequence, digest),
+            SequenceVerdict::First,
+        );
+    };
+    if sequence > state.high {
+        state.advance(sequence, digest);
+        return (state, SequenceVerdict::Advance);
+    }
+    if sequence < state.retained_min() {
+        let retained_min = state.retained_min();
+        return (state, SequenceVerdict::Stale { retained_min });
+    }
+    let verdict = state.observe_retained(sequence, digest);
+    (state, verdict)
+}
+
+/// Versioned durable sender and receiver state.
+///
+/// Fields are private so only [`TransactionReplay`] can apply the capacity and persistence laws.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct ReplaySnapshot {
+    sender: BTreeMap<StreamKey, u64>,
+    receiver: BTreeMap<StreamKey, SequenceState>,
+}
+
+/// Storage accepted by the transaction replay runtime.
+#[cfg(all(feature = "wasm", target_family = "wasm"))]
+pub type ReplayStorage = Box<dyn KvStorageInterface<ReplaySnapshot>>;
+
+/// Storage accepted by the transaction replay runtime.
+#[cfg(not(all(feature = "wasm", target_family = "wasm")))]
+pub type ReplayStorage = Box<dyn KvStorageInterface<ReplaySnapshot> + Send + Sync>;
+
+/// Observable rejected-verdict and persistence-failure counters.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ReplayCounters {
+    /// Exact duplicate transactions rejected.
+    pub replay: u64,
+    /// Conflicting transactions at one sequence rejected.
+    pub fork: u64,
+    /// Transactions below the retained window rejected.
+    pub stale: u64,
+    /// Replay snapshot reads or writes that failed.
+    pub persistence_failure: u64,
+}
+
+#[derive(Default)]
+struct ReplayCounterState {
+    replay: AtomicU64,
+    fork: AtomicU64,
+    stale: AtomicU64,
+    persistence_failure: AtomicU64,
+}
+
+impl ReplayCounterState {
+    fn snapshot(&self) -> ReplayCounters {
+        ReplayCounters {
+            replay: self.replay.load(Ordering::Relaxed),
+            fork: self.fork.load(Ordering::Relaxed),
+            stale: self.stale.load(Ordering::Relaxed),
+            persistence_failure: self.persistence_failure.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Serialized sender allocator and receiver replay-window effect boundary.
+pub(crate) struct TransactionReplay {
+    storage: ReplayStorage,
+    snapshot: Mutex<Option<ReplaySnapshot>>,
+    counters: ReplayCounterState,
+}
+
+impl TransactionReplay {
+    /// Construct a replay runtime. The snapshot is loaded lazily on its first operation.
+    pub(crate) fn new(storage: ReplayStorage) -> Self {
+        Self {
+            storage,
+            snapshot: Mutex::new(None),
+            counters: ReplayCounterState::default(),
+        }
+    }
+
+    /// Current observable counters.
+    pub(crate) fn counters(&self) -> ReplayCounters {
+        self.counters.snapshot()
+    }
+
+    async fn load_snapshot<'a>(
+        &self,
+        slot: &'a mut Option<ReplaySnapshot>,
+    ) -> Result<&'a mut ReplaySnapshot> {
+        if slot.is_none() {
+            let loaded = match self.storage.get(TRANSACTION_REPLAY_SNAPSHOT_KEY).await {
+                Ok(snapshot) => snapshot.unwrap_or_default(),
+                Err(source) => {
+                    self.counters
+                        .persistence_failure
+                        .fetch_add(1, Ordering::Relaxed);
+                    return Err(Error::TransactionReplayPersistence {
+                        operation: "load",
+                        source: Box::new(source),
+                    });
+                }
+            };
+            if loaded.sender.len() > TRANSACTION_REPLAY_STREAM_CAPACITY
+                || loaded.receiver.len() > TRANSACTION_REPLAY_STREAM_CAPACITY
+                || loaded.receiver.values().any(|state| !state.is_valid())
+            {
+                self.counters
+                    .persistence_failure
+                    .fetch_add(1, Ordering::Relaxed);
+                return Err(Error::TransactionReplayStateInvalid);
+            }
+            *slot = Some(loaded);
+        }
+        slot.as_mut().ok_or(Error::TransactionReplayStateInvalid)
+    }
+
+    async fn persist(&self, snapshot: &ReplaySnapshot) -> Result<()> {
+        self.storage
+            .put(TRANSACTION_REPLAY_SNAPSHOT_KEY, snapshot)
+            .await
+            .map_err(|source| {
+                self.counters
+                    .persistence_failure
+                    .fetch_add(1, Ordering::Relaxed);
+                Error::TransactionReplayPersistence {
+                    operation: "store",
+                    source: Box::new(source),
+                }
+            })
+    }
+
+    /// Reserve and persist `count` sender sequences before returning the range to the signer.
+    pub(crate) async fn reserve(
+        &self,
+        key: StreamKey,
+        count: NonZeroU64,
+    ) -> Result<RangeInclusive<u64>> {
+        let mut slot = self.snapshot.lock().await;
+        let snapshot = self.load_snapshot(&mut slot).await?;
+        let previous = snapshot.sender.get(&key).copied();
+        if previous.is_none() && snapshot.sender.len() >= TRANSACTION_REPLAY_STREAM_CAPACITY {
+            return Err(Error::TransactionReplayStreamCapacityExceeded {
+                capacity: TRANSACTION_REPLAY_STREAM_CAPACITY,
+            });
+        }
+        let first = match previous {
+            Some(last) => last
+                .checked_add(1)
+                .ok_or(Error::TransactionSequenceExhausted { key })?,
+            None => 0,
+        };
+        let last = first
+            .checked_add(count.get().saturating_sub(1))
+            .ok_or(Error::TransactionSequenceExhausted { key })?;
+        snapshot.sender.insert(key, last);
+        if let Err(error) = self.persist(snapshot).await {
+            match previous {
+                Some(previous) => {
+                    snapshot.sender.insert(key, previous);
+                }
+                None => {
+                    snapshot.sender.remove(&key);
+                }
+            }
+            return Err(error);
+        }
+        Ok(first..=last)
+    }
+
+    /// Persist one receiver transition before allowing final-destination dispatch.
+    pub(crate) async fn admit(
+        &self,
+        key: StreamKey,
+        sequence: u64,
+        digest: TransactionDigest,
+    ) -> Result<SequenceVerdict> {
+        let mut slot = self.snapshot.lock().await;
+        let snapshot = self.load_snapshot(&mut slot).await?;
+        let previous = snapshot.receiver.get(&key).cloned();
+        if previous.is_none() && snapshot.receiver.len() >= TRANSACTION_REPLAY_STREAM_CAPACITY {
+            return Err(Error::TransactionReplayStreamCapacityExceeded {
+                capacity: TRANSACTION_REPLAY_STREAM_CAPACITY,
+            });
+        }
+        let (next, verdict) = observe(previous.clone(), sequence, digest);
+        match verdict {
+            SequenceVerdict::First | SequenceVerdict::Advance | SequenceVerdict::Late => {
+                snapshot.receiver.insert(key, next);
+                if let Err(error) = self.persist(snapshot).await {
+                    match previous {
+                        Some(previous) => {
+                            snapshot.receiver.insert(key, previous);
+                        }
+                        None => {
+                            snapshot.receiver.remove(&key);
+                        }
+                    }
+                    return Err(error);
+                }
+                Ok(verdict)
+            }
+            SequenceVerdict::Replay => {
+                self.counters.replay.fetch_add(1, Ordering::Relaxed);
+                Err(Error::TransactionReplay { key, sequence })
+            }
+            SequenceVerdict::Fork { accepted, incoming } => {
+                self.counters.fork.fetch_add(1, Ordering::Relaxed);
+                Err(Error::TransactionSequenceFork {
+                    key,
+                    sequence,
+                    evidence: Box::new(TransactionForkEvidence { accepted, incoming }),
+                })
+            }
+            SequenceVerdict::Stale { retained_min } => {
+                self.counters.stale.fetch_add(1, Ordering::Relaxed);
+                Err(Error::TransactionSequenceStale {
+                    key,
+                    sequence,
+                    retained_min,
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ecc::SecretKey;
+
+    fn digest(value: u8) -> TransactionDigest {
+        TransactionDigest::new([value; 32])
+    }
+
+    fn stream(destination: Did) -> StreamKey {
+        StreamKey::new(7, SecretKey::random().address().into(), destination)
+    }
+
+    #[test]
+    fn duplicate_late_stale_fork_and_gap_transitions_are_typed() {
+        let (state, first) = observe(None, 10, digest(1));
+        assert_eq!(first, SequenceVerdict::First);
+
+        let (state, advanced) = observe(Some(state), 12, digest(2));
+        assert_eq!(advanced, SequenceVerdict::Advance);
+
+        let (state, late) = observe(Some(state), 11, digest(3));
+        assert_eq!(late, SequenceVerdict::Late);
+
+        let (state, replay) = observe(Some(state), 11, digest(3));
+        assert_eq!(replay, SequenceVerdict::Replay);
+
+        let (state, fork) = observe(Some(state), 11, digest(4));
+        assert_eq!(fork, SequenceVerdict::Fork {
+            accepted: digest(3),
+            incoming: digest(4),
+        });
+
+        let (state, gap) = observe(Some(state), 100, digest(5));
+        assert_eq!(gap, SequenceVerdict::Advance);
+        let (_, stale) = observe(Some(state), 68, digest(6));
+        assert_eq!(stale, SequenceVerdict::Stale { retained_min: 69 });
+    }
+
+    #[test]
+    fn transition_is_deterministic_for_the_same_state_and_input() {
+        let (state, _) = observe(None, 4, digest(1));
+        assert_eq!(
+            observe(Some(state.clone()), 7, digest(2)),
+            observe(Some(state), 7, digest(2))
+        );
+    }
+
+    #[test]
+    fn destinations_advance_independently() {
+        let origin: Did = SecretKey::random().address().into();
+        let a: Did = SecretKey::random().address().into();
+        let b: Did = SecretKey::random().address().into();
+        let mut states = BTreeMap::new();
+        for (destination, sequence) in [(a, 8), (b, 0), (a, 10), (b, 1)] {
+            let key = StreamKey::new(1, origin, destination);
+            let previous = states.remove(&key);
+            let (next, verdict) = observe(previous, sequence, digest(sequence as u8));
+            assert!(verdict.permits_dispatch());
+            states.insert(key, next);
+        }
+        assert_eq!(
+            states
+                .get(&StreamKey::new(1, origin, a))
+                .map(SequenceState::high),
+            Some(10)
+        );
+        assert_eq!(
+            states
+                .get(&StreamKey::new(1, origin, b))
+                .map(SequenceState::high),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn every_slot_in_the_bounded_reordering_window_is_admitted_once() {
+        let high = TRANSACTION_REPLAY_BACKTRACK.saturating_add(50);
+        let (mut state, verdict) = observe(None, high, digest(0));
+        assert_eq!(verdict, SequenceVerdict::First);
+        for sequence in state.retained_min()..high {
+            let (next, verdict) = observe(Some(state), sequence, digest(sequence as u8));
+            assert_eq!(verdict, SequenceVerdict::Late);
+            state = next;
+        }
+        let below = state.retained_min().saturating_sub(1);
+        let (_, verdict) = observe(Some(state), below, digest(255));
+        assert_eq!(verdict, SequenceVerdict::Stale {
+            retained_min: below.saturating_add(1),
+        });
+    }
+
+    #[test]
+    fn session_rotation_preserves_the_account_destination_stream_key() -> Result<()> {
+        let account = SecretKey::random();
+        let first_session = crate::session::SessionSk::new_with_seckey(&account)?;
+        let rotated_session = crate::session::SessionSk::new_with_seckey(&account)?;
+        let destination: Did = SecretKey::random().address().into();
+        let first = crate::message::Transaction::new(
+            destination,
+            uuid::Uuid::new_v4(),
+            0,
+            crate::message::Message::custom(b"first")?,
+            crate::message::MessageSigner::new(&first_session, 7),
+        )?;
+        let rotated = crate::message::Transaction::new(
+            destination,
+            uuid::Uuid::new_v4(),
+            1,
+            crate::message::Message::custom(b"rotated")?,
+            crate::message::MessageSigner::new(&rotated_session, 7),
+        )?;
+
+        assert_ne!(
+            first_session.session().session_did(),
+            rotated_session.session().session_did()
+        );
+        assert_eq!(first.stream_key(7), rotated.stream_key(7));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sender_allocators_are_independent_per_destination() -> Result<()> {
+        let origin: Did = SecretKey::random().address().into();
+        let a: Did = SecretKey::random().address().into();
+        let b: Did = SecretKey::random().address().into();
+        let runtime = TransactionReplay::new(Box::new(crate::storage::MemStorage::new()));
+        let key_a = StreamKey::new(1, origin, a);
+        let key_b = StreamKey::new(1, origin, b);
+
+        assert_eq!(runtime.reserve(key_a, NonZeroU64::MIN).await?, 0..=0);
+        assert_eq!(runtime.reserve(key_b, NonZeroU64::MIN).await?, 0..=0);
+        assert_eq!(runtime.reserve(key_a, NonZeroU64::MIN).await?, 1..=1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sender_and_receiver_state_survive_runtime_recreation() -> Result<()> {
+        let destination: Did = SecretKey::random().address().into();
+        let key = stream(destination);
+        let storage = std::sync::Arc::new(crate::storage::MemStorage::new());
+        let first_runtime = TransactionReplay::new(Box::new(SharedStorage(storage.clone())));
+        assert_eq!(first_runtime.reserve(key, NonZeroU64::MIN).await?, 0..=0);
+        assert_eq!(
+            first_runtime.admit(key, 0, digest(1)).await?,
+            SequenceVerdict::First
+        );
+        drop(first_runtime);
+
+        let restarted = TransactionReplay::new(Box::new(SharedStorage(storage)));
+        assert_eq!(restarted.reserve(key, NonZeroU64::MIN).await?, 1..=1);
+        assert!(matches!(
+            restarted.admit(key, 0, digest(1)).await,
+            Err(Error::TransactionReplay { .. })
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn counter_exhaustion_fails_closed() -> Result<()> {
+        let key = stream(SecretKey::random().address().into());
+        let storage = crate::storage::MemStorage::new();
+        let runtime = TransactionReplay::new(Box::new(storage));
+        {
+            let mut slot = runtime.snapshot.lock().await;
+            let snapshot = runtime.load_snapshot(&mut slot).await?;
+            snapshot.sender.insert(key, u64::MAX);
+            runtime.persist(snapshot).await?;
+        }
+        assert!(matches!(
+            runtime.reserve(key, NonZeroU64::MIN).await,
+            Err(Error::TransactionSequenceExhausted { .. })
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn load_failure_fails_closed_and_is_counted() {
+        let runtime = TransactionReplay::new(Box::new(FailingStorage));
+        let key = stream(SecretKey::random().address().into());
+
+        assert!(matches!(
+            runtime.admit(key, 0, digest(1)).await,
+            Err(Error::TransactionReplayPersistence {
+                operation: "load",
+                ..
+            })
+        ));
+        assert_eq!(runtime.counters().persistence_failure, 1);
+    }
+
+    #[tokio::test]
+    async fn store_failure_fails_closed_before_admission_and_is_counted() {
+        let runtime = TransactionReplay::new(Box::new(StoreFailingStorage));
+        let key = stream(SecretKey::random().address().into());
+
+        assert!(matches!(
+            runtime.admit(key, 0, digest(1)).await,
+            Err(Error::TransactionReplayPersistence {
+                operation: "store",
+                ..
+            })
+        ));
+        assert_eq!(runtime.counters().persistence_failure, 1);
+    }
+
+    #[tokio::test]
+    async fn new_sender_stream_fails_closed_at_the_table_bound() -> Result<()> {
+        assert_eq!(TRANSACTION_REPLAY_STREAM_CAPACITY, 4096);
+        let runtime = TransactionReplay::new(Box::new(crate::storage::MemStorage::new()));
+        let destination = Did::from(1_u32);
+        {
+            let mut slot = runtime.snapshot.lock().await;
+            let snapshot = runtime.load_snapshot(&mut slot).await?;
+            for origin in 0_u32..4096 {
+                snapshot
+                    .sender
+                    .insert(StreamKey::new(1, Did::from(origin), destination), 0);
+            }
+            runtime.persist(snapshot).await?;
+        }
+        let new_key = StreamKey::new(1, Did::from(4097_u32), destination);
+        assert!(matches!(
+            runtime.reserve(new_key, NonZeroU64::MIN).await,
+            Err(Error::TransactionReplayStreamCapacityExceeded { capacity: 4096 })
+        ));
+        Ok(())
+    }
+
+    struct FailingStorage;
+
+    #[async_trait::async_trait]
+    impl KvStorageInterface<ReplaySnapshot> for FailingStorage {
+        async fn get(&self, _key: &str) -> Result<Option<ReplaySnapshot>> {
+            Err(Error::InvalidTransport)
+        }
+
+        async fn put(&self, _key: &str, _value: &ReplaySnapshot) -> Result<()> {
+            Err(Error::InvalidTransport)
+        }
+
+        async fn get_all(&self) -> Result<Vec<(String, ReplaySnapshot)>> {
+            Err(Error::InvalidTransport)
+        }
+
+        async fn remove(&self, _key: &str) -> Result<()> {
+            Err(Error::InvalidTransport)
+        }
+
+        async fn clear(&self) -> Result<()> {
+            Err(Error::InvalidTransport)
+        }
+
+        async fn count(&self) -> Result<u32> {
+            Err(Error::InvalidTransport)
+        }
+    }
+
+    struct StoreFailingStorage;
+
+    #[async_trait::async_trait]
+    impl KvStorageInterface<ReplaySnapshot> for StoreFailingStorage {
+        async fn get(&self, _key: &str) -> Result<Option<ReplaySnapshot>> {
+            Ok(None)
+        }
+
+        async fn put(&self, _key: &str, _value: &ReplaySnapshot) -> Result<()> {
+            Err(Error::InvalidTransport)
+        }
+
+        async fn get_all(&self) -> Result<Vec<(String, ReplaySnapshot)>> {
+            Ok(Vec::new())
+        }
+
+        async fn remove(&self, _key: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn clear(&self) -> Result<()> {
+            Ok(())
+        }
+
+        async fn count(&self) -> Result<u32> {
+            Ok(0)
+        }
+    }
+
+    struct SharedStorage(std::sync::Arc<crate::storage::MemStorage<ReplaySnapshot>>);
+
+    #[async_trait::async_trait]
+    impl KvStorageInterface<ReplaySnapshot> for SharedStorage {
+        async fn get(&self, key: &str) -> Result<Option<ReplaySnapshot>> {
+            self.0.get(key).await
+        }
+
+        async fn put(&self, key: &str, value: &ReplaySnapshot) -> Result<()> {
+            self.0.put(key, value).await
+        }
+
+        async fn get_all(&self) -> Result<Vec<(String, ReplaySnapshot)>> {
+            self.0.get_all().await
+        }
+
+        async fn remove(&self, key: &str) -> Result<()> {
+            self.0.remove(key).await
+        }
+
+        async fn clear(&self) -> Result<()> {
+            self.0.clear().await
+        }
+
+        async fn count(&self) -> Result<u32> {
+            self.0.count().await
+        }
+    }
+}

--- a/crates/core/src/message/replay.rs
+++ b/crates/core/src/message/replay.rs
@@ -234,11 +234,51 @@ pub fn observe(
 
 /// Versioned durable sender and receiver state.
 ///
-/// Fields are private so only [`TransactionReplay`] can apply the capacity and persistence laws.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+/// Fields are private so only the transaction replay runtime can apply the capacity and
+/// persistence laws. The Serde representation is an opaque Rings-codec byte sequence: browser
+/// storage therefore never exposes structured map keys or `u64` counters to JavaScript's JSON
+/// number and object-key restrictions.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ReplaySnapshot {
     sender: BTreeMap<StreamKey, u64>,
     receiver: BTreeMap<StreamKey, SequenceState>,
+}
+
+#[derive(Serialize)]
+struct ReplaySnapshotRef<'a> {
+    sender: &'a BTreeMap<StreamKey, u64>,
+    receiver: &'a BTreeMap<StreamKey, SequenceState>,
+}
+
+#[derive(Deserialize)]
+struct ReplaySnapshotWire {
+    sender: BTreeMap<StreamKey, u64>,
+    receiver: BTreeMap<StreamKey, SequenceState>,
+}
+
+impl Serialize for ReplaySnapshot {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where S: serde::Serializer {
+        let wire = ReplaySnapshotRef {
+            sender: &self.sender,
+            receiver: &self.receiver,
+        };
+        let encoded = rings_codec::serialize(&wire).map_err(serde::ser::Error::custom)?;
+        encoded.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ReplaySnapshot {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where D: serde::Deserializer<'de> {
+        let encoded = Vec::<u8>::deserialize(deserializer)?;
+        let wire: ReplaySnapshotWire =
+            rings_codec::deserialize(&encoded).map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            sender: wire.sender,
+            receiver: wire.receiver,
+        })
+    }
 }
 
 /// Storage accepted by the transaction replay runtime.
@@ -493,6 +533,23 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_encoding_preserves_structured_keys_and_full_width_sequences() {
+        let origin: Did = SecretKey::random().address().into();
+        let destination: Did = SecretKey::random().address().into();
+        let key = StreamKey::new(7, origin, destination);
+        let mut snapshot = ReplaySnapshot::default();
+        snapshot.sender.insert(key, u64::MAX);
+        snapshot
+            .receiver
+            .insert(key, SequenceState::first(u64::MAX, digest(9)));
+
+        let encoded = rings_codec::serialize(&snapshot).expect("snapshot encodes");
+        let decoded: ReplaySnapshot = rings_codec::deserialize(&encoded).expect("snapshot decodes");
+
+        assert_eq!(decoded, snapshot);
+    }
+
+    #[test]
     fn destinations_advance_independently() {
         let origin: Did = SecretKey::random().address().into();
         let a: Did = SecretKey::random().address().into();
@@ -677,6 +734,52 @@ mod tests {
             Err(Error::TransactionReplayStreamCapacityExceeded { capacity: 4096 })
         ));
         Ok(())
+    }
+
+    #[cfg(all(feature = "wasm", target_family = "wasm"))]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    async fn browser_storage_round_trip_retains_nonempty_replay_state() {
+        const STORAGE_NAME: &str = "rings-core/replay-snapshot-round-trip-v2";
+        let storage = crate::storage::idb::IdbStorage::new_with_cap_and_name(2, STORAGE_NAME)
+            .await
+            .expect("IndexedDB opens");
+        storage.clear().await.expect("IndexedDB clears");
+        let origin: Did = SecretKey::random().address().into();
+        let destination: Did = SecretKey::random().address().into();
+        let key = StreamKey::new(7, origin, destination);
+        let first = TransactionReplay::new(Box::new(storage));
+
+        assert_eq!(
+            first
+                .reserve(key, NonZeroU64::MIN)
+                .await
+                .expect("sender reservation persists"),
+            0..=0
+        );
+        assert_eq!(
+            first
+                .admit(key, u64::MAX, digest(1))
+                .await
+                .expect("receiver state persists"),
+            SequenceVerdict::First
+        );
+        drop(first);
+
+        let reopened = crate::storage::idb::IdbStorage::new_with_cap_and_name(2, STORAGE_NAME)
+            .await
+            .expect("IndexedDB reopens");
+        let restarted = TransactionReplay::new(Box::new(reopened));
+        assert_eq!(
+            restarted
+                .reserve(key, NonZeroU64::MIN)
+                .await
+                .expect("sender state reloads"),
+            1..=1
+        );
+        assert!(matches!(
+            restarted.admit(key, u64::MAX, digest(1)).await,
+            Err(Error::TransactionReplay { .. })
+        ));
     }
 
     #[cfg(not(target_family = "wasm"))]

--- a/crates/core/src/swarm/builder.rs
+++ b/crates/core/src/swarm/builder.rs
@@ -13,6 +13,9 @@ use crate::dht::VirtualNodeConfig;
 use crate::dht::DEFAULT_FINGER_TABLE_SIZE;
 use crate::dht::DEFAULT_STORAGE_VIRTUAL_POSITIONS_PER_OWNER;
 use crate::measure::MeasureImpl;
+use crate::message::ReplaySnapshot;
+use crate::message::ReplayStorage;
+use crate::message::TransactionReplay;
 use crate::session::SessionSk;
 use crate::swarm::callback::SharedSwarmCallback;
 use crate::swarm::callback::SwarmCallback;
@@ -37,6 +40,7 @@ pub struct SwarmBuilder {
     dht_virtual_nodes: u16,
     reassembly_limits: ReassemblyLimits,
     dht_storage: EntryStorage,
+    replay_storage: ReplayStorage,
     session_sk: SessionSk,
     session_ttl: Option<usize>,
     measure: Option<MeasureImpl>,
@@ -62,6 +66,7 @@ impl SwarmBuilder {
             dht_virtual_nodes: DEFAULT_STORAGE_VIRTUAL_POSITIONS_PER_OWNER,
             reassembly_limits: default_reassembly_limits(),
             dht_storage,
+            replay_storage: Box::new(crate::storage::MemStorage::<ReplaySnapshot>::new()),
             session_sk,
             session_ttl: None,
             measure: None,
@@ -143,6 +148,12 @@ impl SwarmBuilder {
         self
     }
 
+    /// Set the durable sender-sequence and receiver replay-window storage.
+    pub fn replay_storage(mut self, storage: ReplayStorage) -> Self {
+        self.replay_storage = storage;
+        self
+    }
+
     /// Try build for `Swarm`.
     pub fn build(self) -> Swarm {
         let dht_did = self.session_sk.account_did();
@@ -174,6 +185,7 @@ impl SwarmBuilder {
             self.session_sk,
             dht.clone(),
             self.measure,
+            Arc::new(TransactionReplay::new(self.replay_storage)),
             SwarmTransportSettings::new(
                 self.dht_storage_redundancy,
                 storage_virtual_node_config,

--- a/crates/core/src/swarm/callback/inbound.rs
+++ b/crates/core/src/swarm/callback/inbound.rs
@@ -784,6 +784,7 @@ pub(super) async fn deliver_local(
     pipeline: &LogicalInbound,
     payload: &MessagePayload,
 ) -> Result<()> {
+    pipeline.admit_final_transaction(payload).await?;
     validate_payload(pipeline, None, payload)
         .await
         .map_err(inbound_failure_error)?;
@@ -802,6 +803,16 @@ async fn validate_event(
         .map_err(InboundFailure::Core)?
     {
         return Ok(InboundValidation::AcknowledgeDrop);
+    }
+    // Chunk envelopes are transport framing, not logical transactions. Their existing bounded
+    // reassembly/tombstone state handles envelope replay; the reassembled payload returns through
+    // this function on its logical lane and is admitted exactly once here.
+    if event.lane() != InboundLane::Reassembly {
+        processor
+            .logical
+            .admit_final_transaction(&event.payload)
+            .await
+            .map_err(InboundFailure::Core)?;
     }
     validate_payload(&processor.logical, event.peer, &event.payload).await?;
     let still_admitted = processor

--- a/crates/core/src/swarm/callback/logical.rs
+++ b/crates/core/src/swarm/callback/logical.rs
@@ -82,10 +82,119 @@ impl LogicalInbound {
         payload.transaction.destination == self.transport.dht.did
     }
 
+    pub(super) async fn admit_final_transaction(
+        &self,
+        payload: &MessagePayload,
+    ) -> crate::error::Result<()> {
+        if self.is_local_destination(payload) {
+            self.transport
+                .admit_transaction_replay(&payload.transaction)
+                .await?;
+        }
+        Ok(())
+    }
+
     pub(super) async fn on_inbound(
         &self,
         payload: &MessagePayload,
     ) -> std::result::Result<(), CallbackError> {
         self.callback.on_inbound(payload).await
+    }
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::ecc::SecretKey;
+    use crate::error::Error;
+    use crate::message::Message;
+    use crate::message::MessageSigner;
+    use crate::session::SessionSk;
+    use crate::storage::MemStorage;
+    use crate::swarm::SwarmBuilder;
+    use crate::tests::TEST_NETWORK_ID;
+
+    #[derive(Default)]
+    struct ObservedCallback {
+        validations: AtomicUsize,
+        inbounds: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::swarm::callback::SwarmCallback for ObservedCallback {
+        async fn on_validate(
+            &self,
+            _payload: &MessagePayload,
+        ) -> std::result::Result<(), CallbackError> {
+            self.validations.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        async fn on_inbound(
+            &self,
+            _payload: &MessagePayload,
+        ) -> std::result::Result<(), CallbackError> {
+            self.inbounds.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    fn payload(
+        destination: crate::dht::Did,
+        sequence: u64,
+    ) -> crate::error::Result<MessagePayload> {
+        let sender = SessionSk::new_with_seckey(&SecretKey::random())?;
+        MessagePayload::new_send_with_sequence(
+            Message::custom(b"replay boundary")?,
+            MessageSigner::new(&sender, TEST_NETWORK_ID),
+            destination,
+            destination,
+            sequence,
+        )
+    }
+
+    #[tokio::test]
+    async fn final_destination_persists_before_validation_and_rejects_duplicate_dispatch() {
+        let local = SessionSk::new_with_seckey(&SecretKey::random()).expect("local session");
+        let callback = Arc::new(ObservedCallback::default());
+        let swarm = SwarmBuilder::new(TEST_NETWORK_ID, "", Box::new(MemStorage::new()), local)
+            .callback(callback.clone())
+            .build();
+        let delivery = LocalDelivery::new(swarm.transport.clone(), callback.clone());
+        let payload = payload(swarm.did(), 0).expect("payload");
+
+        delivery.deliver(&payload).await.expect("first delivery");
+        assert!(matches!(
+            delivery.deliver(&payload).await,
+            Err(Error::TransactionReplay { .. })
+        ));
+        assert_eq!(callback.validations.load(Ordering::Relaxed), 1);
+        assert_eq!(callback.inbounds.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn intermediate_relay_does_not_create_origin_replay_state() {
+        let local = SessionSk::new_with_seckey(&SecretKey::random()).expect("local session");
+        let callback = Arc::new(ObservedCallback::default());
+        let swarm = SwarmBuilder::new(TEST_NETWORK_ID, "", Box::new(MemStorage::new()), local)
+            .callback(callback.clone())
+            .build();
+        let logical = LogicalInbound::new(swarm.transport.clone(), callback);
+        let remote_destination = SecretKey::random().address().into();
+        let payload = payload(remote_destination, 0).expect("payload");
+
+        logical
+            .admit_final_transaction(&payload)
+            .await
+            .expect("first relay pass");
+        logical
+            .admit_final_transaction(&payload)
+            .await
+            .expect("second relay pass");
+        assert_eq!(swarm.transaction_replay_counters(), Default::default());
     }
 }

--- a/crates/core/src/swarm/callback/processor.rs
+++ b/crates/core/src/swarm/callback/processor.rs
@@ -192,7 +192,7 @@ impl InboundProcessor {
             }
         };
         let network_id = self.logical.transport.network_id;
-        if !(payload.verify(network_id) && payload.transaction.verify(network_id)) {
+        if !payload.verify_transaction_and_payload(network_id) {
             log_inbound_verification_failure(peer, &payload, msg.len());
             self.record_receive_failure(peer, authentication).await;
             return Err(crate::error::Error::InvalidMessage(
@@ -245,7 +245,7 @@ pub(super) fn prepare_transport_frame(
     bytes: &[u8],
 ) -> crate::error::Result<PreparedInboundFrame> {
     let payload = MessagePayload::from_wire(bytes)?;
-    if !(payload.transaction.verify(network_id) && payload.verify(network_id)) {
+    if !payload.verify_transaction_and_payload(network_id) {
         log_inbound_verification_failure(peer, &payload, bytes.len());
         return Err(crate::error::Error::InvalidMessage(
             "message verification failed or message expired".to_string(),

--- a/crates/core/src/swarm/mod.rs
+++ b/crates/core/src/swarm/mod.rs
@@ -30,6 +30,7 @@ use crate::message::Message;
 use crate::message::MessagePayload;
 use crate::message::MessageVerificationExt;
 use crate::message::PayloadSender;
+use crate::message::ReplayCounters;
 use crate::swarm::callback::SharedSwarmCallback;
 use crate::swarm::callback::SwarmCallbackSlot;
 use crate::swarm::inbox::SwarmInboxDelivery;
@@ -190,6 +191,11 @@ impl Swarm {
     pub async fn inspect(&self) -> SwarmInspect {
         SwarmInspect::inspect(self).await
     }
+
+    /// Return destination-scoped transaction replay counters.
+    pub fn transaction_replay_counters(&self) -> ReplayCounters {
+        self.transport.replay_counters()
+    }
 }
 
 impl Swarm {
@@ -203,12 +209,10 @@ impl Swarm {
 
         // This payload has fake next_hop.
         // The invoker should fix it before sending.
-        let payload = MessagePayload::new_send(
-            Message::ConnectNodeSend(offer_msg),
-            self.transport.message_signer(),
-            self.did(),
-            peer,
-        )?;
+        let payload = self
+            .transport
+            .signed_payload(Message::ConnectNodeSend(offer_msg), self.did(), peer)
+            .await?;
 
         Ok(payload)
     }
@@ -225,6 +229,14 @@ impl Swarm {
                 "Should be ConnectNodeSend".to_string(),
             ));
         };
+        if offer_payload.transaction.destination != self.did() {
+            return Err(Error::InvalidMessage(
+                "ConnectNodeSend destination does not match this node".to_string(),
+            ));
+        }
+        self.transport
+            .admit_transaction_replay(&offer_payload.transaction)
+            .await?;
 
         let peer = offer_payload.transaction.origin();
         let answer_msg = self
@@ -234,12 +246,10 @@ impl Swarm {
 
         // This payload has fake next_hop.
         // The invoker should fix it before sending.
-        let answer_payload = MessagePayload::new_send(
-            Message::ConnectNodeReport(answer_msg),
-            self.transport.message_signer(),
-            self.did(),
-            self.did(),
-        )?;
+        let answer_payload = self
+            .transport
+            .signed_payload(Message::ConnectNodeReport(answer_msg), self.did(), peer)
+            .await?;
 
         Ok(answer_payload)
     }
@@ -256,6 +266,14 @@ impl Swarm {
                 "Should be ConnectNodeReport".to_string(),
             ));
         };
+        if answer_payload.transaction.destination != self.did() {
+            return Err(Error::InvalidMessage(
+                "ConnectNodeReport destination does not match this node".to_string(),
+            ));
+        }
+        self.transport
+            .admit_transaction_replay(&answer_payload.transaction)
+            .await?;
 
         let peer = answer_payload.transaction.signer();
         self.transport.accept_remote_connection(peer, msg).await

--- a/crates/core/src/swarm/mod.rs
+++ b/crates/core/src/swarm/mod.rs
@@ -220,7 +220,7 @@ impl Swarm {
     /// Answer the offer of remote connection. This function will verify the answer payload and
     /// will wrap the answer inside a payload with verification.
     pub async fn answer_offer(&self, offer_payload: MessagePayload) -> Result<MessagePayload> {
-        if !offer_payload.verify(self.network_id()) {
+        if !offer_payload.verify_transaction_and_payload(self.network_id()) {
             return Err(Error::VerifySignatureFailed);
         }
 
@@ -257,7 +257,7 @@ impl Swarm {
     /// Accept the answer of remote connection. This function will verify the answer payload and
     /// will return its did with the connection.
     pub async fn accept_answer(&self, answer_payload: MessagePayload) -> Result<()> {
-        if !answer_payload.verify(self.network_id()) {
+        if !answer_payload.verify_transaction_and_payload(self.network_id()) {
             return Err(Error::VerifySignatureFailed);
         }
 

--- a/crates/core/src/swarm/transport.rs
+++ b/crates/core/src/swarm/transport.rs
@@ -51,6 +51,7 @@ use crate::message::ConnectNodeSend;
 use crate::message::DhtProtocolMode;
 use crate::message::Message;
 use crate::message::PayloadSender;
+use crate::message::TransactionReplay;
 use crate::session::Session;
 use crate::session::SessionSk;
 use crate::swarm::callback::InnerSwarmCallback;
@@ -68,6 +69,7 @@ mod readiness;
 mod retention;
 mod storage_lookup;
 mod storage_sync;
+mod transaction_replay;
 #[cfg(all(test, not(target_family = "wasm")))]
 pub(crate) use storage_sync::StorageSyncBatch;
 #[cfg(all(test, not(target_family = "wasm")))]
@@ -144,6 +146,7 @@ pub struct SwarmTransport {
     outbound_schedulers: OutboundSchedulers,
     measured_disconnects: Mutex<MeasuredDisconnectMap>,
     measure: Option<MeasureImpl>,
+    transaction_replay: Arc<TransactionReplay>,
 }
 
 type MeasuredDisconnectMap = BTreeMap<Did, MeasuredDisconnect>;
@@ -234,6 +237,7 @@ impl SwarmTransport {
         session_sk: SessionSk,
         dht: Arc<PeerRing>,
         measure: Option<MeasureImpl>,
+        transaction_replay: Arc<TransactionReplay>,
         settings: SwarmTransportSettings,
     ) -> Self {
         let lifecycle_bounds = self::retention::lifecycle_bounds(dht.successors().capacity());
@@ -266,6 +270,7 @@ impl SwarmTransport {
             outbound_schedulers: OutboundSchedulers::new(measure.clone()),
             measured_disconnects: Mutex::new(BTreeMap::new()),
             measure,
+            transaction_replay,
         }
     }
 

--- a/crates/core/src/swarm/transport/delivery.rs
+++ b/crates/core/src/swarm/transport/delivery.rs
@@ -402,9 +402,15 @@ pub(super) fn frame_chunk(
     signer: MessageSigner<&SessionSk>,
     did: Did,
     chunk: Chunk,
+    sequence: u64,
 ) -> Result<Bytes> {
-    let transaction =
-        Transaction::new(did, crate::utils::new_uuid(), Message::Chunk(chunk), signer)?;
+    let transaction = Transaction::new(
+        did,
+        crate::utils::new_uuid(),
+        sequence,
+        Message::Chunk(chunk),
+        signer,
+    )?;
     let relay = MessageRelay::new(did, did, HopBudget::EXHAUSTED);
     let payload = MessagePayload::new(transaction, signer, relay)?;
     #[cfg(all(test, feature = "dummy", not(target_family = "wasm")))]

--- a/crates/core/src/swarm/transport/outbound.rs
+++ b/crates/core/src/swarm/transport/outbound.rs
@@ -90,6 +90,7 @@ use queue::TransferQueues;
 pub(crate) use queue::OUTBOUND_CONTROL_BURST;
 use spawn::spawn_worker;
 pub(super) use transfer::ChunkFrames;
+pub(super) use transfer::ChunkedFrameSource;
 use transfer::FinalTransferResult;
 pub(super) use transfer::OutboundTransfer;
 pub(super) use transfer::OutboundTransferRoute;

--- a/crates/core/src/swarm/transport/outbound/transfer.rs
+++ b/crates/core/src/swarm/transport/outbound/transfer.rs
@@ -33,17 +33,38 @@ pub(in crate::swarm::transport) type ChunkFrames = Box<dyn Iterator<Item = Chunk
 
 enum FrameSource {
     Whole(Option<Bytes>),
-    Chunked {
-        signer: MessageSigner<SessionSk>,
+    Chunked(ChunkedFrameSource),
+}
+
+pub(in crate::swarm::transport) struct ChunkedFrameSource {
+    signer: MessageSigner<SessionSk>,
+    chunks: ChunkFrames,
+    logical_sequence: u64,
+}
+
+impl ChunkedFrameSource {
+    pub(in crate::swarm::transport) fn new(
+        signer: MessageSigner<&SessionSk>,
         chunks: ChunkFrames,
-    },
+        logical_sequence: u64,
+    ) -> Self {
+        Self {
+            signer: signer.owned(),
+            chunks,
+            logical_sequence,
+        }
+    }
 }
 
 impl FrameSource {
     fn next_frame(&mut self, did: Did) -> Result<Option<(Bytes, &'static str)>> {
         match self {
             Self::Whole(frame) => Ok(frame.take().map(|bytes| (bytes, "whole_message"))),
-            Self::Chunked { signer, chunks } => {
+            Self::Chunked(ChunkedFrameSource {
+                signer,
+                chunks,
+                logical_sequence,
+            }) => {
                 let Some(chunk) = chunks.next() else {
                     return Ok(None);
                 };
@@ -53,7 +74,8 @@ impl FrameSource {
                 } else {
                     "chunked_tail"
                 };
-                frame_chunk(signer.by_ref(), did, chunk).map(|bytes| Some((bytes, context)))
+                frame_chunk(signer.by_ref(), did, chunk, *logical_sequence)
+                    .map(|bytes| Some((bytes, context)))
             }
         }
     }
@@ -176,8 +198,7 @@ impl OutboundTransfer {
     /// signing authority for the whole transfer.
     pub(in crate::swarm::transport) fn chunked(
         route: OutboundTransferRoute,
-        signer: MessageSigner<&SessionSk>,
-        chunks: ChunkFrames,
+        source: ChunkedFrameSource,
         useful_bytes: u64,
         completion: OutboundCompletion,
         stop: StopToken,
@@ -185,10 +206,7 @@ impl OutboundTransfer {
     ) -> (Self, oneshot::Receiver<Result<SendCompletionOutcome>>) {
         Self::new(
             route,
-            FrameSource::Chunked {
-                signer: signer.owned(),
-                chunks,
-            },
+            FrameSource::Chunked(source),
             useful_bytes,
             completion,
             stop,

--- a/crates/core/src/swarm/transport/payload_send.rs
+++ b/crates/core/src/swarm/transport/payload_send.rs
@@ -12,6 +12,7 @@ use super::delivery::terminate_accepted_connection;
 use super::delivery::ChunkSendPermit;
 use super::delivery::SendCompletionOutcome;
 use super::outbound::ChunkFrames;
+use super::outbound::ChunkedFrameSource;
 use super::outbound::DetachedAdmission;
 use super::outbound::DetachedAdmissionCancel;
 use super::outbound::OutboundCompletion;
@@ -92,6 +93,7 @@ struct FramedOutboundTransfer {
 }
 
 struct OutboundTransferProperties {
+    logical_sequence: u64,
     useful_bytes: u64,
     completion: OutboundCompletion,
     stop: StopToken,
@@ -621,6 +623,7 @@ impl SwarmTransport {
             data,
             plan,
             OutboundTransferProperties {
+                logical_sequence: payload.transaction.sequence,
                 useful_bytes,
                 completion,
                 stop,
@@ -698,6 +701,7 @@ impl SwarmTransport {
         properties: OutboundTransferProperties,
     ) -> FramedOutboundTransfer {
         let OutboundTransferProperties {
+            logical_sequence,
             useful_bytes,
             completion,
             stop,
@@ -716,8 +720,7 @@ impl SwarmTransport {
                 let chunks: ChunkFrames = Box::new(ChunkList::stream(data, chunk_size));
                 OutboundTransfer::chunked(
                     route,
-                    self.message_signer(),
-                    chunks,
+                    ChunkedFrameSource::new(self.message_signer(), chunks, logical_sequence),
                     useful_bytes,
                     completion,
                     stop,
@@ -843,6 +846,14 @@ impl PayloadSender for SwarmTransport {
 
     fn is_connected(&self, did: Did) -> bool {
         self.get_connection(did).is_some()
+    }
+
+    async fn reserve_transaction_sequences(
+        &self,
+        destination: Did,
+        count: std::num::NonZeroU64,
+    ) -> Result<std::ops::RangeInclusive<u64>> {
+        SwarmTransport::reserve_transaction_sequences(self, destination, count).await
     }
 
     async fn do_send_payload(&self, did: Did, payload: MessagePayload) -> Result<()> {

--- a/crates/core/src/swarm/transport/storage_sync.rs
+++ b/crates/core/src/swarm/transport/storage_sync.rs
@@ -16,8 +16,6 @@ use crate::error::Error;
 use crate::error::Result;
 use crate::message::yield_core_actor_step;
 use crate::message::Message;
-use crate::message::MessagePayload;
-use crate::message::PayloadSender;
 use crate::message::SyncEntriesWithSuccessor;
 use crate::message::SyncEntriesWithSuccessorReport;
 use crate::utils::get_epoch_ms;
@@ -504,12 +502,13 @@ impl SwarmTransport {
                 .await?;
             return Ok(StorageSyncCompletion::PersistedLocally);
         };
-        let payload = MessagePayload::new_send(
-            Message::SyncEntriesWithSuccessor(msg.clone()),
-            self.message_signer(),
-            next_hop,
-            destination,
-        )?;
+        let payload = self
+            .signed_payload(
+                Message::SyncEntriesWithSuccessor(msg.clone()),
+                next_hop,
+                destination,
+            )
+            .await?;
         let tx_id = payload.transaction.tx_id;
         let records_cleanup_ack = msg.purpose.permits_source_cleanup();
         if records_cleanup_ack {

--- a/crates/core/src/swarm/transport/tests/mod.rs
+++ b/crates/core/src/swarm/transport/tests/mod.rs
@@ -433,6 +433,9 @@ fn transport_with_key_measure_and_reassembly_limits(
         session_sk,
         dht,
         Some(measure),
+        Arc::new(crate::message::TransactionReplay::new(Box::new(
+            crate::storage::MemStorage::new(),
+        ))),
         SwarmTransportSettings::new(1, VirtualNodeConfig::disabled(), reassembly_limits),
     ))
 }

--- a/crates/core/src/swarm/transport/tests/test_inbound.rs
+++ b/crates/core/src/swarm/transport/tests/test_inbound.rs
@@ -460,14 +460,19 @@ async fn test_inbound_mailbox_reserves_control_capacity_under_application_satura
         let key = SecretKey::random();
         let peer: Did = key.address().into();
         let session = SessionSk::new_with_seckey(&key)?;
-        let message = MessagePayload::new_send(
-            Message::custom(b"bounded-inbound-mailbox")?,
-            MessageSigner::new(&session, TEST_NETWORK_ID),
-            transport.dht.did,
-            transport.dht.did,
-        )?
-        .to_wire()?;
-        application_inputs.push((peer.to_string(), message));
+        let mut messages = Vec::with_capacity(inbound_peer_capacity_for_test());
+        for _ in 0..inbound_peer_capacity_for_test() {
+            messages.push(
+                MessagePayload::new_send(
+                    Message::custom(b"bounded-inbound-mailbox")?,
+                    MessageSigner::new(&session, TEST_NETWORK_ID),
+                    transport.dht.did,
+                    transport.dht.did,
+                )?
+                .to_wire()?,
+            );
+        }
+        application_inputs.push((peer.to_string(), messages));
     }
     let control_key = SecretKey::random();
     let control_peer: Did = control_key.address().into();
@@ -489,10 +494,9 @@ async fn test_inbound_mailbox_reserves_control_capacity_under_application_satura
     let control_cid = control_peer.to_string();
     let mut deliveries = Vec::new();
 
-    for (cid, message) in application_inputs {
-        for _ in 0..inbound_peer_capacity_for_test() {
+    for (cid, messages) in application_inputs {
+        for message in messages {
             let callback = Arc::clone(&callback);
-            let message = message.clone();
             let cid = cid.clone();
             deliveries.push(tokio::spawn(async move {
                 callback

--- a/crates/core/src/swarm/transport/tests/test_inbound/test_storage_interleave.rs
+++ b/crates/core/src/swarm/transport/tests/test_inbound/test_storage_interleave.rs
@@ -129,6 +129,9 @@ async fn test_inbound_storage_batch_yields_to_control_between_persistence_steps(
         local_session,
         dht,
         Some(Arc::new(RecordingMeasure::default())),
+        Arc::new(crate::message::TransactionReplay::new(Box::new(
+            crate::storage::MemStorage::new(),
+        ))),
         SwarmTransportSettings::new(
             1,
             VirtualNodeConfig::disabled(),

--- a/crates/core/src/swarm/transport/transaction_replay.rs
+++ b/crates/core/src/swarm/transport/transaction_replay.rs
@@ -1,0 +1,67 @@
+//! Sender reservation and final-destination replay admission.
+
+use std::num::NonZeroU64;
+use std::ops::RangeInclusive;
+
+use super::SwarmTransport;
+use crate::dht::Did;
+use crate::error::Result;
+use crate::message::MessagePayload;
+use crate::message::PayloadSender;
+use crate::message::ReplayCounters;
+use crate::message::StreamKey;
+use crate::message::Transaction;
+
+impl SwarmTransport {
+    /// Current destination-scoped replay rejection and persistence counters.
+    pub(crate) fn replay_counters(&self) -> ReplayCounters {
+        self.transaction_replay.counters()
+    }
+
+    /// Persistently reserve one or more sequences for this account and final destination.
+    pub(crate) async fn reserve_transaction_sequences(
+        &self,
+        destination: Did,
+        count: NonZeroU64,
+    ) -> Result<RangeInclusive<u64>> {
+        let key = StreamKey::new(
+            self.network_id,
+            self.message_signer().account_did(),
+            destination,
+        );
+        self.transaction_replay.reserve(key, count).await
+    }
+
+    /// Persist the final destination's replay transition before application validation.
+    pub(crate) async fn admit_transaction_replay(&self, transaction: &Transaction) -> Result<()> {
+        let key = transaction.stream_key(self.network_id);
+        let digest = transaction.digest()?;
+        self.transaction_replay
+            .admit(key, transaction.sequence, digest)
+            .await
+            .map(|_| ())
+    }
+
+    /// Build a locally originated payload after durably reserving its stream sequence.
+    pub(crate) async fn signed_payload<T>(
+        &self,
+        data: T,
+        next_hop: Did,
+        destination: Did,
+    ) -> Result<MessagePayload>
+    where
+        T: serde::Serialize,
+    {
+        let sequence = *self
+            .reserve_transaction_sequences(destination, NonZeroU64::MIN)
+            .await?
+            .start();
+        MessagePayload::new_send_with_sequence(
+            data,
+            self.message_signer(),
+            next_hop,
+            destination,
+            sequence,
+        )
+    }
+}

--- a/crates/core/src/tests/default/test_connection.rs
+++ b/crates/core/src/tests/default/test_connection.rs
@@ -6,6 +6,8 @@ use rings_transport::core::transport::WebrtcConnectionState;
 use crate::dht::successor::SuccessorReader;
 use crate::ecc::tests::gen_ordered_keys;
 use crate::ecc::SecretKey;
+use crate::error::Error;
+use crate::error::Result;
 use crate::tests::default::assert_no_more_msg;
 use crate::tests::default::prepare_node;
 use crate::tests::default::wait_for_msgs;
@@ -21,6 +23,30 @@ async fn test_handshake_on_both_sides_ordered() {
 async fn test_handshake_on_both_sides_desc_ordered() {
     let [key3, key2, key1]: [SecretKey; 3] = gen_ordered_keys::<3>();
     test_handshake_on_both_sides(key1, key2, key3).await
+}
+
+#[tokio::test]
+async fn test_http_handshake_transactions_are_replay_protected() -> Result<()> {
+    let [key1, key2]: [SecretKey; 2] = gen_ordered_keys::<2>();
+    let node1 = prepare_node(key1).await;
+    let node2 = prepare_node(key2).await;
+
+    let offer = node1.swarm.create_offer(node2.did()).await?;
+    let duplicate_offer = offer.clone();
+    let answer = node2.swarm.answer_offer(offer).await?;
+    assert!(matches!(
+        node2.swarm.answer_offer(duplicate_offer).await,
+        Err(Error::TransactionReplay { .. })
+    ));
+
+    assert_eq!(answer.transaction.destination, node1.did());
+    let duplicate_answer = answer.clone();
+    node1.swarm.accept_answer(answer).await?;
+    assert!(matches!(
+        node1.swarm.accept_answer(duplicate_answer).await,
+        Err(Error::TransactionReplay { .. })
+    ));
+    Ok(())
 }
 
 async fn test_handshake_on_both_sides(key1: SecretKey, key2: SecretKey, key3: SecretKey) {

--- a/crates/core/src/tests/default/test_connection.rs
+++ b/crates/core/src/tests/default/test_connection.rs
@@ -49,6 +49,32 @@ async fn test_http_handshake_transactions_are_replay_protected() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_http_handshake_rejects_invalid_inner_signatures_before_replay_admission() -> Result<()>
+{
+    let [key1, key2]: [SecretKey; 2] = gen_ordered_keys::<2>();
+    let node1 = prepare_node(key1).await;
+    let node2 = prepare_node(key2).await;
+
+    let offer = node1.swarm.create_offer(node2.did()).await?;
+    let mut forged_offer = offer.clone();
+    forged_offer.transaction.verification.sig.clear();
+    assert!(matches!(
+        node2.swarm.answer_offer(forged_offer).await,
+        Err(Error::VerifySignatureFailed)
+    ));
+
+    let answer = node2.swarm.answer_offer(offer).await?;
+    let mut forged_answer = answer.clone();
+    forged_answer.transaction.verification.sig.clear();
+    assert!(matches!(
+        node1.swarm.accept_answer(forged_answer).await,
+        Err(Error::VerifySignatureFailed)
+    ));
+    node1.swarm.accept_answer(answer).await?;
+    Ok(())
+}
+
 async fn test_handshake_on_both_sides(key1: SecretKey, key2: SecretKey, key3: SecretKey) {
     let node1 = prepare_node(key1).await;
     let node2 = prepare_node(key2).await;

--- a/crates/node/bin/rings.rs
+++ b/crates/node/bin/rings.rs
@@ -55,6 +55,7 @@ use tokio::task::JoinSet;
 
 const FOREGROUND_CLEANUP_TIMEOUT: Duration = Duration::from_secs(30);
 const ONION_ENTRY_GUARD_STORAGE_CAPACITY: u32 = 64 * 1024;
+const TRANSACTION_REPLAY_STORAGE_CAPACITY: u32 = 16 * 1024 * 1024;
 
 fn onion_entry_guard_storage_path(data_storage_path: &str) -> String {
     let data_path = Path::new(data_storage_path);
@@ -64,6 +65,18 @@ fn onion_entry_guard_storage_path(data_storage_path: &str) -> String {
         .unwrap_or_else(|| Path::new("."));
     parent
         .join("onion-entry-guards")
+        .to_string_lossy()
+        .to_string()
+}
+
+fn transaction_replay_storage_path(data_storage_path: &str) -> String {
+    let data_path = Path::new(data_storage_path);
+    let parent = data_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    parent
+        .join("transaction-replay-v2")
         .to_string_lossy()
         .to_string()
 }
@@ -868,6 +881,13 @@ async fn foreground_run(args: RunCommand) -> anyhow::Result<()> {
         )
         .await?,
     );
+    let per_transaction_replay_storage = Box::new(
+        FileStorage::new_with_cap_and_path(
+            TRANSACTION_REPLAY_STORAGE_CAPACITY,
+            transaction_replay_storage_path(&data_storage.path),
+        )
+        .await?,
+    );
 
     let measure = PeriodicMeasure::new(per_measure_storage).await?;
 
@@ -875,6 +895,7 @@ async fn foreground_run(args: RunCommand) -> anyhow::Result<()> {
         ProcessorBuilder::from_config(&pc)?
             .storage(per_data_storage)
             .onion_entry_guard_storage(per_onion_entry_guard_storage)
+            .replay_storage(per_transaction_replay_storage)
             .measure(measure)
             .reassembly_limits(args.reassembly_profile.limits())
             .build()?,
@@ -1326,6 +1347,7 @@ mod tests {
     use super::await_gateway_startup;
     use super::await_task_cleanup;
     use super::onion_entry_guard_storage_path;
+    use super::transaction_replay_storage_path;
     use super::Cli;
 
     fn parse_without_log_level_env<const N: usize>(args: [&str; N]) -> Result<Cli, clap::Error> {
@@ -1378,6 +1400,18 @@ mod tests {
         assert_eq!(
             onion_entry_guard_storage_path("/tmp/rings/data"),
             "/tmp/rings/onion-entry-guards"
+        );
+    }
+
+    #[test]
+    fn test_transaction_replay_storage_is_sibling_of_data_storage() {
+        assert_eq!(
+            transaction_replay_storage_path(".rings/data"),
+            ".rings/transaction-replay-v2"
+        );
+        assert_eq!(
+            transaction_replay_storage_path("/tmp/rings/data"),
+            "/tmp/rings/transaction-replay-v2"
         );
     }
 

--- a/crates/node/src/processor/builder.rs
+++ b/crates/node/src/processor/builder.rs
@@ -10,6 +10,7 @@ pub struct ProcessorBuilder {
     pub(in crate::processor) session_sk: SessionSk,
     pub(in crate::processor) onion_exit_epoch: OnionExitEpoch,
     pub(in crate::processor) storage: Option<EntryStorage>,
+    pub(in crate::processor) replay_storage: Option<ReplayStorage>,
     pub(in crate::processor) onion_entry_guard_storage: Option<OnionEntryGuardStorage>,
     pub(in crate::processor) measure: Option<Arc<PeriodicMeasure>>,
     pub(in crate::processor) stabilize_interval: Duration,
@@ -64,6 +65,7 @@ impl ProcessorBuilder {
             session_sk: config.session_sk.clone(),
             onion_exit_epoch: OnionExitEpoch::random(),
             storage: None,
+            replay_storage: None,
             onion_entry_guard_storage: None,
             measure: None,
             stabilize_interval: config.stabilize_interval,
@@ -87,6 +89,12 @@ impl ProcessorBuilder {
     /// Set the storage for the processor.
     pub fn storage(mut self, storage: EntryStorage) -> Self {
         self.storage = Some(storage);
+        self
+    }
+
+    /// Set durable destination-scoped transaction replay storage.
+    pub fn replay_storage(mut self, storage: ReplayStorage) -> Self {
+        self.replay_storage = Some(storage);
         self
     }
 
@@ -171,6 +179,9 @@ impl ProcessorBuilder {
             .map_err(|e| Error::VerifyError(e.to_string()))?;
 
         let storage = self.storage.unwrap_or_else(|| Box::new(MemStorage::new()));
+        let replay_storage = self
+            .replay_storage
+            .unwrap_or_else(|| Box::new(MemStorage::new()));
         let onion_entry_guard_storage = self
             .onion_entry_guard_storage
             .unwrap_or_else(|| Box::new(MemStorage::new()));
@@ -211,6 +222,7 @@ impl ProcessorBuilder {
         swarm_builder = swarm_builder.dht_finger_table_size(self.dht_finger_table_size);
         swarm_builder = swarm_builder.dht_virtual_nodes(self.dht_virtual_nodes);
         swarm_builder = swarm_builder.reassembly_limits(self.reassembly_limits);
+        swarm_builder = swarm_builder.replay_storage(replay_storage);
 
         if let Some(external_address) = self.external_address {
             swarm_builder = swarm_builder.external_address(external_address);

--- a/crates/node/src/processor/mod.rs
+++ b/crates/node/src/processor/mod.rs
@@ -27,6 +27,7 @@ use rings_core::message::DhtProtocolMode;
 use rings_core::message::Encoded;
 use rings_core::message::Encoder;
 use rings_core::message::Message;
+use rings_core::message::ReplayStorage;
 use rings_core::storage::MemStorage;
 use rings_core::swarm::Swarm;
 use rings_core::swarm::SwarmBuilder;

--- a/crates/node/src/provider/browser/provider.rs
+++ b/crates/node/src/provider/browser/provider.rs
@@ -19,6 +19,7 @@ use rings_core::lifecycle::StopSource;
 use rings_core::measure::PeerQuality;
 use rings_core::message::DhtProtocolMode;
 use rings_core::message::MessageSigner;
+use rings_core::message::ReplayStorage;
 use rings_core::storage::idb::IdbStorage;
 use rings_core::utils::js_utils;
 use rings_core::utils::js_value;
@@ -447,6 +448,16 @@ async fn open_browser_entry_guard_storage(storage_name: &str) -> Option<OnionEnt
     }
 }
 
+async fn open_browser_replay_storage(storage_name: &str) -> NodeResult<ReplayStorage> {
+    IdbStorage::new_with_cap_and_name(2, storage_name)
+        .await
+        .map(|storage| Box::new(storage) as ReplayStorage)
+        .map_err(|source| Error::BrowserStorageOpen {
+            name: storage_name.to_string(),
+            source,
+        })
+}
+
 impl Provider {
     /// Create a browser provider backed by IndexedDB storage and install its default backend.
     ///
@@ -463,12 +474,15 @@ impl Provider {
             open_browser_measure_storage(&format!("{storage_name}/measure")).await;
         let onion_entry_guard_storage =
             open_browser_entry_guard_storage(&format!("{storage_name}/onion-entry-guards")).await;
+        let replay_storage =
+            open_browser_replay_storage(&format!("{storage_name}/transaction-replay-v2")).await?;
 
         let provider = Self::new_provider_with_storage_internal(
             config,
             entry_storage,
             measure_storage,
             onion_entry_guard_storage,
+            Some(replay_storage),
         )
         .await?;
         provider.set_backend()?;
@@ -515,6 +529,8 @@ impl Provider {
             let measure_storage = open_browser_measure_storage("rings-node/measure").await;
             let onion_entry_guard_storage =
                 open_browser_entry_guard_storage("rings-node/onion-entry-guards").await;
+            let replay_storage =
+                open_browser_replay_storage("rings-node/transaction-replay-v2").await?;
 
             let provider = Provider::new_provider_internal(
                 network_id,
@@ -526,6 +542,7 @@ impl Provider {
                 entry_storage,
                 measure_storage,
                 onion_entry_guard_storage,
+                Some(replay_storage),
             )
             .await?;
 
@@ -557,6 +574,8 @@ impl Provider {
             let measure_storage = open_browser_measure_storage("rings-node/measure").await;
             let onion_entry_guard_storage =
                 open_browser_entry_guard_storage("rings-node/onion-entry-guards").await;
+            let replay_storage =
+                open_browser_replay_storage("rings-node/transaction-replay-v2").await?;
 
             let config_policy = policy.clone();
             let provider = Provider::new_provider_internal_with_config(
@@ -569,6 +588,7 @@ impl Provider {
                 entry_storage,
                 measure_storage,
                 onion_entry_guard_storage,
+                Some(replay_storage),
                 move |config| {
                     config
                         .enable_https_onion_exit()

--- a/crates/node/src/provider/ffi.rs
+++ b/crates/node/src/provider/ffi.rs
@@ -427,6 +427,7 @@ pub unsafe extern "C" fn rings_node_new_provider_with_callback(
                     None,
                     None,
                     None,
+                    None,
                 ))?;
                 Ok((provider, runtime))
             })
@@ -654,6 +655,7 @@ mod tests {
                     config,
                     None,
                     Some(Box::new(storage.clone())),
+                    None,
                     None,
                 )
                 .await

--- a/crates/node/src/provider/mod.rs
+++ b/crates/node/src/provider/mod.rs
@@ -11,6 +11,7 @@ use rings_core::dht::EntryStorage;
 #[cfg(feature = "node")]
 use rings_core::lifecycle::StopToken;
 use rings_core::measure::PeerMeasurement;
+use rings_core::message::ReplayStorage;
 use rings_core::session::SessionSkBuilder;
 use rings_core::storage::MemStorage;
 use rings_core::swarm::callback::SharedSwarmCallback;
@@ -152,17 +153,20 @@ impl Provider {
         entry_storage: Option<EntryStorage>,
         measure_storage: Option<MeasureStorage>,
         onion_entry_guard_storage: Option<OnionEntryGuardStorage>,
+        replay_storage: Option<ReplayStorage>,
     ) -> Result<Provider> {
         let entry_storage = entry_storage.unwrap_or_else(|| Box::new(MemStorage::new()));
         let measure_storage = measure_storage.unwrap_or_else(|| Box::new(MemStorage::new()));
         let onion_entry_guard_storage =
             onion_entry_guard_storage.unwrap_or_else(|| Box::new(MemStorage::new()));
+        let replay_storage = replay_storage.unwrap_or_else(|| Box::new(MemStorage::new()));
 
         let measure = PeriodicMeasure::new(measure_storage).await?;
 
         let processor_builder = ProcessorBuilder::from_config(&config)?
             .storage(entry_storage)
             .onion_entry_guard_storage(onion_entry_guard_storage)
+            .replay_storage(replay_storage)
             .measure(measure);
 
         let processor = Arc::new(processor_builder.build()?);
@@ -199,6 +203,7 @@ impl Provider {
         entry_storage: Option<EntryStorage>,
         measure_storage: Option<MeasureStorage>,
         onion_entry_guard_storage: Option<OnionEntryGuardStorage>,
+        replay_storage: Option<ReplayStorage>,
     ) -> Result<Provider> {
         Self::new_provider_internal_with_config(
             network_id,
@@ -210,6 +215,7 @@ impl Provider {
             entry_storage,
             measure_storage,
             onion_entry_guard_storage,
+            replay_storage,
             core::convert::identity,
         )
         .await
@@ -226,6 +232,7 @@ impl Provider {
         entry_storage: Option<EntryStorage>,
         measure_storage: Option<MeasureStorage>,
         onion_entry_guard_storage: Option<OnionEntryGuardStorage>,
+        replay_storage: Option<ReplayStorage>,
         configure: impl FnOnce(ProcessorConfig) -> ProcessorConfig,
     ) -> Result<Provider> {
         let mut sk_builder = SessionSkBuilder::new(account, account_type);
@@ -243,6 +250,7 @@ impl Provider {
             entry_storage,
             measure_storage,
             onion_entry_guard_storage,
+            replay_storage,
         )
         .await
     }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -27,6 +27,7 @@
 - [DHT - Network Layer](advanced-topic/chord.md)
 - [API](jsonrpc.md)
 - [Account Abstraction](advanced-topic/account-abstraction.md)
+- [Transaction Replay Protection](advanced-topic/transaction-replay.md)
 - [config.yaml](advanced-topic/config.yaml.md)
 
 # Features

--- a/docs/src/advanced-topic/transaction-replay.md
+++ b/docs/src/advanced-topic/transaction-replay.md
@@ -1,0 +1,98 @@
+# Destination-scoped transaction replay protection
+
+Rings 0.24.0 gives a retained final destination an at-most-once dispatch guarantee for exact
+signed transactions. The guarantee is receiver-local. It does not provide reliable delivery,
+global ordering, exactly-once application effects, or replay recognition after replay state has
+been deleted.
+
+## Stream and transcript
+
+Replay state is keyed by:
+
+```text
+StreamKey = (network_id, origin_account_did, destination_did)
+```
+
+The origin is recovered from `Transaction.verification.session.account_did()`. It is not the
+delegated session DID and not an intermediate relay. Rotating a session key therefore preserves
+the same account-to-destination stream, while two destinations advance independently.
+
+Every transaction carries a mandatory `u64` sequence. The transaction v2 signature transcript
+binds the receiver-selected `network_id` through the signing domain and binds `destination`,
+`tx_id`, `sequence`, and `data` through the transaction hash. `ts_ms` and `ttl_ms` remain session
+authorization and message-liveness inputs; neither is used to order replay state.
+
+## Receiver state machine
+
+One stream retains a fixed 32-slot window:
+
+```text
+SequenceState {
+    high: u64,
+    accepted: [Option<TransactionDigest>; 32],
+}
+```
+
+`observe(state, sequence, digest)` is deterministic and returns one typed verdict:
+
+- `First` establishes a baseline when no retained stream exists.
+- `Advance` moves the window to a higher sequence. A gap is allowed and is not evidence of
+  omission.
+- `Late` fills an empty slot inside the retained window.
+- `Replay` rejects the same digest at an occupied sequence.
+- `Fork` rejects a different digest at an occupied sequence and reports both digests.
+- `Stale` rejects a sequence below the retained window.
+
+The final destination applies this transition after both transaction and payload signatures
+verify and before application validation, handler effects, or the application inbound callback.
+An intermediate Chord relay does not read or advance origin replay state. Chunk envelopes retain
+their existing bounded reassembly/tombstone replay defense and do not advance logical transaction
+replay state. Each envelope binds the already-reserved logical sequence without consuming another
+sequence; after reassembly, the original logical transaction is admitted only if that node is its
+final destination.
+
+## Persistence and bounds
+
+The sender reserves and persists the next sequence before exposing a signature. A crash may leave
+a gap but cannot reuse a successfully reserved sequence. A reservation that would wrap `u64`
+fails closed.
+
+One runtime serializes all writers to its allocator. Multiple devices or processes using the same
+account and destination must delegate signing to that one allocator; merely pointing independent
+runtimes at the same key-value store is not an atomic multi-writer protocol. If they do not
+coordinate, the destination reports their conflicting sequence as `Fork`. Restoring an identity
+backup without its allocator state has the same limitation and is unsupported.
+
+The receiver persists every admitted transition before application validation or dispatch. A
+crash after persistence but before dispatch may lose the event. This is the deliberate
+persistence-before-dispatch boundary: it prevents duplicate dispatch but is not exactly-once
+execution because replay storage and application handlers do not share a transaction.
+
+Sender and receiver state are stored in one versioned snapshot. Each table retains at most 4096
+streams, and each receiver stream has exactly 32 hot digest slots. New streams fail closed at the
+bound; there is no LRU eviction or sender-controlled reset. The native daemon keeps the snapshot
+in a dedicated 16 MiB atomic file store, and browser providers keep it in a dedicated IndexedDB
+store. A custom `SwarmBuilder` or `ProcessorBuilder` must supply durable `ReplayStorage` to retain
+the restart guarantee; their in-memory default guarantees replay rejection only for the lifetime
+of that runtime.
+
+Deleting or replacing the replay store deletes the guarantee for its streams. There is no safe
+incarnation/reset protocol in 0.24.0, so operators must retain the store across restarts and fail
+closed on storage errors. Counters expose `Replay`, `Fork`, `Stale`, and persistence failures.
+
+## Hard cutover
+
+0.24.0 is a network-wide protocol cutover. The sequence field is mandatory, transaction
+signatures use the `rings-core:message-verification:transaction:v2` domain, and the payload wire
+encoding begins with the `RINGS-TX-V2` marker. Unprefixed 0.23.x payloads are rejected before
+deserialization. There is no dual decoder, negotiation, feature flag, downgrade path, or legacy
+fallback. Mixed-version overlays are unsupported.
+
+## Non-guarantees
+
+- No cross-account or global order.
+- No claim that a sequence gap identifies loss or a dishonest relay.
+- No retransmission, acknowledgement, or head-of-line blocking protocol.
+- No exactly-once application side effects.
+- No recognition of messages older than a deliberately deleted replay store.
+- No reputation or slashing consequence for fork evidence.

--- a/examples/native/Cargo.toml
+++ b/examples/native/Cargo.toml
@@ -12,7 +12,7 @@ async-trait = { workspace = true }
 base64 = "0.13"
 bytes = "1.2.1"
 rings-core = { workspace = true }
-rings-node = { path = "../../crates/node", version = "0.23.0", default-features = false, features = ["node"] }
+rings-node = { path = "../../crates/node", version = "0.24.0", default-features = false, features = ["node"] }
 rings-rpc = { workspace = true }
 serde_json = "1.0.70"
 tokio = { version = "1.13.0", features = ["macros", "rt-multi-thread", "time"] }

--- a/examples/relay/Cargo.toml
+++ b/examples/relay/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 rings-core = { workspace = true }
-rings-node = { path = "../../crates/node", version = "0.23.0", default-features = false, features = ["node"] }
+rings-node = { path = "../../crates/node", version = "0.24.0", default-features = false, features = ["node"] }
 tokio = { version = "1.13.0", features = ["io-util", "macros", "net", "rt-multi-thread", "time"] }
 
 [[example]]

--- a/frontend/Cargo.lock
+++ b/frontend/Cargo.lock
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "rings-codec"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "postcard",
  "serde",
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "rings-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "rings-derive"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "rings-measure"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "rings-network-policy"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "thiserror 1.0.69",
  "url",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "rings-node"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "rings-rpc"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "rings-transport"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "rings-webview"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ringsnetwork/rings-node",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ringsnetwork/rings-node",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "GPL-3.0",
       "devDependencies": {
         "@biomejs/biome": "2.5.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "RND <dev@ringsnetwork.io>"
   ],
   "description": "Rings is a structured peer-to-peer network implementation using WebRTC, Chord algorithm, and full WebAssembly (WASM) support.\n",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- add the mandatory v2 destination-scoped transaction sequence and hard wire-format cutover
- persist bounded sender reservations before signing and receiver replay windows before final-destination dispatch
- keep intermediate relays and chunk-envelope framing outside logical replay state
- wire dedicated native and browser replay stores, document the security boundary, and bump the release to 0.24.0

## Validation

- `cargo +nightly-aarch64-apple-darwin fmt --all -- --check`
- `cargo clippy -p rings-core --all-targets --all-features -- -D warnings -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented -D clippy::indexing_slicing`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo clippy -p rings-core --features wasm --no-deps --no-default-features --target=wasm32-unknown-unknown --tests -- -D warnings`
- `cargo test -p rings-core --all-targets --all-features --no-fail-fast -q`
- `cargo test -p rings-node --all-targets --all-features -q`
- `cargo check -p rings-core --target wasm32-unknown-unknown --no-default-features --features wasm`
- `cargo check -p rings-node --target wasm32-unknown-unknown --no-default-features --features browser`
- `cargo check --manifest-path frontend/Cargo.toml --target wasm32-unknown-unknown`

Closes #740
